### PR TITLE
Release/0.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Compendium 'Weapons' contains a single test weapon.
 version 0.3.5 :
 
 * Automatic damage.
-  * When a combat card is resolved an option will appear to automaticaly deal the damage to the target(s).
-  * When damage is dealt status (major wounds, dying, unconscious ...) will be triggered.
+  * When a combat card is resolved an option will appear to automatically deal the damage to the target(s).
+  * When damage is dealt status (major wounds, dying, unconscious...) will be triggered.
   * When receiving major wounds status a CON roll card will be triggered.
   * When dying, the only option for the player will be ti do a CON roll by clicking on the dice in the header of the sheet.
-  * On failling a dying CON check or receiving more damage than max HP a player will die.
+  * On failing a dying CON check or receiving more damage than max HP a player will die.
   * When dying or death, the actor portrait will be replaced by the dying/death icon.
   * Only the keeper can clear the dying/dead status by DOUBLE clicking on the portrait.
 * Ammunition/Uses per round.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ Compendium 'Weapons' contains a single test weapon.
 
 ## What is working
 
+version 0.3.5 :
+
+* Automatic damage.
+  * When a combat card is resolved an option will appear to automaticaly deal the damage to the target(s).
+  * When damage is dealt status (major wounds, dying, unconscious ...) will be triggered.
+  * When receiving major wounds status a CON roll card will be triggered.
+  * When dying, the only option for the player will be ti do a CON roll by clicking on the dice in the header of the sheet.
+  * On failling a dying CON check or receiving more damage than max HP a player will die.
+  * When dying or death, the actor portrait will be replaced by the dying/death icon.
+  * Only the keeper can clear the dying/dead status by DOUBLE clicking on the portrait.
+* Ammunition/Uses per round.
+  * Using a range weapon will now compare the number of bullet shot to the number of bullets available.
+  * Shots will be limited by the max uses/round of the weapon.
+
 version 0.3.4 :
 
 * Inventory tab added to NPC and Creatures. Inventory can contains items, books and spells.

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
 	"name": "CoC7",
 	"title": "The Call of Cthulhu 7th edition",
 	"description": "The Call of Cthulhu 7th edition simple game system",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"author": "HavelockV",
 	"minimumCoreVersion": "0.5.2",
 	"compatibleCoreVersion": "0.6.6",
@@ -72,6 +72,6 @@
 	"secondaryTokenAttribute": "power",
 	"url": "https://github.com/HavlockV/CoC7-FoundryVTT/",
 	"manifest": "https://github.com/HavlockV/CoC7-FoundryVTT/raw/master/system.json",
-	"download": "https://github.com/HavlockV/CoC7-FoundryVTT/archive/0.3.4.zip"
+	"download": "https://github.com/HavlockV/CoC7-FoundryVTT/archive/0.3.5.zip"
   }
   

--- a/templates/actors/parts/npc-combat.html
+++ b/templates/actors/parts/npc-combat.html
@@ -38,6 +38,13 @@
 								<a class="roll" data-mode="roll" title="{{weapon.data.range.normal.value}}" data-formula="{{weapon.data.range.normal.damage}}"><i class="fas fa-dice-d20"></i> {{weapon.data.range.normal.damage}}</a>
 							</div>
 							{{/if}}
+							<div class='flexrow' style='flex: 0 0 35px;'>
+								<span class="tag" style='line-height: 16px;font-size: 10px;'>{{weapon.data.ammo}}</span>
+								<div class='flexcol' style='font-size: 9px;'>
+									<i class="fas fa-redo-alt reload-weapon" title="Reload"></i>
+									<i class="far fa-plus-square add-ammo" title="Add 1 ammunition"></i>
+								</div>
+							</div>
 						{{else}}
 						<div class="flex1 weapon-damage"  data-range="normal">
 							<a class="roll" data-mode="roll" data-formula="{{weapon.data.range.normal.damage}}" title="{{weapon.data.range.normal.value}}"><i class="fas fa-dice-d20"></i> {{weapon.data.range.normal.damage}}</a>


### PR DESCRIPTION
* Automatic damage.
  * When a combat card is resolved an option will appear to automatically deal the damage to the target(s).
  * When damage is dealt status (major wounds, dying, unconscious...) will be triggered.
  * When receiving major wounds status a CON roll card will be triggered.
  * When dying, the only option for the player will be ti do a CON roll by clicking on the dice in the header of the sheet.
  * On failing a dying CON check or receiving more damage than max HP a player will die.
  * When dying or death, the actor portrait will be replaced by the dying/death icon.
  * Only the keeper can clear the dying/dead status by DOUBLE clicking on the portrait.
* Ammunition/Uses per round.
  * Using a range weapon will now compare the number of bullet shot to the number of bullets available.
  * Shots will be limited by the max uses/round of the weapon.