### PR TITLE
Bugfix: close-button in roll dialog does not trigger roll anymore

### DIFF
--- a/module/apps/roll-dialog.js
+++ b/module/apps/roll-dialog.js
@@ -47,11 +47,14 @@ export class RollDialog {
 				buttons: {
 					roll: {
 						label: 'Roll !',
-						callback: html => formData = new FormData(html[0].querySelector("#bonus-roll-form"))
+						callback: html => {
+							formData = new FormData(html[0].querySelector("#bonus-roll-form"));
+							return resolve(formData);
+						}
 					}
 				},
 				default: "roll",
-				close: () => resolve( formData)
+				close: () => {}
 			});
 			dlg.render(true);
 		});


### PR DESCRIPTION
I noticed that the roll-dialog executes the roll by clicking the close button. In my opinion it should only close the dialog, without making a roll.

I removed the functionality from the close function and moved it to the callback function of the roll.