### PR TITLE
Feature/display level of success

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,30 @@ Compendium 'Weapons' contains a single test weapon.
 
 ## What is working
 
+version 0.2.8 :
+
+* Bug fix/improvement on melee flow cards.
+  * Synthetic actors and token are retrieved from the viewed scene (use to be from active scene).
+  * Actors and target retrieval hardened.
+  * Flow simplification (Resolution card is replaced after resolution).
+* Rolls received a lot of work.
+  * Succed level is displayed as medals (critical), stars (success), spiders (failure) or skull (fumble).
+  * Addition of unknown difficulty rolls.
+    * Selection of difficulty is done in the roll dialogue. Select the '???' options.
+    * Default mode (unknown difficulty or normal difficulty) can be selected in the world options.
+    * Player rolling can see his numbers but not the check difficulty. He can spend luck to improve his success.
+    * Roll difficulty and succes level is revealed uppon difficulty selection by the keeper.
+  * Unknown difficulty check can be rolled as normal check (public, private and blind).
+* @ただいま#0125 Dicebot module has been integrated and will be supported in the system.
+  * Type commands /cc and /cbr to use it.
+  * /cc xx will roll a D100 vs a xxx difficulty and display the level od success.
+  * /cbr xx, yy will roll a D100 vs xx and yy difficulty and display the level od success.
+* Japanese translation improved and augmented thanks to @ただいま#0125!
+* Localization continues thanks to the efforts of @Kael79#8036.
+* French translation improved and augmented thanks to @Kael79#8036.
+* French community is helping with debugging and testing (pecial thanks to @Carter#2703 and @Drakenvar#8665).
+* Tutorial videos are on the way !
+
 version 0.2.7 :
 
 * Bug fix/improvement on melee flow cards.

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ version 0.2.8 :
     * Player rolling can see his numbers but not the check difficulty. He can spend luck to improve his success.
     * Roll difficulty and success level is revealed upon difficulty selection by the keeper.
   * Unknown difficulty check can be rolled as normal check (public, private and blind).
-* @ただいま#0125 Dicebot module has been integrated and will be supported in the system.
+* ただいま#0125 Dicebot module has been integrated and will be supported in the system.
   * Type commands /cc and /cbr to use it.
   * /cc xx will roll a D100 vs a xxx difficulty and display the level of success.
   * /cbr xx, yy will roll a D100 vs xx and yy difficulty and display the level of success.
-* Japanese translation improved and augmented thanks to @ただいま#0125!
-* Localization continues thanks to the efforts of @Kael79#8036.
-* French translation improved and augmented thanks to @Kael79#8036.
-* French community is helping with debugging and testing (special thanks to @Carter#2703 and @Drakenvar#8665).
+* Japanese translation improved and augmented thanks to ただいま#0125!
+* Localization continues thanks to the efforts of Kael79#8036.
+* French translation improved and augmented thanks to Kael79#8036.
+* French discord community is helping with debugging and testing (special thanks to Carter#2703 and Drakenvar#8665).
 * Tutorial videos are on the way !
 
 version 0.2.7 :

--- a/README.md
+++ b/README.md
@@ -27,21 +27,21 @@ version 0.2.8 :
   * Actors and target retrieval hardened.
   * Flow simplification (Resolution card is replaced after resolution).
 * Rolls received a lot of work.
-  * Succed level is displayed as medals (critical), stars (success), spiders (failure) or skull (fumble).
+  * Success level is displayed as medals (critical), stars (success), spiders (failure) or skull (fumble).
   * Addition of unknown difficulty rolls.
     * Selection of difficulty is done in the roll dialogue. Select the '???' options.
     * Default mode (unknown difficulty or normal difficulty) can be selected in the world options.
     * Player rolling can see his numbers but not the check difficulty. He can spend luck to improve his success.
-    * Roll difficulty and succes level is revealed uppon difficulty selection by the keeper.
+    * Roll difficulty and success level is revealed upon difficulty selection by the keeper.
   * Unknown difficulty check can be rolled as normal check (public, private and blind).
 * @ただいま#0125 Dicebot module has been integrated and will be supported in the system.
   * Type commands /cc and /cbr to use it.
-  * /cc xx will roll a D100 vs a xxx difficulty and display the level od success.
-  * /cbr xx, yy will roll a D100 vs xx and yy difficulty and display the level od success.
+  * /cc xx will roll a D100 vs a xxx difficulty and display the level of success.
+  * /cbr xx, yy will roll a D100 vs xx and yy difficulty and display the level of success.
 * Japanese translation improved and augmented thanks to @ただいま#0125!
 * Localization continues thanks to the efforts of @Kael79#8036.
 * French translation improved and augmented thanks to @Kael79#8036.
-* French community is helping with debugging and testing (pecial thanks to @Carter#2703 and @Drakenvar#8665).
+* French community is helping with debugging and testing (special thanks to @Carter#2703 and @Drakenvar#8665).
 * Tutorial videos are on the way !
 
 version 0.2.7 :

--- a/lang/en.json
+++ b/lang/en.json
@@ -99,6 +99,8 @@
 "CoC7.RollDifficultyCritical": "Critical",
 "CoC7.RollResult.LuckSpendText": "{luckAmount} luck spend, {successLevel} success",
 "CoC7.RollDice": "Roll !",
+"CoC7.SuccesLevelHint": "{value} level(s) of success",
+"CoC7.FailureLevelHint": "Failed by {value} level(s)",
 
 "CoC7.CheckResult": "{name} check ({value}%) - {difficulty} difficulty",
 "CoC7.ItemCheckResult": "{item} - {skill} check ({value}%) - {difficulty} difficulty",

--- a/module/chat.js
+++ b/module/chat.js
@@ -1172,6 +1172,7 @@ export class CoC7Chat{
 		case 'reveal-check':{
 			const check = await CoC7Check.getFromCard( card);
 			check.isBlind = false;
+			check.computeCheck();
 			check.updateChatCard();
 			break;
 		}
@@ -1179,6 +1180,7 @@ export class CoC7Chat{
 		case 'flag-for-development':{
 			const check = await CoC7Check.getFromCard( card);
 			await check.flagForDevelopement();
+			check.computeCheck();
 			check.updateChatCard();
 			break;
 		}

--- a/module/check.js
+++ b/module/check.js
@@ -104,6 +104,36 @@ export class CoC7Check {
 		this.actor.alias = this.actor.name;
 	}
 
+	get successLevelIcons(){
+		if( this.unknownDifficulty) return null;
+		if( this.successLevel >= this.difficultyLevel){
+			let icons = [];
+			for (let index = 0; index < (this.successLevel - this.difficultyLevel + 1); index++) {
+				icons.push( this.isCritical ? 'medal' : 'star');
+				
+			}
+			const successHint = game.i18n.format('CoC7.SuccesLevelHint', {value : this.successLevel - this.difficultyLevel + 1});
+			return {
+				success: true,
+				cssClass: this.isCritical ? 'critical' : 'success',
+				hint: successHint,
+				icons: icons};
+		} else {
+			let icons = [];
+			const successLevel = this.isFumble ? -1 : this.successLevel;
+			for (let index = 0; index < (this.difficultyLevel - successLevel); index++) {
+				icons.push(this.isFumble? 'skull' : 'spider');
+			}
+			const failureHint = game.i18n.format('CoC7.FailureLevelHint', {value : this.difficultyLevel - successLevel});
+			return {
+				success: false,
+				cssClass: this.isFumble? 'fumble' : 'failure',
+				hint: failureHint,
+				icons: icons};
+		}
+		
+	}
+
 	get isBlind(){
 		if( undefined === this._isBlind) this._isBlind = 'blindroll' === this.rollMode;
 		return this._isBlind;
@@ -361,7 +391,12 @@ export class CoC7Check {
 			this.passed = true; // 1 is always a success
 			this.successLevel = CoC7Check.successLevel.critical;
 		}
-		if( !this.luckSpent) this.isSuccess = this.passed;
+		if( !this.luckSpent && !this.isUnknown){
+			this.isFailure = !this.passed;
+			this.isSuccess = this.passed;
+		}
+
+	
 
 		this.isFumble = this.dices.total >= this.fumbleThreshold;
 		this.isCritical = this.dices.total == 1;
@@ -482,7 +517,10 @@ export class CoC7Check {
 				this.increaseSuccess.forEach( s => {s.luckToSpend = s.luckToSpend- luckAmount;});
 				this.luckSpent = true;
 				this.computeCheck();
-			} else this.removeUpgrades();
+			} else {
+				this.successLevel = this.difficulty; 
+				this.removeUpgrades();
+			}
 			this.isFailure = false;
 			this.isUnknown = false;
 			this.isSuccess = true;
@@ -500,6 +538,7 @@ export class CoC7Check {
 		this.forced = true;
 		this.removeUpgrades();
 		if( this.isSuccess){
+			this.successLevel = this.difficulty - 1;
 			this.isFailure = true;
 			this.isUnknown = false;
 			this.isSuccess = false;

--- a/styles/coc7.css
+++ b/styles/coc7.css
@@ -250,12 +250,32 @@
 }
 
 .dice-roll .dice-formula.critical{
-    background-color: palegreen;
+    background-color: whitesmoke;
 }
 
 .dice-roll .dice-formula.fumble{
-    background-color: darkred;
+    background-color: black;
 }
+
+.dice-roll .dice-formula .roll-icons.success {
+    color: goldenrod;
+}
+.dice-roll .dice-formula .roll-icons.critical {
+    color: goldenrod;
+    font-size: 20px;
+    font-weight: bold;
+}
+
+.dice-roll .dice-formula .roll-icons.failure {
+    color: red;
+}
+
+.dice-roll .dice-formula .roll-icons.fumble {
+    color: darkred;
+    font-size: 20px;
+    font-weight: bold;
+}
+
 
 .tooltip {
     position: relative;

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
 	"name": "CoC7",
 	"title": "The Call of Cthulhu 7th edition",
 	"description": "The Call of Cthulhu 7th edition simple game system",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"author": "HavelockV",
 	"minimumCoreVersion": "0.5.2",
 	"compatibleCoreVersion": "0.6.5",
@@ -70,6 +70,6 @@
 	"secondaryTokenAttribute": "power",
 	"url": "https://github.com/HavlockV/CoC7-FoundryVTT/",
 	"manifest": "https://github.com/HavlockV/CoC7-FoundryVTT/raw/master/system.json",
-	"download": "https://github.com/HavlockV/CoC7-FoundryVTT/archive/0.2.7.zip"
+	"download": "https://github.com/HavlockV/CoC7-FoundryVTT/archive/0.2.8.zip"
   }
   

--- a/templates/chat/roll-result.html
+++ b/templates/chat/roll-result.html
@@ -72,7 +72,18 @@
 		<div class="dice-result"
 			data-total="{{dices.total}}"
 			data-ten-result="{{dices.tenResult}}">
-			<div class="dice-formula {{#if isSuccess}}success{{/if}} {{#if isCritial}}critical{{/if}} {{#if isFumble}}{{/if}}">1D% {{#if dices.hasBonus}}{{dices.bonus}} {{dices.bonusType}} {{localize 'CoC7.Dice'}}{{/if}}</div>
+			<div class="dice-formula {{#if isSuccess}}success{{/if}} {{#if isFailure}}failure{{/if}} {{#if isCritical}}critical{{/if}} {{#if isFumble}}fumble{{/if}}"
+			  title="{{successLevelIcons.hint}}">
+				{{#if successLevelIcons}}
+					<span class="roll-icons {{successLevelIcons.cssClass}}">
+					{{#each successLevelIcons.icons as |icon|}}
+						<i class="fas fa-{{icon}}"></i>
+					{{/each}}
+					</span>
+				{{else}}
+				1D% {{#if dices.hasBonus}}{{dices.bonus}} {{dices.bonusType}} {{localize 'CoC7.Dice'}}{{/if}}
+				{{/if}}
+			</div>
 			<div class="dice-tooltip" style="display: none;">
 				<section class="tooltip-part">
 					<div class="dice ten-dice">
@@ -148,7 +159,7 @@
 					{{/unless}}
 				</div>
 			</div>
-			<h4 id="diceResult" class="dice-total {{cssClass}}">{{dices.total}} {{#if pushing}} {{localize 'CoC7.PushedRoll'}}{{/if}} {{#if luckSpent}}Luck spent{{/if}}</h4>
+			<h4 id="diceResult" class="dice-total {{cssClass}}" title="{{resultType}}">{{dices.total}} {{#if pushing}} {{localize 'CoC7.PushedRoll'}}{{/if}} {{#if luckSpent}}Luck spent{{/if}}</h4>
 			{{#if hasMalfunction}}<h4 class="malfunction">{{malfunctionTxt}}</h4>{{/if}}
 		</div>
 	</div>


### PR DESCRIPTION
* Bug fix/improvement on melee flow cards.
  * Synthetic actors and token are retrieved from the viewed scene (use to be from active scene).
  * Actors and target retrieval hardened.
  * Flow simplification (Resolution card is replaced after resolution).
* Rolls received a lot of work.
  * Success level is displayed as medals (critical), stars (success), spiders (failure) or skull (fumble).
  * Addition of unknown difficulty rolls.
    * Selection of difficulty is done in the roll dialogue. Select the '???' options.
    * Default mode (unknown difficulty or normal difficulty) can be selected in the world options.
    * Player rolling can see his numbers but not the check difficulty. He can spend luck to improve his success.
    * Roll difficulty and success level is revealed upon difficulty selection by the keeper.
  * Unknown difficulty check can be rolled as normal check (public, private and blind).
* ただいま#0125 Dicebot module has been integrated and will be supported in the system.
  * Type commands /cc and /cbr to use it.
  * /cc xx will roll a D100 vs a xxx difficulty and display the level of success.
  * /cbr xx, yy will roll a D100 vs xx and yy difficulty and display the level of success.
* Japanese translation improved and augmented thanks to ただいま#0125!
* Localization continues thanks to the efforts of Kael79#8036.
* French translation improved and augmented thanks to Kael79#8036.
* French discord community is helping with debugging and testing (special thanks to Carter#2703 and Drakenvar#8665).
* Tutorial videos are on the way !