### PR TITLE
0.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ version 0.3.4 :
   * The PC has to choose to retaliate/dodge without knowing the outcome of the attack.
   * GM can see everything.
 * Creature and NPC sheet design sliglty reworked.
+* Japanese transalation updated thanks to AdmiralNyar.
 
 version 0.3.3 :
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ Compendium 'Weapons' contains a single test weapon.
 
 ## What is working
 
+version 0.3.4 :
+
+* Inventory tab added to NPC and Creatures. Inventory can contains items, books and spells.
+  * Items, book and spells can be dragged/dropped.
+  * Any empty section will not be displayed.
+  * Is empty the inventory will not be displayed.
+* Close combat flow: if the target is a PC, only GM can see the initiator roll.
+  * The PC has to choose to retaliate/dodge without knowing the outcome of the attack.
+  * GM can see everything.
+* Creature and NPC sheet design sliglty reworked.
+
 version 0.3.3 :
 
 * Inventory (Gear&Cash tab) displays items, books and spells.

--- a/coc7g.css
+++ b/coc7g.css
@@ -295,10 +295,10 @@
 .coc7.sheet.book .sheet-body .spell-list .item-summary,
 .coc7.sheet.spell .sheet-body .spell-list .item-summary {
   flex: 0 0 100%;
-  font-size: 10px;
-  line-height: 11px;
+  font-size: 12px;
+  line-height: 13px;
   padding: 0.25em 0.5em;
-  border-top: 1px solid #c9c7b8;
+  border-top: 2px groove #eeede0;
 }
 .coc7 input[type="text"],
 .coc7 select {
@@ -689,10 +689,10 @@
 .coc7.sheet.skill .sheet-body .spell-list .item-summary,
 .coc7.sheet.item .sheet-body .spell-list .item-summary {
   flex: 0 0 100%;
-  font-size: 10px;
-  line-height: 11px;
+  font-size: 12px;
+  line-height: 13px;
   padding: 0.25em 0.5em;
-  border-top: 1px solid #c9c7b8;
+  border-top: 2px groove #eeede0;
 }
 .coc7.sheet .inventory {
   height: 100%;
@@ -822,16 +822,49 @@
 }
 .coc7.sheet .inventory-list .item-controls a {
   flex: 0 0 16px;
-  font-size: 12px;
+  font-size: 10px;
   text-align: center;
   color: #7a7971;
 }
 .coc7.sheet .inventory-list .item-summary {
   flex: 0 0 100%;
   font-size: 12px;
-  line-height: 16px;
+  line-height: 13px;
   padding: 0.25em 0.5em;
-  border-top: 1px solid #c9c7b8;
+  border-top: 2px groove #eeede0;
+}
+.coc7.sheet.actor .sheet-section h3 {
+  margin: 0 -5px 0 0;
+  padding-left: 5px;
+  font-family: "Signika", sans-serif;
+  font-weight: bold;
+  font-size: 13px;
+}
+.coc7.sheet.actor .sheet-section .editor {
+  width: 100%;
+  height: 200px;
+  border: 2px groove #eeede0;
+  padding: 0;
+  line-height: normal;
+  font-size: 12px;
+}
+.coc7.sheet.actor .sheet-section .editor-content {
+  overflow-x: hidden;
+}
+.coc7.sheet.actor .sheet-section .section-header {
+  margin: 2px 0 0 0;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.05);
+  border: 2px groove #eeede0;
+  font-weight: bold;
+  line-height: 15px;
+  height: 100%;
+}
+.coc7.sheet.actor input:read-only:hover,
+.coc7.sheet.actor input:read-only:focus {
+  border: 1px solid transparent;
+  box-shadow: none;
+  cursor: default;
 }
 .coc7.sheet.actor .info-fields .form-group label {
   width: auto;

--- a/lang/en.json
+++ b/lang/en.json
@@ -137,6 +137,10 @@
 "CoC7.TitleOutNumbered":"Add 1 bonus dice for outnumbered target",
 "CoC7.TitleSurprised": "Add 1 bonus dice for surprised target",
 "CoC7.TitleAutoSuccess": "Attack automaticaly hit",
+"CoC7.WinnerRollDamage": "{name} won. Roll damage.",
+"CoC7.NoWinner": "Both side failed.",
+"CoC7.DodgeSuccess": "{name} dodged!",
+"CoC7.ManeuverSuccess": "{name} maneuver was successful.",
 
 "CoC7.combatCard.dive4cover": "Dive for Cover",
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -250,6 +250,7 @@
 "CoC7.WeaponName": "Name",
 "CoC7.WeaponSkill": "Skill",
 "CoC7.WeaponSkillAlt": "Alt-skill",
+"CoC7.Inventory": "Inventory",
 
 
 "CoC7.ManualCreditValues": "Manual Credit Values",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -101,6 +101,7 @@
 "CoC7.check.DecreaseSuccessLevel": "成功レベルを減少させる",
 
 "CoC7.BonusSelectionWindow": "ボーナス選択ウィンドウ",
+"CoC7.SkillDetailsWindow" : "技能詳細ウィンドウ",
 "CoC7.RegularDifficulty": "レギュラー",
 "CoC7.HardDifficulty": "ハード",
 "CoC7.ExtremeDifficulty": "イクストリーム",
@@ -296,6 +297,11 @@
 "CoC7.OccultBook": "オカルトの本",
 "CoC7.Unidentified": "独自の書き込み",
 
+"CoC7.Items": "アイテム",
+"CoC7.Books": "魔導書",
+
+"CoC7.PutGunAway": "銃をしまう",
+"CoC7.DrawGun": "銃を抜く",
 
 "SETTINGS.DefaultDifficulty": "デフォルトの難易度",
 "SETTINGS.DefaultDifficultyHint": "判定におけるデフォルトの難易度を選択できる。不明を選べば、プレイヤーは難易度を知らずに判定をロールすることになる。",
@@ -304,5 +310,13 @@
 "SETTINGS.UseToken": "トークンのイメージを使用する",
 "SETTINGS.UseTokenHint": "チャットカードの絵にトークンのイメージを使用する",
 "SETTINGS.DisplayActorOnCard": "アクター（あるいはトークン）を表示させる",
-"SETTINGS.DisplayActorOnCardHint": "アクター（あるいはトークン）のイメージを戦闘のチャットカードで表示させる"
+"SETTINGS.DisplayActorOnCardHint": "アクター（あるいはトークン）のイメージを戦闘のチャットカードで表示させる",
+"SETTINGS.InitiativeRule": "イニシアチブのルールの選択",
+"SETTINGS.InitiativeRuleHint": "通常のイニシアチブのルール（DEXの値で決定）か、選択ルール（ロールで決定）を選ぶことができる",
+"SETTINGS.InitiativeRuleBasic": "通常ルール",
+"SETTINGS.InitiativeRuleOptional": "選択ルール",
+"SETTINGS.displayInitDices": "イニシアチブのダイスを表示する",
+"SETTINGS.displayInitDicesHint": "イニシアチブ決定のためのロールのダイスを表示する（選択ルール使用時のみ）",
+"SETTINGS.PulpRules" : "パルプのHPを使用する",
+"SETTINGS.PulpRulesHint" : "パルプ・クトゥルフのHP計算ルールを使用する"
 }

--- a/less/actor.less
+++ b/less/actor.less
@@ -40,6 +40,11 @@
 		box-shadow: none;
 		cursor: default;
 	}
+
+	.read-only:hover,
+	.read-only:focus {
+		border: 1px solid black;
+	}
 	
 	.info-fields{
 		.form-group{

--- a/less/actor.less
+++ b/less/actor.less
@@ -1,15 +1,57 @@
 .coc7.sheet.actor{
-    .info-fields{
-        .form-group{
-            label{
-                width: auto;
-                flex: unset;
-                line-height: 18px;
-                height: 18px;
-                border: 0;
-                margin: 0;
-                font-weight: bold;
-            }
-        }
-    }
+
+	.sheet-section{
+
+		h3{
+			margin: 0 -5px 0 0;
+			padding-left: 5px;
+			font-family: "Signika", sans-serif;
+			font-weight: bold;
+			font-size: 13px;
+		}
+
+		.editor{
+			width: 100%;
+			height: 200px;
+			border: 2px groove #eeede0;
+			padding: 0;
+			line-height: normal;
+    		font-size: 12px;
+		}
+
+		.editor-content{
+			overflow-x: hidden;
+		}
+
+		.section-header{
+			margin: 2px 0 0 0;
+			padding: 0;
+			background: rgba(0, 0, 0, 0.05);
+			border: 2px groove #eeede0;
+			font-weight: bold;
+			line-height: 15px;
+			height: 100%;
+		}
+	}
+
+	input:read-only:hover,
+	input:read-only:focus {
+		border: 1px solid transparent;
+		box-shadow: none;
+		cursor: default;
+	}
+	
+	.info-fields{
+		.form-group{
+			label{
+				width: auto;
+				flex: unset;
+				line-height: 18px;
+				height: 18px;
+				border: 0;
+				margin: 0;
+				font-weight: bold;
+			}
+		}
+	}
 }

--- a/less/book.less
+++ b/less/book.less
@@ -202,10 +202,10 @@
 			// Item Dropdown Summary
 			.item-summary {
 				flex: 0 0 100%;
-				font-size: 10px;
-				line-height: 11px;
+				font-size: 12px;
+				line-height: 13px;
 				padding: 0.25em 0.5em;
-				border-top: 1px solid @colorFaint;
+				border-top: @borderGroove;
 			}
 		}
 	}

--- a/less/chat-card.less
+++ b/less/chat-card.less
@@ -2,16 +2,18 @@
 	h4.san-result {
 		flex: 0 0 100%;
 		line-height: 24px;
-    text-align: center;
-    background: rgba(0, 0, 0, 0.1);
-    border: 1px solid #999;
-    border-radius: 3px;
+    	text-align: center;
+	    background: rgba(0, 0, 0, 0.1);
+    	border: 1px solid #999;
+	    border-radius: 3px;
 		box-shadow: 0 0 2px #FFF inset;
 		font-size: 20px;
 		font-weight: bold;
+
 		&.loss{
 			color:darkred;
 		}
+
 		&.resist{
 			color:green;
 		}

--- a/less/items.less
+++ b/less/items.less
@@ -214,10 +214,10 @@
 			// Item Dropdown Summary
 			.item-summary {
 				flex: 0 0 100%;
-				font-size: 10px;
-				line-height: 11px;
+				font-size: 12px;
+				line-height: 13px;
 				padding: 0.25em 0.5em;
-				border-top: 1px solid @colorFaint;
+				border-top: @borderGroove;
 			}
 		}
 	}

--- a/less/items.less
+++ b/less/items.less
@@ -6,6 +6,11 @@
     	box-shadow: none;
     	cursor: default;
 	}
+
+	.read-only:hover,
+	.read-only:focus {
+		border: 1px solid black;
+	}
 	
 	.sheet-header {
 		img.profile {

--- a/less/sheet.less
+++ b/less/sheet.less
@@ -126,7 +126,7 @@
 	
 		  a {
 			flex: 0 0 16px;
-			font-size: 12px;
+			font-size: 10px;
 			text-align: center;
 			color: @colorTan;
 		  }
@@ -136,9 +136,9 @@
 		.item-summary {
 		  flex: 0 0 100%;
 		  font-size: 12px;
-		  line-height: 16px;
+		  line-height: 13px;
 		  padding: 0.25em 0.5em;
-		  border-top: 1px solid @colorFaint;
+		  border-top: @borderGroove;
 		}
 	}
 }

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -239,6 +239,8 @@ export class CoC7ActorSheet extends ActorSheet {
 		data.data.indefiniteInsanityLevel.value = data.data.attribs.san.dailyLoss ? data.data.attribs.san.dailyLoss:0;
 		data.data.indefiniteInsanityLevel.max = Math.floor( data.data.attribs.san.value/5);
 
+		data.hasInventory = Object.prototype.hasOwnProperty.call( data.itemsByType, 'item') || Object.prototype.hasOwnProperty.call( data.itemsByType, 'book') || Object.prototype.hasOwnProperty.call( data.itemsByType, 'spell');
+
 		// const first = data.data.biography[0];
 		// first.isFirst = true;
 		// data.data.biography[0] = first;
@@ -300,6 +302,7 @@ export class CoC7ActorSheet extends ActorSheet {
 			html.on('click', '.weapon-damage', this._onWeaponDamage.bind(this));
 
 			html.find( '.inventory-header').click( this._onInventoryHeader.bind(this));
+			html.find( '.section-header').click( this._onSectionHeader.bind(this));
 
 
 			const wheelInputs = html.find('.attribute-value');
@@ -555,6 +558,19 @@ export class CoC7ActorSheet extends ActorSheet {
 			div.slideDown(200);
 		}
 		li.toggleClass('expanded');
+	}
+
+	_onSectionHeader(event){
+		event.preventDefault();
+		let section = $(event.currentTarget).parents('section'),
+			pannelClass = $(event.currentTarget).data('pannel'),
+			pannel = section.find( `.${pannelClass}`);
+		pannel.toggle();
+		// if( pannel.hasClass('expanded'))
+		// 	pannel.slideUp(200);
+		// else
+		// 	pannel.slideDown(200);
+		// pannel.toggleClass('expanded');		
 	}
 
 	_onInventoryHeader(event){

--- a/module/actors/sheets/creature-sheet.js
+++ b/module/actors/sheets/creature-sheet.js
@@ -57,16 +57,23 @@ export class CoC7CreatureSheet extends CoC7ActorSheet {
 	*/
 
 	static get defaultOptions() {
-		return mergeObject(super.defaultOptions, {
-			classes: ['coc7', 'sheet', 'actor', 'npc', 'creature'],
+		const options=mergeObject(super.defaultOptions, {
 			template: 'systems/CoC7/templates/actors/creature-sheet.html',
-			width: 600,
-			height: 'auto'
+			width: 560,
+			height: 'auto',
+			classes: ['coc7', 'sheet', 'actor', 'npc', 'creature'],
+			resizable: true
 		});
+		return options;
 	}
 
 
-	
+	setPosition(position={}) {
+		const test = super.setPosition(position);
+		test.height = 'auto';
+		return test; 
+	}
+
 	/**
 	 * Implement the _updateObject method as required by the parent class spec
 	 * This defines how to update the subject of the form when the form is submitted
@@ -86,5 +93,7 @@ export class CoC7CreatureSheet extends CoC7ActorSheet {
 		return super._updateObject(event, formData);
 	}
 
-
+	static forceAuto( app, html){
+		html[0].style.height = 'auto';
+	}
 }

--- a/module/actors/sheets/npc-sheet.js
+++ b/module/actors/sheets/npc-sheet.js
@@ -37,8 +37,20 @@ export class CoC7NPCSheet extends CoC7ActorSheet {
 		return mergeObject(super.defaultOptions, {
 			classes: ['coc7', 'sheet', 'actor', 'npc'],
 			template: 'systems/CoC7/templates/actors/npc-sheet.html',
-			width: 600,
-			height: 'auto'
+			width: 560,
+			height: 'auto',
+			resizable: true
 		});
+	}
+
+	
+	static forceAuto( app, html){
+		html[0].style.height = 'auto';
+	}
+
+	setPosition(position={}) {
+		const test = super.setPosition(position);
+		test.height = 'auto';
+		return test; 
 	}
 }

--- a/module/actors/sheets/npc-sheet.js
+++ b/module/actors/sheets/npc-sheet.js
@@ -15,8 +15,12 @@ export class CoC7NPCSheet extends CoC7ActorSheet {
 
 		//TODO : do we need that ?
 		data.allowFormula = true;
-		data.displayFormula = this.actor.getActorFlag( 'displayFormula'); // Put to false for now.
+		data.displayFormula = this.actor.getActorFlag( 'displayFormula');
 		if( data.displayFormula === undefined) data.displayFormula = false;
+		// await this.actor.creatureInit();
+		data.hasSan = (null !== data.data.attribs.san.value);
+		data.hasMp = (null !== data.data.attribs.mp.value);
+		data.hasLuck = (null !== data.data.attribs.lck.value);
 
 		return data;
 	}

--- a/module/chat.js
+++ b/module/chat.js
@@ -64,6 +64,8 @@ export class CoC7Chat{
 
 
 	static async onUpdateChatMessage( chatMessage){
+		// if( chatMessage.getFlag( 'CoC7', 'reveled')){
+		// }
 		if( game.user.isGM){
 			const card = $(chatMessage.data.content)[0];
 			if( card.classList.contains('melee'))
@@ -75,21 +77,25 @@ export class CoC7Chat{
 							const target = CoC7MeleeTarget.getFromMessageId( initiator.targetCard);
 							if( target.resolved){
 								const resolutionCard = new CoC7MeleeResoltion( chatMessage.id, target.messageId, target.resolutionCard);
-								resolutionCard.resolve();
+								await resolutionCard.resolve();
+								if( !initiator.checkRevealed) await initiator.revealCheck();
+
 							}
 						}
 						else { 
 							const initiator = CoC7MeleeInitiator.getFromMessageId( chatMessage.id);
 							if( initiator.resolutionCard){
 								const resolutionCard = new CoC7MeleeResoltion( chatMessage.id, null, initiator.resolutionCard);
-								resolutionCard.resolve();
+								await resolutionCard.resolve();
+								if( !initiator.checkRevealed) await initiator.revealCheck();
 							}
 						}
 					}
 					if( card.classList.contains('target')){
 						const target = CoC7MeleeTarget.getFromMessageId( chatMessage.id);
 						const resolutionCard = new CoC7MeleeResoltion( target.parentMessageId, chatMessage.id, target.resolutionCard);
-						resolutionCard.resolve();
+						await resolutionCard.resolve();
+						if( !target.meleeInitiator.checkRevealed) await target.meleeInitiator.revealCheck();
 					}
 
 				}
@@ -100,6 +106,18 @@ export class CoC7Chat{
 	}
 
 	static async renderMessageHook(message, html) {
+
+		if( message.getFlag( 'CoC7', 'checkRevealed')){
+			html.find('.dice-roll').removeClass('gm-visible-only');
+			html[0].dataset.checkRevealed = true;
+
+			// const htmlMessage = $(chatMessage.data.content);
+			// const roll = new CoC7Check;
+			// CoC7Roll.getFromElement(htmlMessage.find('.dice-roll')[0], roll );
+			// roll.showDiceRoll();
+	
+
+		}
 
 		//Handle showing dropdown selection
 		html.find('.dropbtn').click(event => event.currentTarget.closest('.dropdown').querySelector('.dropdown-content').classList.toggle('show'));

--- a/module/chat/combat/melee-initiator.js
+++ b/module/chat/combat/melee-initiator.js
@@ -5,6 +5,7 @@ import { CoC7MeleeTarget } from './melee-target.js';
 import { CoC7MeleeResoltion } from './melee-resolution.js';
 import { ChatCardActor } from '../card-actor.js';
 
+//TODO : récupérer le jet en tant qu'objet !!!
 export class CoC7MeleeInitiator extends ChatCardActor{
 	constructor(actorKey = null, itemId = null, fastForward = false) {
 		super( actorKey, fastForward);
@@ -21,6 +22,14 @@ export class CoC7MeleeInitiator extends ChatCardActor{
 	}
 
 	template = 'systems/CoC7/templates/chat/combat/melee-initiator.html';
+
+	async revealCheck(){
+		//TODO : on utilise l'update du message au lieu de reconstruire l'objet. Changer ce comportement.
+		const chatMessage = game.messages.get( this.messageId);
+
+		await chatMessage.setFlag( 'CoC7', 'checkRevealed', true);
+		await ui.chat.updateMessage( chatMessage, false);
+	}
 
 	async createChatCard(){
 		chatHelper.getActorImgFromKey(this.actorKey);
@@ -78,6 +87,9 @@ export class CoC7MeleeInitiator extends ChatCardActor{
 		check.skill = skillId;
 		check.difficulty = CoC7Check.difficultyLevel.regular;
 		check.diceModifier = 0;
+
+		if( game.user.isGM) this.checkRevealed = false;
+		else this.checkRevealed = true;
 
 		if( this.outnumbered) check.diceModifier += 1;
 		if( this.surprised) check.diceModifier += 1;

--- a/module/chat/combat/melee-resolution.js
+++ b/module/chat/combat/melee-resolution.js
@@ -74,12 +74,18 @@ export class CoC7MeleeResoltion{
 				else if( this.initiator.roll.successLevel > this.target.roll.successLevel){
 					this.resultString = `${this.initiator.name} won. Roll damage`;
 					this.winner = this.initiator;
+					this.winnerImg = this.initiator.weapon.img;
+					this.winnerTitle = this.initiator.weapon.name;
+					this.looser = this.target;
 					this.action = 'roll-melee-damage';
 					this.rollDamage = true;
 				}
 				else if( this.initiator.roll.successLevel <= this.target.roll.successLevel){
 					this.resultString = `${this.target.name} dodged.`;
 					this.winner = this.target;
+					this.looser = this.initiator;
+					this.winnerImg = this.target.skill.data.img;
+					this.winnerTitle = this.target.skill.name;
 					this.action = 'dodge';
 					this.rollDamage = false;
 				}
@@ -95,12 +101,16 @@ export class CoC7MeleeResoltion{
 				else if( this.initiator.roll.successLevel >= this.target.roll.successLevel){
 					this.resultString = `${this.initiator.name} won. Roll damage`;
 					this.winner = this.initiator;
+					this.winnerImg = this.initiator.weapon.img;
+					this.winnerTitle = this.initiator.weapon.name;
 					this.looser = this.target;
 					this.rollDamage = true;
 				}
 				else if( this.initiator.roll.successLevel <= this.target.roll.successLevel){
 					this.resultString = `${this.target.name} won. Roll damage`;
 					this.winner = this.target;
+					this.winnerImg = this.target.weapon.img;
+					this.winnerTitle = this.target.weapon.name;
 					this.looser = this.initiator;
 					this.rollDamage = true;
 				}
@@ -116,12 +126,16 @@ export class CoC7MeleeResoltion{
 				else if( this.initiator.roll.successLevel >= this.target.roll.successLevel){
 					this.resultString = `${this.initiator.name} won. Roll damage`;
 					this.winner = this.initiator;
+					this.winnerImg = this.initiator.weapon.img;
+					this.winnerTitle = this.initiator.weapon.name;
 					this.looser = this.target;
 					this.rollDamage = true;
 				}
 				else if( this.initiator.roll.successLevel <= this.target.roll.successLevel){
 					this.resultString = `${this.target.name} maneuver was successful.`;
 					this.winner = this.target;
+					this.winnerImg = this.target.skill.data.img;
+					this.winnerTitle = this.target.skill.name;
 					this.looser = this.initiator;
 					this.rollDamage = false;
 				}

--- a/module/chat/combat/melee-resolution.js
+++ b/module/chat/combat/melee-resolution.js
@@ -67,12 +67,12 @@ export class CoC7MeleeResoltion{
 			switch (this.target.action) {
 			case 'dodge':
 				if( this.initiator.roll.successLevel <= 0 && this.target.roll.successLevel <= 0){
-					this.resultString = 'Both side failed.';
+					this.resultString = game.i18n.localize('CoC7.NoWinner');
 					this.winner = null;
 					this.rollDamage = false;
 				}
 				else if( this.initiator.roll.successLevel > this.target.roll.successLevel){
-					this.resultString = `${this.initiator.name} won. Roll damage`;
+					this.resultString = game.i18n.format('CoC7.WinnerRollDamage', {name : this.initiator.name});
 					this.winner = this.initiator;
 					this.winnerImg = this.initiator.weapon.img;
 					this.winnerTitle = this.initiator.weapon.name;
@@ -81,7 +81,7 @@ export class CoC7MeleeResoltion{
 					this.rollDamage = true;
 				}
 				else if( this.initiator.roll.successLevel <= this.target.roll.successLevel){
-					this.resultString = `${this.target.name} dodged.`;
+					this.resultString = game.i18n.format('CoC7.DodgeSuccess', {name : this.target.name});
 					this.winner = this.target;
 					this.looser = this.initiator;
 					this.winnerImg = this.target.skill.data.img;
@@ -94,20 +94,20 @@ export class CoC7MeleeResoltion{
 			
 			case 'fightBack':
 				if( this.initiator.roll.successLevel <= 0 && this.target.roll.successLevel <= 0){
-					this.resultString = 'Both side failed.';
+					this.resultString = game.i18n.localize('CoC7.NoWinner');
 					this.winner = null;
 					this.rollDamage = false;
 				}
 				else if( this.initiator.roll.successLevel >= this.target.roll.successLevel){
-					this.resultString = `${this.initiator.name} won. Roll damage`;
+					this.resultString = game.i18n.format('CoC7.WinnerRollDamage', {name : this.initiator.name});
 					this.winner = this.initiator;
 					this.winnerImg = this.initiator.weapon.img;
 					this.winnerTitle = this.initiator.weapon.name;
 					this.looser = this.target;
 					this.rollDamage = true;
 				}
-				else if( this.initiator.roll.successLevel <= this.target.roll.successLevel){
-					this.resultString = `${this.target.name} won. Roll damage`;
+				else if( this.initiator.roll.successLevel <= this.target.roll.successLevel){ //TODO verifier la condition <= vs <
+					this.resultString = game.i18n.format('CoC7.WinnerRollDamage', {name : this.target.name});
 					this.winner = this.target;
 					this.winnerImg = this.target.weapon.img;
 					this.winnerTitle = this.target.weapon.name;
@@ -119,12 +119,12 @@ export class CoC7MeleeResoltion{
 			
 			case 'maneuver':
 				if( this.initiator.roll.successLevel <= 0 && this.target.roll.successLevel <= 0){
-					this.resultString = 'Both side failed.';
+					this.resultString = game.i18n.localize('CoC7.NoWinner');
 					this.winner = null;
 					this.rollDamage = false;
 				}
 				else if( this.initiator.roll.successLevel >= this.target.roll.successLevel){
-					this.resultString = `${this.initiator.name} won. Roll damage`;
+					this.resultString = game.i18n.format('CoC7.WinnerRollDamage', {name : this.initiator.name});
 					this.winner = this.initiator;
 					this.winnerImg = this.initiator.weapon.img;
 					this.winnerTitle = this.initiator.weapon.name;
@@ -132,7 +132,7 @@ export class CoC7MeleeResoltion{
 					this.rollDamage = true;
 				}
 				else if( this.initiator.roll.successLevel <= this.target.roll.successLevel){
-					this.resultString = `${this.target.name} maneuver was successful.`;
+					this.resultString = game.i18n.format('CoC7.ManeuverSuccess', {name : this.target.name});
 					this.winner = this.target;
 					this.winnerImg = this.target.skill.data.img;
 					this.winnerTitle = this.target.skill.name;

--- a/module/chat/combat/melee-target.js
+++ b/module/chat/combat/melee-target.js
@@ -27,7 +27,7 @@ export class CoC7MeleeTarget extends ChatCardActor{
 		this.fightingBack = false;
 		this.maneuvering = false;
 	}
-    
+	
 	get actionSelected(){
 		return this.dodging || this.fightingBack || this.maneuvering;
 	}
@@ -74,6 +74,11 @@ export class CoC7MeleeTarget extends ChatCardActor{
 		return chatHelper.getActorFromKey( this.initiatorKey);
 	}
 
+	get meleeInitiator(){
+		if( !this._initiator) this._initiator = CoC7MeleeInitiator.getFromMessageId( this.parentMessageId);
+		return this._initiator;
+	}
+
 	template = 'systems/CoC7/templates/chat/combat/melee-target.html';
 
 	static getFromMessageId( messageId){
@@ -111,8 +116,13 @@ export class CoC7MeleeTarget extends ChatCardActor{
 
 	async createChatCard(){
 		const html = await renderTemplate(this.template, this);
+
+		const speakerData = {};
+		const token = chatHelper.getTokenFromKey( this.actorKey);
+		if( token) speakerData.token = token;
+		else speakerData.actor = this.actor;
 		
-		const speaker = ChatMessage.getSpeaker({token: this.token});
+		const speaker = ChatMessage.getSpeaker(speakerData);
 		if( this.actor.isToken) speaker.alias = this.actor.token.name;
 		
 		const user = this.actor.user ? this.actor.user : game.user;

--- a/module/chat/helper.js
+++ b/module/chat/helper.js
@@ -177,6 +177,24 @@ export class CoC7Roll{
 		return null;
 	}
 
+	showDiceRoll(){
+		if( game.dice3d){
+			const diceResults = [];
+			this.dices.tens.forEach(dieResult => { 
+				diceResults.push( 100 == dieResult.value ?0:dieResult.value/10);
+			});
+			diceResults.push( this.dices.unit.value);
+
+			const diceData = {
+				formula: `${this.dices.tens.length}d100+1d10`,
+				results: diceResults,
+				whisper: null,
+				blind: false
+			};
+			game.dice3d.show(diceData);
+		}
+	}
+
 	static getFromElement( element, object = null){
 		if( !element) return;
 		const roll = object? object : new CoC7Roll();

--- a/module/check.js
+++ b/module/check.js
@@ -370,11 +370,9 @@ export class CoC7Check {
 			// if( die.value == 100) die.value = "00";
 			this.dices.tens.push( die);
 		}
-
 		this.computeCheck();
-
 	}
-
+	
 	async computeCheck(){
 
 		this.isUnknown = this.unknownDifficulty;
@@ -532,6 +530,24 @@ export class CoC7Check {
 
 		if( this.passed && this.diceModifier <= 0 && this.skill && !this.skill.data.data.properties.noxpgain &&!this.luckSpent &&!this.forced &&!this.isBlind &&!this.isUnknown){
 			this.flagForDevelopement();
+		}
+	}
+
+	showDiceRoll(){
+		if( game.dice3d){
+			const diceResults = [];
+			this.dices.tens.forEach(dieResult => { 
+				diceResults.push( 100 == dieResult.value ?0:dieResult.value/10);
+			});
+			diceResults.push( this.dices.unit.value);
+
+			const diceData = {
+				formula: `${this.dices.tens.length}d100+1d10`,
+				results: diceResults,
+				whisper: null,
+				blind: false
+			};
+			game.dice3d.show(diceData);
 		}
 	}
 

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -187,6 +187,8 @@ Hooks.on('preCreateActor', (createData) => CoCActor.initToken( createData));
 
 // Called on closing a character sheet to lock it on getting it to display values
 Hooks.on('closeActorSheet', (characterSheet) => characterSheet.onCloseSheet());
+Hooks.on('renderCoC7CreatureSheet', (app, html, data) => CoC7CreatureSheet.forceAuto(app, html, data));
+Hooks.on('renderCoC7NPCSheet', (app, html, data) => CoC7NPCSheet.forceAuto(app, html, data));
 
 
 // Add button on Token selection bar

--- a/styles/coc7.css
+++ b/styles/coc7.css
@@ -596,6 +596,7 @@
     height: 100%;
     overflow-y: auto;
     align-content: flex-start;
+    padding: 0 5px;
 }
 
 .coc7.sheet input[type="text"],

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
 	"name": "CoC7",
 	"title": "The Call of Cthulhu 7th edition",
 	"description": "The Call of Cthulhu 7th edition simple game system",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"author": "HavelockV",
 	"minimumCoreVersion": "0.5.2",
 	"compatibleCoreVersion": "0.6.6",
@@ -72,6 +72,6 @@
 	"secondaryTokenAttribute": "power",
 	"url": "https://github.com/HavlockV/CoC7-FoundryVTT/",
 	"manifest": "https://github.com/HavlockV/CoC7-FoundryVTT/raw/master/system.json",
-	"download": "https://github.com/HavlockV/CoC7-FoundryVTT/archive/0.3.3.zip"
+	"download": "https://github.com/HavlockV/CoC7-FoundryVTT/archive/0.3.4.zip"
   }
   

--- a/templates/actors/creature-sheet.html
+++ b/templates/actors/creature-sheet.html
@@ -129,7 +129,7 @@
 
 					<div class="flexrow flex1 attribute"  data-attrib="lck">
 						<label class="attribute-label rollable">{{localize 'CoC7.Luck'}} :</label>
-						<input class="attribute-value read-only" type="text" name="data.attribs.lck.value" value="{{data.attribs.lck.value}}" data-dtype="Number" readonly>
+						<input class="attribute-value read-only" type="text" name="data.attribs.lck.value" value="{{data.attribs.lck.value}}" data-dtype="Number">
 						<div class="flex1"></div>
 					</div>
 				{{/if}}

--- a/templates/actors/creature-sheet.html
+++ b/templates/actors/creature-sheet.html
@@ -1,9 +1,9 @@
 <form class="{{cssClass}} flexcol" autocomplete="off" data-actor-id="{{actor._id}}" {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}}>
 
 	{{!-- Sheet Header --}}
-	<header class="flexrow" style="flex: 0 0 auto;padding-bottom: 10px;border-bottom: 2px groove;">
+	<header class="sheet-header flexrow" style="flex: 0 0 auto;padding-bottom: 10px;border-bottom: 2px groove;">
 		<div class="flexcol">
-			<div class="flexrow" style="flex: 0 0 auto;display: flex;">
+			<div class="infos flexrow" style="flex: 0 0 auto;display: flex;">
 				<div class="flexrow flex1">
 					<label>{{localize 'CoC7.Name'}}</label>
 					<input name="name" type="text" value="{{actor.name}}" placeholder="{{localize 'CoC7.Name'}}"/>
@@ -14,7 +14,7 @@
 				</div>
 			</div>
 
-			<div class="flexrow" style="flex: 0 0 auto;display: flex;">
+			<div class="characteritics flexrow" style="flex: 0 0 auto;display: flex;">
 			{{#each data.characteristics as |characteristic key|}}
 				{{#if ../data.flags.locked}}
 					{{#if characteristic.display}}
@@ -54,13 +54,14 @@
 			{{/each}}
 			</div>
 
-			<div class="flexrow attribute-list" style="display: flex;">
+			<div class="attribute-list flexrow" style="display: flex;">
 				<div class="flexrow flex1 attribute" style="display: flex;" data-attrib="hp">
 					<label class="attribute-label">{{localize 'CoC7.HP'}} :</label>
 					<input class="attribute-value" type="text" name="data.attribs.hp.value" value="{{data.attribs.hp.value}}" data-dtype="Number"/>
 					<span style="flex: none;font-size: large;">/</span>
 					{{#if data.attribs.hp.auto}}
-					<span class="attribute-max" type="text" style="line-height: 22px;"> {{data.attribs.hp.max}} </span>
+					<input class="attribute-max" type="text" name="data.attribs.hp.max" value="{{data.attribs.hp.max}}" data-dtype="Number" readonly/>
+					<!-- <span class="attribute-max" type="text" style="line-height: 22px;"> {{data.attribs.hp.max}} </span> -->
 					{{else}}
 					<input class="attribute-max {{#if data.flags.locked}}read-only{{/if}}" type="text" name="data.attribs.hp.max" value="{{data.attribs.hp.max}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}>
 					{{/if}}
@@ -77,7 +78,8 @@
 						<input class="attribute-value" type="text" name="data.attribs.mp.value" value="{{data.attribs.mp.value}}" data-dtype="Number"/>
 						<span style="flex: none;font-size: large;">/</span>
 						{{#if data.attribs.mp.auto}}
-						<span class="attribute-max" type="text" style="line-height: 22px;"> {{data.attribs.mp.max}} </span>
+						<input class="attribute-max" type="text" name="data.attribs.mp.max" value="{{data.attribs.mp.max}}" data-dtype="Number" readonly/>
+						<!-- <span class="attribute-max" type="text" style="line-height: 22px;"> {{data.attribs.mp.max}} </span> -->
 						{{else}}
 						<input class="attribute-max {{#if data.flags.locked}}read-only{{/if}}" type="text" name="data.attribs.mp.max" value="{{data.attribs.mp.max}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}>
 						{{/if}}
@@ -108,7 +110,8 @@
 						<input class="attribute-value" type="text" name="data.attribs.mp.value" value="{{data.attribs.mp.value}}" data-dtype="Number"/>
 						<span style="flex: none;font-size: large;">/</span>
 						{{#if data.attribs.mp.auto}}
-						<span class="attribute-max" type="text" style="line-height: 22px;"> {{data.attribs.mp.max}} </span>
+						<input class="attribute-max" type="text" name="data.attribs.mp.max" value="{{data.attribs.mp.max}}" data-dtype="Number" readonly/>
+						<!-- <span class="attribute-max" type="text" style="line-height: 22px;"> {{data.attribs.mp.max}} </span> -->
 						{{else}}
 						<input class="attribute-max {{#if data.flags.locked}}read-only{{/if}}" type="text" name="data.attribs.mp.max" value="{{data.attribs.mp.max}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}>
 						{{/if}}
@@ -129,10 +132,10 @@
 						<input class="attribute-value read-only" type="text" name="data.attribs.lck.value" value="{{data.attribs.lck.value}}" data-dtype="Number" readonly>
 						<div class="flex1"></div>
 					</div>
-					{{/if}}
+				{{/if}}
 			</div>
 
-			<div class="flexrow" style="flex: none;height: 20px;">
+			<div class="attribute-list flexrow" style="flex: none;height: 20px;">
 				<div class="flexrow flex1 attribute" data-attrib="mov">
 					<label>{{localize 'CoC7.Mov'}} :</label>
 					
@@ -190,6 +193,7 @@
 					{{/unless}} -->
 				</div>
 			</div>
+
 			<div class="status-monitors flexrow">
 				<a class="status-monitor {{#if data.status.unconscious.value}}status-on{{/if}}" title="{{localize 'CoC7.Unconsious'}}" data-status="unconscious"> <i class="fas fa-bed"></i></a>
 				<a class="status-monitor {{#if data.status.criticalWounds.value}}status-on{{/if}}" title="{{localize 'CoC7.CriticalWounds'}}" data-status="criticalWounds"> <i class="fas fa-user-injured"></i></a>
@@ -248,62 +252,125 @@
 
 	{{!-- Sheet Body --}}
 	<section class="sheet-body">
+		<div class="tab">
 		
-		{{!-- Skills Tab --}}
-		<div class="section-header flexrow"> 
-			<h4 class="flex1" >{{localize 'CoC7.Skills'}}</h4>
-			{{#unless data.flags.locked}}
-				<div style="flex: 0 0 14px;">
-					<a class="add-item" title="{{localize 'CoC7.AddSkill'}}" data-type="skill"><i class="fas fa-plus-circle"></i></a>
-				</div>
-			{{/unless}}
-		</div>
-    	<div class="skills flexrow" style="padding-top: 1px;border-bottom: 2px groove;">
-			{{> "systems/CoC7/templates/actors/parts/npc-skills.html"}}
-		</div>
-		
-
-		<div class="section-header flexrow">
-			<h4 class="flex1">{{localize 'CoC7.Combat'}}</h4>
-			{{#unless data.flags.locked}}
-			<div style="flex: 0 0 14px;">
-				<a class="add-item" title="{{localize 'CoC7.AddWeapon'}}" data-type="weapon"><i class="fas fa-plus-circle"></i></a>
-			</div>
-			{{/unless}}
-		</div>
-		<div class="combat flexcol"  style="padding-top: 1px;border-bottom: 2px groove;">
-			{{> "systems/CoC7/templates/actors/parts/npc-combat.html"}}
-		</div>
-		
-		<div class="section-header flexrow"> 
-			<h4 class="flex1">{{localize 'CoC7.Possessions'}}</h4>
-			{{#unless data.flags.locked}}
-			<div style="flex: 0 0 14px;">
-				<a class="add-item" title="{{localize 'CoC7.AddItem'}}" data-type="item"><i class="fas fa-plus-circle"></i></a>
-			</div>
-			{{/unless}}
-		</div>
-		<div class="possession flexrow" style="padding-top: 1px;border-bottom: 2px groove;">
-				{{#each itemsByType.item as |item id|}}
-					<div class="item flexrow" style="flex: 0 0 33%;flex-wrap: wrap;border-right: 1px groove;" data-skill-id="{{item._id}}" data-item-id="{{item._id}}">
-						{{#if ../data.flags.locked}}
-							<h4 class="item-name" style="height:18px;padding: 1px 0 1px 2px;margin: 0;overflow: hidden;">{{item.name}}</h4>
-						{{else}}
-							<input class="item-name flex1" style="height: fit-content;padding: 0 2px;text-align: left;" type="text" name="item-name.{{id}}" value="{{item.name}}">
-							<div class="item-controls" style="height: 18px;">
-								<a class="item-control item-delete" title="{{localize 'CoC7.DeleteItem'}}"><i class="fas fa-trash"></i></a>
-								<a class="item-control item-edit" title="{{localize 'CoC7.EditItem'}}"><i class="fas fa-edit"></i></a>
-							</div>
-						{{/if}}
+		<section class="sheet-section">
+			<div class="section-header flexrow"   data-pannel="skills"> 
+				<h3 class="flex1" >{{localize 'CoC7.Skills'}}</h3>
+				{{#unless data.flags.locked}}
+					<div style="flex: 0 0 14px;">
+						<a class="add-item" title="{{localize 'CoC7.AddSkill'}}" data-type="skill"><i class="fas fa-plus-circle"></i></a>
 					</div>
-				{{/each}}
-		</div>
+				{{/unless}}
+			</div>
+			<div class="skills flexrow" style="padding-top: 1px;border-bottom: 2px groove;">
+				{{> "systems/CoC7/templates/actors/parts/npc-skills.html"}}
+			</div>
+		</section>
 
-		<div class="section-header flexrow" style="padding-top: 1px;border-bottom: 2px groove;">
-			<h4 class="flex1">{{localize 'CoC7.Notes'}} </h4>
-		</div>
-		<div class="background" style="display: flex;border: 2px groove #eeede0;padding: 0 5px;max-height: 200px;">
-			{{editor content=data.biography.personalDescription.value target="data.biography.personalDescription.value" style="height:95%" button=true owner=owner editable=editable}}
+		<section class="sheet-section">
+			<div class="section-header flexrow" data-pannel="combat">
+				<h3 class="flex1">{{localize 'CoC7.Combat'}}</h4>
+				{{#unless data.flags.locked}}
+				<div style="flex: 0 0 14px;">
+					<a class="add-item" title="{{localize 'CoC7.AddWeapon'}}" data-type="weapon"><i class="fas fa-plus-circle"></i></a>
+				</div>
+				{{/unless}}
+			</div>
+			<div class="combat flexcol"  style="padding-top: 1px;border-bottom: 2px groove;">
+				{{> "systems/CoC7/templates/actors/parts/npc-combat.html"}}
+			</div>
+		</section>
+		
+		{{#if hasInventory}}
+		<section class="sheet-section">
+			<div class="section-header flexrow" data-pannel="inventory"> 
+				<h3 class="flex1">{{localize 'CoC7.Inventory'}}</h3>
+				{{#unless data.flags.locked}}
+				<div style="flex: 0 0 14px;">
+					<a class="add-item" title="{{localize 'CoC7.AddItem'}}" data-type="item"><i class="fas fa-plus-circle"></i></a>
+				</div>
+				{{/unless}}
+			</div>
+			<div class="inventory flexrow" style="display: none;">
+				<ol class="inventory-list">
+					{{#if  itemsByType.item}}
+					<div class="inventory-section">
+						<li class="flexrow inventory-header">
+							<div class="item-name flexrow">
+								<h3>{{localize 'CoC7.Items'}}</h3>
+							</div>
+						</li>
+						<ol class="item-list">
+						{{#each itemsByType.item as |item id|}}
+							<li class="item flexrow" data-item-id="{{item._id}}">
+								<div class="item-image" style="background-image: url({{item.img}})"></div>
+								<h4 class="item-name show-detail">{{item.name}}</h4>
+								<div class="item-controls">
+									<a class="item-control item-edit" title="{{localize 'CoC7.EditItem'}}"><i class="fas fa-edit"></i></a>
+									<a class="item-control item-delete" title="{{localize 'CoC7.DeleteItem'}}"><i class="fas fa-trash"></i></a>
+								</div>
+							</li>
+						{{/each}}
+						</ol>
+					</div>
+					{{/if}}
+					{{#if  itemsByType.book}}
+					<div class="inventory-section">
+						<li class="flexrow inventory-header">
+							<div class="item-name flexrow">
+								<h3>{{localize 'CoC7.Books'}}</h3>
+							</div>
+						</li>
+						<ol class="item-list">
+						{{#each itemsByType.book as |item id|}}
+							<li class="item flexrow" data-item-id="{{item._id}}">
+								<div class="item-image" style="background-image: url({{item.img}})"></div>
+								<h4 class="item-name show-detail">{{item.name}}</h4>
+								<div class="item-controls">
+									<a class="item-control item-edit" title="{{localize 'CoC7.EditItem'}}"><i class="fas fa-edit"></i></a>
+									<a class="item-control item-delete" title="{{localize 'CoC7.DeleteItem'}}"><i class="fas fa-trash"></i></a>
+								</div>
+							</li>
+						{{/each}}
+						</ol>
+					</div>
+					{{/if}}
+					{{#if  itemsByType.spell}}
+					<div class="inventory-section">
+						<li class="flexrow inventory-header">
+							<div class="item-name flexrow">
+								<h3>{{localize 'CoC7.Spells'}}</h3>
+							</div>
+						</li>
+						<ol class="item-list">
+						{{#each itemsByType.spell as |item id|}}
+							<li class="item flexrow" data-item-id="{{item._id}}">
+								<div class="item-image" style="background-image: url({{item.img}})"></div>
+								<h4 class="item-name show-detail">{{item.name}}</h4>
+								<div class="item-controls">
+									<a class="item-control item-edit" title="{{localize 'CoC7.EditItem'}}"><i class="fas fa-edit"></i></a>
+									<a class="item-control item-delete" title="{{localize 'CoC7.DeleteItem'}}"><i class="fas fa-trash"></i></a>
+								</div>
+							</li>
+						{{/each}}
+						</ol>
+					</div>
+					{{/if}}
+				</ol>
+			</div>
+		</section>
+		{{/if}}
+
+
+		<section class="sheet-section">
+			<div class="section-header flexrow" data-pannel="description">
+				<h3 class="flex1">{{localize 'CoC7.Notes'}} </h3>
+			</div>
+			<div class="description" >
+				{{editor content=data.biography.personalDescription.value target="data.biography.personalDescription.value" style="height:95%" button=true owner=owner editable=editable}}
+			</div>
+		</section>
 		</div>
 	</section>
 </form>

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -1,9 +1,9 @@
 <form class="{{cssClass}} flexcol" autocomplete="off" data-actor-id="{{actor._id}}" {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}}>
 
 	{{!-- Sheet Header --}}
-	<header class="flexrow" style="flex: 0 0 auto;padding-bottom: 10px;border-bottom: 2px groove;">
+	<header class="sheet-header flexrow" style="flex: 0 0 auto;padding-bottom: 10px;border-bottom: 2px groove;">
 		<div class="flexcol">
-			<div class="flexrow" style="flex: 0 0 auto;display: flex;">
+			<div class="infos flexrow" style="flex: 0 0 auto;display: flex;">
 				<div class="flexrow flex2">
 					<label>{{localize 'CoC7.Name'}}</label>
 					<input name="name" type="text" value="{{actor.name}}" placeholder="{{localize 'CoC7.Name'}}"/>
@@ -18,8 +18,24 @@
 				</div>
 			</div>
 
-			<div class="flexrow" style="flex: 0 0 auto;display: flex;">
+			<div class="characteritics flexrow" style="flex: 0 0 auto;display: flex;">
 			{{#each data.characteristics as |characteristic key|}}
+				{{#if ../data.flags.locked}}
+					{{#if characteristic.display}}
+						<div class="flexcol" style=" margin-right: 2px;" data-characteristic="{{key}}">
+							<div class="characteristics-label rollable" style="text-align: left;">
+								<label>{{localize characteristic.short}}</label>
+							</div>
+							<div style="text-align:center;border: 1px groove;margin-right: 2px;">
+								{{#if characteristic.editable}}
+								<input class="characteristic-score" style="text-align: center;" type="text" name="data.characteristics.{{key}}.value" value="{{characteristic.value}}" data-dtype="Number">
+								{{else}}
+								<input class="characteristic-score read-only" style="text-align: center;" type="text" name="data.characteristics.{{key}}.value" value="{{characteristic.value}}" data-dtype="Number" {{#if ../data.flags.locked}}readonly{{/if}}>
+								{{/if}}
+							</div>
+						</div>
+					{{/if}}
+				{{else}}
 				<div class="flexcol" style=" margin-right: 2px;" data-characteristic="{{key}}">
 					<div class="characteristics-label rollable" style="text-align: left;">
 						<label>{{localize characteristic.short}}</label>
@@ -38,16 +54,18 @@
 						</div>
 					{{/if}}
 				</div>
+				{{/if}}
 			{{/each}}
 			</div>
 
-			<div class="flexrow attribute-list" style="display: flex;">
-				<div class="flexrow flex1 attribute" data-attrib="hp">
+			<div class="attribute-list flexrow" style="display: flex;">
+				<div class="flexrow flex1 attribute" style="display: flex;" data-attrib="hp">
 					<label class="attribute-label">{{localize 'CoC7.HP'}} :</label>
 					<input class="attribute-value" type="text" name="data.attribs.hp.value" value="{{data.attribs.hp.value}}" data-dtype="Number"/>
 					<span style="flex: none;font-size: large;">/</span>
 					{{#if data.attribs.hp.auto}}
-					<span class="attribute-max" type="text" style="line-height: 22px;"> {{data.attribs.hp.max}} </span>
+					<input class="attribute-max" type="text" name="data.attribs.hp.max" value="{{data.attribs.hp.max}}" data-dtype="Number" readonly/>
+					<!-- <span class="attribute-max" type="text" style="line-height: 22px;"> {{data.attribs.hp.max}} </span> -->
 					{{else}}
 					<input class="attribute-max {{#if data.flags.locked}}read-only{{/if}}" type="text" name="data.attribs.hp.max" value="{{data.attribs.hp.max}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}>
 					{{/if}}
@@ -57,43 +75,78 @@
 					{{/unless}}
 					<div class="flex1"></div>
 				</div>
-				<div class="flexrow flex1 attribute" data-attrib="mp">
-					<label class="attribute-label">{{localize 'CoC7.MP'}} :</label>
-					<input class="attribute-value" type="text" name="data.attribs.mp.value" value="{{data.attribs.mp.value}}" data-dtype="Number"/>
-					<span style="flex: none;font-size: large;">/</span>
-					{{#if data.attribs.mp.auto}}
-					<span class="attribute-max" type="text" style="line-height: 22px;"> {{data.attribs.mp.max}} </span>
-					{{else}}
-					<input class="attribute-max {{#if data.flags.locked}}read-only{{/if}}" type="text" name="data.attribs.mp.max" value="{{data.attribs.mp.max}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}>
-					{{/if}}
+				{{#if data.flags.locked}}
+					<div class="flexrow flex1 attribute" data-attrib="mp">
+						{{#if hasMp}}
+						<label class="attribute-label">{{localize 'CoC7.MP'}} :</label>
+						<input class="attribute-value" type="text" name="data.attribs.mp.value" value="{{data.attribs.mp.value}}" data-dtype="Number"/>
+						<span style="flex: none;font-size: large;">/</span>
+						{{#if data.attribs.mp.auto}}
+						<input class="attribute-max" type="text" name="data.attribs.mp.max" value="{{data.attribs.mp.max}}" data-dtype="Number" readonly/>
+						<!-- <span class="attribute-max" type="text" style="line-height: 22px;"> {{data.attribs.mp.max}} </span> -->
+						{{else}}
+						<input class="attribute-max {{#if data.flags.locked}}read-only{{/if}}" type="text" name="data.attribs.mp.max" value="{{data.attribs.mp.max}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}>
+						{{/if}}
+						<div class="flex1"></div>
+						{{/if}}
+					</div>
 
-					{{#unless data.flags.locked}}
-					<div class="auto-toggle {{#if data.attribs.mp.auto}}auto-on{{else}}auto-off{{/if}}"><i class="fas fa-cogs" style="padding-top: 4px;"></i></div>
-					{{/unless}}
-					<div class="flex1"></div>
-				</div>
-				<div class="flexrow flex1 attribute"  data-attrib="san">
-					<label class="attribute-label rollable">{{localize 'CoC7.SAN'}} :</label>
-					<input class="attribute-value" type="text" name="data.attribs.san.value" value="{{data.attribs.san.value}}" data-dtype="Number"/>
-					<span style="flex: none;font-size: large;">/</span>
-					<input class="attribute-max {{#if data.flags.locked}}read-only{{/if}}" type="text" name="data.attribs.san.max" value="{{data.attribs.san.max}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}>
-					<div class="flex1"></div>
-				</div>
-				<div class="flexrow flex1 attribute"  data-attrib="lck">
-					<label class="attribute-label rollable">{{localize 'CoC7.Luck'}} :</label>
-					<input class="attribute-value read-only" type="text" name="data.attribs.lck.value" value="{{data.attribs.lck.value}}" data-dtype="Number" readonly>
-					<div class="flex1"></div>
-				</div>
+					<div class="flexrow flex1 attribute"  data-attrib="san">
+						{{#if hasSan}}
+						<label class="attribute-label rollable">{{localize 'CoC7.SAN'}} :</label>
+						<input class="attribute-value" type="text" name="data.attribs.san.value" value="{{data.attribs.san.value}}" data-dtype="Number"/>
+						<span style="flex: none;font-size: large;">/</span>
+						<input class="attribute-max {{#if data.flags.locked}}read-only{{/if}}" type="text" name="data.attribs.san.max" value="{{data.attribs.san.max}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}>
+						<div class="flex1"></div>
+						{{/if}}
+					</div>
+
+					<div class="flexrow flex1 attribute"  data-attrib="lck">
+						{{#if hasLuck}}
+						<label class="attribute-label rollable">{{localize 'CoC7.Luck'}} :</label>
+						<input class="attribute-value read-only" type="text" name="data.attribs.lck.value" value="{{data.attribs.lck.value}}" data-dtype="Number" readonly>
+						<div class="flex1"></div>
+						{{/if}}
+					</div>
+				{{else}}
+					<div class="flexrow flex1 attribute" data-attrib="mp">
+						<label class="attribute-label">{{localize 'CoC7.MP'}} :</label>
+						<input class="attribute-value" type="text" name="data.attribs.mp.value" value="{{data.attribs.mp.value}}" data-dtype="Number"/>
+						<span style="flex: none;font-size: large;">/</span>
+						{{#if data.attribs.mp.auto}}
+						<input class="attribute-max" type="text" name="data.attribs.mp.max" value="{{data.attribs.mp.max}}" data-dtype="Number" readonly/>
+						<!-- <span class="attribute-max" type="text" style="line-height: 22px;"> {{data.attribs.mp.max}} </span> -->
+						{{else}}
+						<input class="attribute-max {{#if data.flags.locked}}read-only{{/if}}" type="text" name="data.attribs.mp.max" value="{{data.attribs.mp.max}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}>
+						{{/if}}
+						<div class="auto-toggle {{#if data.attribs.mp.auto}}auto-on{{else}}auto-off{{/if}}"><i class="fas fa-cogs" style="padding-top: 4px;"></i></div>
+						<div class="flex1"></div>
+					</div>
+
+					<div class="flexrow flex1 attribute"  data-attrib="san">
+						<label class="attribute-label rollable">{{localize 'CoC7.SAN'}} :</label>
+						<input class="attribute-value" type="text" name="data.attribs.san.value" value="{{data.attribs.san.value}}" data-dtype="Number"/>
+						<span style="flex: none;font-size: large;">/</span>
+						<input class="attribute-max {{#if data.flags.locked}}read-only{{/if}}" type="text" name="data.attribs.san.max" value="{{data.attribs.san.max}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}>
+						<div class="flex1"></div>
+					</div>
+
+					<div class="flexrow flex1 attribute"  data-attrib="lck">
+						<label class="attribute-label rollable">{{localize 'CoC7.Luck'}} :</label>
+						<input class="attribute-value read-only" type="text" name="data.attribs.lck.value" value="{{data.attribs.lck.value}}" data-dtype="Number">
+						<div class="flex1"></div>
+					</div>
+				{{/if}}
 			</div>
 
-			<div class="flexrow" style="flex: none;height: 20px;">
+			<div class="attribute-list flexrow" style="flex: none;height: 20px;">
 				<div class="flexrow flex1 attribute" data-attrib="mov">
 					<label>{{localize 'CoC7.Mov'}} :</label>
 					
 					{{#if data.attribs.mov.auto}}
 						<span class="attribute-value" type="text" style="line-height: 22px;"> {{data.attribs.mov.value}} </span>
 					{{else}}
-						<input class="attribute-value {{#if data.flags.locked}}read-only{{/if}}" type="text" name="data.attribs.mov.value" value="{{data.attribs.mov.value}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}>
+						<input class="attribute-value {{#if data.flags.locked}}read-only{{/if}}" type="text" name="data.attribs.mov.value" value="{{data.attribs.mov.value}}" {{#if data.flags.locked}}readonly{{/if}}>
 					{{/if}}
 
 					{{#unless data.flags.locked}}
@@ -144,46 +197,48 @@
 					{{/unless}} -->
 				</div>
 			</div>
+
+			<div class="status-monitors flexrow">
+				<a class="status-monitor {{#if data.status.unconscious.value}}status-on{{/if}}" title="{{localize 'CoC7.Unconsious'}}" data-status="unconscious"> <i class="fas fa-bed"></i></a>
+				<a class="status-monitor {{#if data.status.criticalWounds.value}}status-on{{/if}}" title="{{localize 'CoC7.CriticalWounds'}}" data-status="criticalWounds"> <i class="fas fa-user-injured"></i></a>
+				<a class="status-monitor {{#if data.status.dying.value}}status-on{{/if}}" title="Dying" data-status="{{localize 'CoC7.Dying'}}"> <i class="fas fa-heartbeat"></i></a>
+
+				<a class="status-monitor {{#if data.status.tempoInsane.value}}status-on{{/if}}" title="{{localize 'CoC7.TemporaryInsanity'}}" data-status="tempoInsane"> <i class="fas fa-filter"></i></a>
+				<a class="status-monitor {{#if data.status.indefInsane.value}}status-on{{/if}}" title="{{localize 'CoC7.IndefiniteInsanity'}}" data-status="indefInsane"> <i class="far fa-hospital"></i></a>
+				<div class="flex1"></div>
+
+				<div class="flexrow sheet-controls" style="flex: 0 0 70px;align-content: flex-start;">
+					{{#if allowFormula}}
+						{{#if data.flags.locked}}
+							<div style="flex: 0 0 32px;"></div>
+						{{else}}
+							{{#if displayFormula}}
+								<div style="flex: 0 0 32px;"></div>
+							{{else}}
+								<a class="roll-characteritics" style="flex: 0 0 16px;color: darkred;" data-html="true" title="{{localize 'CoC7.NpcRollCharacteristics'}}"> <i class="fas fa-dice"></i></a>
+								<a class="average-characteritics" style="flex: 0 0 16px;color: darkred;" title="{{localize 'CoC7.NpcAvarageCharacteristics'}}"> <i class="fas fa-balance-scale"></i></a>
+							{{/if}}
+						{{/if}}
+					{{else}}
+						<div style="flex: 0 0 16px;"></div>
+					{{/if}}
+					{{#if data.flags.locked}}
+						<a class="lock"  style="flex: 0 0 32px;align-content: flex-start;"  title="{{localize 'CoC7.UnlockActor'}}" data-locked="true"> <i class="fas fa-lock"></i></a>
+					{{else}}
+						<a class="lock"  style="flex: 0 0 16px;" title="{{localize 'CoC7.LockActor'}}" data-locked="false"> <i class="fas fa-lock-open"></i></a>
+						{{#if allowFormula}}
+							{{#if displayFormula}}
+								<a class="formula"  style="flex: 0 0 16px;" title="{{localize 'CoC7.NpcCharacteristicsFormula'}}" data-locked="true"> <i class="fas fa-square-root-alt"></i></a>
+							{{else}}
+								<a class="formula"  style="flex: 0 0 16px;" title="{{localize 'CoC7.NpcCharacteristicsValues'}}" data-locked="false"> <i class="fas fa-user-edit"></i></a>
+							{{/if}}
+						{{/if}}
+					{{/if}}
+				</div>
+			</div>
 		</div>
 		<img class="profile-img" src="{{actor.img}}" title="{{actor.name}}" data-edit="img" height="100" width="100"/>
 	</header>
-	<div class="status-monitors flexrow" style="max-height: 16px;">
-		<a class="status-monitor {{#if data.status.unconscious.value}}status-on{{/if}}" title="Unconsious" data-status="unconscious"> <i class="fas fa-bed"></i></a>
-		<a class="status-monitor {{#if data.status.criticalWounds.value}}status-on{{/if}}" title="Critical" data-status="criticalWounds"> <i class="fas fa-user-injured"></i></a>
-		<a class="status-monitor {{#if data.status.dying.value}}status-on{{/if}}" title="Dying" data-status="dying"> <i class="fas fa-heartbeat"></i></a>
-
-		<a class="status-monitor {{#if data.status.tempoInsane.value}}status-on{{/if}}" title="Temporary insanity" data-status="tempoInsane"> <i class="fas fa-filter"></i></a>
-		<a class="status-monitor {{#if data.status.indefInsane.value}}status-on{{/if}}" title="Indefinite insanity" data-status="indefInsane"> <i class="far fa-hospital"></i></a>
-		<div class="flex1"></div>
-		<div class="flexrow sheet-controls" style="flex: 0 0 70px;align-content: flex-start;">
-			{{#if allowFormula}}
-				{{#if data.flags.locked}}
-					<div style="flex: 0 0 32px;"></div>
-				{{else}}
-					{{#if displayFormula}}
-						<div style="flex: 0 0 32px;"></div>
-					{{else}}
-						<a class="roll-characteritics" style="flex: 0 0 16px;color: darkred;" data-html="true" title="{{localize 'CoC7.NpcRollCharacteristics'}}"> <i class="fas fa-dice"></i></a>
-						<a class="average-characteritics" style="flex: 0 0 16px;color: darkred;" title="{{localize 'CoC7.NpcAvarageCharacteristics'}}"> <i class="fas fa-balance-scale"></i></a>
-					{{/if}}
-				{{/if}}
-			{{else}}
-				<div style="flex: 0 0 16px;"></div>
-			{{/if}}
-			{{#if data.flags.locked}}
-				<a class="lock"  style="flex: 0 0 32px;align-content: flex-start;"  title="{{localize 'CoC7.UnlockActor'}}" data-locked="true"> <i class="fas fa-lock"></i></a>
-			{{else}}
-				<a class="lock"  style="flex: 0 0 16px;" title="{{localize 'CoC7.LockActor'}}" data-locked="false"> <i class="fas fa-lock-open"></i></a>
-				{{#if allowFormula}}
-					{{#if displayFormula}}
-						<a class="formula"  style="flex: 0 0 16px;" title="{{localize 'CoC7.NpcCharacteristicsFormula'}}" data-locked="true"> <i class="fas fa-square-root-alt"></i></a>
-					{{else}}
-						<a class="formula"  style="flex: 0 0 16px;" title="{{localize 'CoC7.NpcCharacteristicsValues'}}" data-locked="false"> <i class="fas fa-user-edit"></i></a>
-					{{/if}}
-				{{/if}}
-			{{/if}}
-		</div>
-	</div>
 
 
 	{{!-- Sheet Body --}}

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -188,62 +188,125 @@
 
 	{{!-- Sheet Body --}}
 	<section class="sheet-body">
+		<div class="tab">
 		
-		{{!-- Skills Tab --}}
-		<div class="section-header flexrow"> 
-			<h4 class="flex1" >{{localize 'CoC7.Skills'}}</h4>
-			{{#unless data.flags.locked}}
-				<div style="flex: 0 0 14px;">
-					<a class="add-item" title="{{localize 'CoC7.AddSkill'}}" data-type="skill"><i class="fas fa-plus-circle"></i></a>
-				</div>
-			{{/unless}}
-		</div>
-    	<div class="skills flexrow" style="padding-top: 1px;border-bottom: 2px groove;">
-			{{> "systems/CoC7/templates/actors/parts/npc-skills.html"}}
-		</div>
-		
-
-		<div class="section-header flexrow">
-			<h4 class="flex1">{{localize 'CoC7.Combat'}}</h4>
-			{{#unless data.flags.locked}}
-			<div style="flex: 0 0 14px;">
-				<a class="add-item" title="{{localize 'CoC7.AddWeapon'}}" data-type="weapon"><i class="fas fa-plus-circle"></i></a>
-			</div>
-			{{/unless}}
-		</div>
-		<div class="combat flexcol"  style="padding-top: 1px;border-bottom: 2px groove;">
-			{{> "systems/CoC7/templates/actors/parts/npc-combat.html"}}
-		</div>
-		
-		<div class="section-header flexrow"> 
-			<h4 class="flex1">{{localize 'CoC7.Possessions'}}</h4>
-			{{#unless data.flags.locked}}
-			<div style="flex: 0 0 14px;">
-				<a class="add-item" title="{{localize 'CoC7.AddItem'}}" data-type="item"><i class="fas fa-plus-circle"></i></a>
-			</div>
-			{{/unless}}
-		</div>
-		<div class="possession flexrow" style="padding-top: 1px;border-bottom: 2px groove;">
-				{{#each itemsByType.item as |item id|}}
-					<div class="item flexrow" style="flex: 0 0 33%;flex-wrap: wrap;border-right: 1px groove;" data-skill-id="{{item._id}}" data-item-id="{{item._id}}">
-						{{#if ../data.flags.locked}}
-							<h4 class="item-name" style="height:18px;padding: 1px 0 1px 2px;margin: 0;overflow: hidden;">{{item.name}}</h4>
-						{{else}}
-							<input class="item-name flex1" style="height: fit-content;padding: 0 2px;text-align: left;" type="text" name="item-name.{{id}}" value="{{item.name}}">
-							<div class="item-controls" style="height: 18px;">
-								<a class="item-control item-delete" title="{{localize 'CoC7.DeleteItem'}}"><i class="fas fa-trash"></i></a>
-								<a class="item-control item-edit" title="{{localize 'CoC7.EditItem'}}"><i class="fas fa-edit"></i></a>
-							</div>
-						{{/if}}
+		<section class="sheet-section">
+			<div class="section-header flexrow"   data-pannel="skills"> 
+				<h3 class="flex1" >{{localize 'CoC7.Skills'}}</h3>
+				{{#unless data.flags.locked}}
+					<div style="flex: 0 0 14px;">
+						<a class="add-item" title="{{localize 'CoC7.AddSkill'}}" data-type="skill"><i class="fas fa-plus-circle"></i></a>
 					</div>
-				{{/each}}
-		</div>
+				{{/unless}}
+			</div>
+			<div class="skills flexrow" style="padding-top: 1px;border-bottom: 2px groove;">
+				{{> "systems/CoC7/templates/actors/parts/npc-skills.html"}}
+			</div>
+		</section>
 
-		<div class="section-header flexrow" style="padding-top: 1px;border-bottom: 2px groove;">
-			<h4 class="flex1">{{localize 'CoC7.Notes'}} </h4>
-		</div>
-		<div class="background" style="display: flex;border: 2px groove #eeede0;padding: 0 5px;height: auto;">
-			{{editor content=data.biography.personalDescription.value target="data.biography.personalDescription.value" button=true owner=owner editable=editable}}
+		<section class="sheet-section">
+			<div class="section-header flexrow" data-pannel="combat">
+				<h3 class="flex1">{{localize 'CoC7.Combat'}}</h4>
+				{{#unless data.flags.locked}}
+				<div style="flex: 0 0 14px;">
+					<a class="add-item" title="{{localize 'CoC7.AddWeapon'}}" data-type="weapon"><i class="fas fa-plus-circle"></i></a>
+				</div>
+				{{/unless}}
+			</div>
+			<div class="combat flexcol"  style="padding-top: 1px;border-bottom: 2px groove;">
+				{{> "systems/CoC7/templates/actors/parts/npc-combat.html"}}
+			</div>
+		</section>
+		
+		{{#if hasInventory}}
+		<section class="sheet-section">
+			<div class="section-header flexrow" data-pannel="inventory"> 
+				<h3 class="flex1">{{localize 'CoC7.Inventory'}}</h3>
+				{{#unless data.flags.locked}}
+				<div style="flex: 0 0 14px;">
+					<a class="add-item" title="{{localize 'CoC7.AddItem'}}" data-type="item"><i class="fas fa-plus-circle"></i></a>
+				</div>
+				{{/unless}}
+			</div>
+			<div class="inventory flexrow" style="display: none;">
+				<ol class="inventory-list">
+					{{#if  itemsByType.item}}
+					<div class="inventory-section">
+						<li class="flexrow inventory-header">
+							<div class="item-name flexrow">
+								<h3>{{localize 'CoC7.Items'}}</h3>
+							</div>
+						</li>
+						<ol class="item-list">
+						{{#each itemsByType.item as |item id|}}
+							<li class="item flexrow" data-item-id="{{item._id}}">
+								<div class="item-image" style="background-image: url({{item.img}})"></div>
+								<h4 class="item-name show-detail">{{item.name}}</h4>
+								<div class="item-controls">
+									<a class="item-control item-edit" title="{{localize 'CoC7.EditItem'}}"><i class="fas fa-edit"></i></a>
+									<a class="item-control item-delete" title="{{localize 'CoC7.DeleteItem'}}"><i class="fas fa-trash"></i></a>
+								</div>
+							</li>
+						{{/each}}
+						</ol>
+					</div>
+					{{/if}}
+					{{#if  itemsByType.book}}
+					<div class="inventory-section">
+						<li class="flexrow inventory-header">
+							<div class="item-name flexrow">
+								<h3>{{localize 'CoC7.Books'}}</h3>
+							</div>
+						</li>
+						<ol class="item-list">
+						{{#each itemsByType.book as |item id|}}
+							<li class="item flexrow" data-item-id="{{item._id}}">
+								<div class="item-image" style="background-image: url({{item.img}})"></div>
+								<h4 class="item-name show-detail">{{item.name}}</h4>
+								<div class="item-controls">
+									<a class="item-control item-edit" title="{{localize 'CoC7.EditItem'}}"><i class="fas fa-edit"></i></a>
+									<a class="item-control item-delete" title="{{localize 'CoC7.DeleteItem'}}"><i class="fas fa-trash"></i></a>
+								</div>
+							</li>
+						{{/each}}
+						</ol>
+					</div>
+					{{/if}}
+					{{#if  itemsByType.spell}}
+					<div class="inventory-section">
+						<li class="flexrow inventory-header">
+							<div class="item-name flexrow">
+								<h3>{{localize 'CoC7.Spells'}}</h3>
+							</div>
+						</li>
+						<ol class="item-list">
+						{{#each itemsByType.spell as |item id|}}
+							<li class="item flexrow" data-item-id="{{item._id}}">
+								<div class="item-image" style="background-image: url({{item.img}})"></div>
+								<h4 class="item-name show-detail">{{item.name}}</h4>
+								<div class="item-controls">
+									<a class="item-control item-edit" title="{{localize 'CoC7.EditItem'}}"><i class="fas fa-edit"></i></a>
+									<a class="item-control item-delete" title="{{localize 'CoC7.DeleteItem'}}"><i class="fas fa-trash"></i></a>
+								</div>
+							</li>
+						{{/each}}
+						</ol>
+					</div>
+					{{/if}}
+				</ol>
+			</div>
+		</section>
+		{{/if}}
+
+
+		<section class="sheet-section">
+			<div class="section-header flexrow" data-pannel="description">
+				<h3 class="flex1">{{localize 'CoC7.Notes'}} </h3>
+			</div>
+			<div class="description" >
+				{{editor content=data.biography.personalDescription.value target="data.biography.personalDescription.value" style="height:95%" button=true owner=owner editable=editable}}
+			</div>
+		</section>
 		</div>
 	</section>
 </form>

--- a/templates/chat/combat/melee-initiator.html
+++ b/templates/chat/combat/melee-initiator.html
@@ -11,6 +11,7 @@
     data-disadvantage="{{disadvantage}}"
     data-target-card="{{targetCard}}"
     data-resolution-card="{{resolutionCard}}"
+    data-check-revealed="{{checkRevealed}}"
     data-is-blind="false">
     
     <div class="roll"></div>
@@ -90,31 +91,35 @@
     {{/unless}}
 
     {{#if rolled}}
-    <div class="dice-roll" style="padding-top: 5px;"
-        data-roll-type={{roll.rollType}}
-        data-side={{roll.side}}
-        data-action={{roll.action}}
-        data-ref-message-id={{roll.referenceMessageId}}
-        data-success-level={{roll.successLevel}}
-        data-difficulty={{roll.difficulty}}
-        data-actor-id={{roll.actorId}}
-        data-token-id={{roll.tokenId}}
-        data-actor-key={{roll.actorKey}}
-        data-skill-id={{roll.skillId}}
-        data-item-id={{roll.itemId}}
-        data-dice-mod={{roll.diceMod}}
-        data-value={{roll.value}}
-        data-result={{roll.result}}
-        data-fumble={{roll.fumble}}
-        data-critical={{roll.critical}}
-        data-characteristic={{roll.characteristic}}
+    <div class="dice-roll {{#unless checkRevealed}}gm-visible-only{{/unless}}" style="padding-top: 5px;"
+        data-roll-type="{{roll.rollType}}"
+        data-side="{{roll.side}}"
+        data-action="{{roll.action}}"
+        data-ref-message-id="{{roll.referenceMessageId}}"
+        data-success-level="{{roll.successLevel}}"
+        data-difficulty="{{roll.difficulty}}"
+        data-actor-id="{{roll.actorId}}"
+        data-token-id="{{roll.tokenId}}"
+        data-actor-key="{{roll.actorKey}}"
+        data-skill-id="{{roll.skillId}}"
+        data-item-id="{{roll.itemId}}"
+        data-dice-mod="{{roll.diceMod}}"
+        data-value="{{roll.value}}"
+        data-result="{{roll.result}}"
+        data-fumble="{{roll.fumble}}"
+        data-critical="{{roll.critical}}"
+        data-characteristic="{{roll.characteristic}}"
+        data-dice-modifier="{{check.diceModifier}}"
         data-is-blind="false"
         >
-		<div class="dice-result">
+
+        <div class="dice-result"
+            data-total="{{check.dices.total}}"
+            data-ten-result="{{check.dices.tenResult}}">
 			<!-- <div class="dice-formula">1D% {{#if check.dices.hasBonus}}{{check.dices.bonus}} {{check.dices.bonusType}} {{localize 'CoC7.Dice'}}{{/if}}</div> -->
 			<div class="dice-tooltip" style="display: none;">
 				<section class="tooltip-part">
-					<div class="dice">
+					<div class="dice ten-dice">
 						<span class="part-formula part-header flexrow">
 							{{#if check.dices.tenOnlyOneDie}}
 							{{localize 'CoC7.TensDie'}}
@@ -126,20 +131,25 @@
 						</span>
 						<ol class="dice-rolls">
 							{{#each check.dices.tens as |die key|}}
-								<li class="roll die d10 {{#unless die.selected}}discarded{{/unless}} {{#if die.isMax}}min{{/if}} {{#if die.isMin}}max{{/if}}">{{die.value}}</li>
+								<li
+                                    data-selected="{{#if die.selected}}true{{else}}false{{/if}}"
+                                    data-is-max="{{die.isMax}}"
+                                    data-is-min="{{die.isMin}}"
+                                    data-value="{{die.value}}"
+                                    class="roll die d10 {{#unless die.selected}}discarded{{/unless}} {{#if die.isMax}}min{{/if}} {{#if die.isMin}}max{{/if}}">{{die.value}}</li>
 							{{/each}}
 						</ol>
 					</div>
 				</section>
 				<section class="tooltip-part">
-					<div class="dice">
+					<div class="dice unit-die">
 						<span class="part-formula part-header flexrow">
                             {{localize 'CoC7.UnitsDie'}}
                             <div class="flex1"></div>
 							<span class="part-total flex0">{{check.dices.unit.value}}</span>
 						</span>
 						<ol class="dice-rolls">
-							<li class="roll die d10">{{check.dices.unit.value}}</li>
+							<li data-value="{{check.dices.unit.value}}"  class="roll die d10">{{check.dices.unit.value}}</li>
 						</ol>
 					</div>
 				</section>

--- a/templates/chat/combat/melee-resolution.html
+++ b/templates/chat/combat/melee-resolution.html
@@ -10,38 +10,32 @@
     data-resolved="{{resolved}}"
     data-is-blind="false"
 >
+
 <header class="card-header flexcol">
     {{#if winner}}
-    <div class="flexrow">
-        {{#if displayActorOnCard}}
-        <img class="open-actor" data-actor-key="{{winner.actorKey}}" style="flex: none;" src="{{winner.actorImg}}" title="{{winner.name}}" width="36" height="36"/>
-        {{/if}}
-        <img class="open-actor" data-actor-key="{{winner.actorKey}}" style="flex: none;" src="{{winner.item.img}}" title="{{winner.item.name}}" width="36" height="36"/>
-        <h3 style="text-align: center;font-weight: bolder;"class="item-name card-title">{{winner.item.name}}</h3>
-        {{#if looser}}
-        <img class="open-actor" style="flex: none;" data-actor-key="{{looser.actorKey}}" src="{{looser.actorImg}}" title="{{looser.name}}" width="36" height="36"/>
-        {{/if}}
-    </div>
-    
-    {{#unless rollDamage}}    
-    <div class="flexrow">
-        <h3 style="text-align: center;font-weight: bolder;"class="card-title">{{resultString}}</h3>
-    </div>
-    {{/unless}}
-
+        <div class="flexrow">
+            {{#if displayActorOnCard}}
+            <img class="open-actor" data-actor-key="{{winner.actorKey}}" style="flex: none;" src="{{winner.actorImg}}" title="{{winner.name}}" width="36" height="36"/>
+            {{/if}}
+            <img class="open-actor" data-actor-key="{{winner.actorKey}}" style="flex: none;" src="{{winnerImg}}" title="{{winnerTitle}}" width="36" height="36"/>
+            <h3 style="text-align: center;font-weight: bolder;"class="item-name card-title">{{winnerTitle}}</h3>
+            {{#if looser}}
+            <img class="open-actor" style="flex: none;" data-actor-key="{{looser.actorKey}}" src="{{looser.actorImg}}" title="{{looser.name}}" width="36" height="36"/>
+            {{/if}}
+        </div>
     {{else}}
-    <div class="flexrow">
-        <h3 style="text-align: center;font-weight: bolder;"class="card-title">{{resultString}}</h3>
-    </div>
+        <div class="flexrow">
+            <h3 style="text-align: center;font-weight: bolder;" class="card-title">{{resultString}}</h3>
+        </div>
     {{/if}}
 </header>
 
 {{#if rollDamage}}
 <div class="card details">
     {{#if looser}}
-        <h4>{{looser.name}} takes {{winner.weapon.data.data.range.normal.damage}}{{#if winner.weapon.data.data.properties.addb}}+DB{{/if}}{{#if winner.weapon.data.data.properties.ahdb}}+DB/2{{/if}} from {{winner.weapon.name}}</h4>
+        <h4 style="font-weight: bolder;">{{looser.name}} takes {{winner.weapon.data.data.range.normal.damage}}{{#if winner.weapon.data.data.properties.addb}}+DB{{/if}}{{#if winner.weapon.data.data.properties.ahdb}}+DB/2{{/if}} from {{winner.weapon.name}}</h4>
     {{else}}
-    <h4>{{winner.name}} deals {{winner.weapon.data.data.range.normal.damage}}{{#if winner.weapon.data.data.properties.addb}}+DB{{/if}}{{#if winner.weapon.data.data.properties.ahdb}}+DB/2{{/if}} with {{winner.weapon.name}}</h4>
+        <h4 style="font-weight: bolder;">{{winner.name}} deals {{winner.weapon.data.data.range.normal.damage}}{{#if winner.weapon.data.data.properties.addb}}+DB{{/if}}{{#if winner.weapon.data.data.properties.ahdb}}+DB/2{{/if}} with {{winner.weapon.name}}</h4>
     {{/if}}
 </div>
 <div class="card-buttons owner-only" data-actor-id="{{winner.actorKey}}" style="padding: 2px 0;margin: 0;">
@@ -53,6 +47,10 @@
       data-critical="{{winner.roll.criticalDamage}}">
         Roll damage
     </button>
+</div>
+{{else}}
+<div class="flexrow">
+    <h4 style="font-weight: bolder;">{{resultString}}</h4>
 </div>
 {{/if}}
 


### PR DESCRIPTION
* Inventory tab added to NPC and Creatures. Inventory can contains items, books and spells.
  * Items, book and spells can be dragged/dropped.
  * Any empty section will not be displayed.
  * Is empty the inventory will not be displayed.
* Close combat flow: if the target is a PC, only GM can see the initiator roll.
  * The PC has to choose to retaliate/dodge without knowing the outcome of the attack.
  * GM can see everything.
* Creature and NPC sheet design sliglty reworked.
* Japanese transalation updated thanks to AdmiralNyar.