### PR TITLE
0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ version 0.3.6 :
   * Talents have no effect in play (e.g. the "Resilient" talent will NOT be taken in account for sanity loss, you'll have to do it "manually")
 * Two fields added to the character sheet for pulp heroes (Archetype and Organization).
   * To have those displayed, as well as the auto HP calculation you will have to enable the "Pulp Rules" option from the system's options.
+* Bug correction: Ammo loaded in weapons is now correctly saved between sessions.
+* Option added on the combat chat card to increase/decrease the volley size in full-auto mode.
 
 version 0.3.5 :
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ version 0.3.6 :
 * Two fields added to the character sheet for pulp heroes (Archetype and Organization).
   * To have those displayed, as well as the auto HP calculation you will have to enable the "Pulp Rules" option from the system's options.
 * Bug correction: Ammo loaded in weapons is now correctly saved between sessions.
-* Option added on the combat chat card to increase/decrease the volley size in full-auto mode.
+* On the combat chat card you can now increase/decrease the volley size in full-auto mode.
+* Added option to ignore bullets limitation.
+* Added option to ignore uses per round limitation.
 
 version 0.3.5 :
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Compendium 'Weapons' contains a single test weapon.
 
 ## What is working
 
+version 0.3.6 :
+
+* Addition of pulp talents (To be tested, I’m not familiar with Pulp Cthulhu, all of this is mainly cosmetic, no automation implemented so far)
+  * There's a new sheet for pulp talents.
+  * Talents can be dragged/dropped on actors (PC & NPC).
+  * Talents are displayed as a section of the "Gear&Cash" tab.
+  * Talents have no effect in play (e.g. the "Resilient" talent will NOT be taken in account for sanity loss, you'll have to do it "manually")
+* Two fields added to the character sheet for pulp heroes (Archetype and Organization).
+  * To have those displayed, as well as the auto HP calculation you will have to enable the "Pulp Rules" option from the system's options.
+
 version 0.3.5 :
 
 * Automatic damage.

--- a/coc7g.css
+++ b/coc7g.css
@@ -67,7 +67,8 @@
   flex: 4;
 }
 .coc7.sheet.book .sheet-header img.profile,
-.coc7.sheet.spell .sheet-header img.profile {
+.coc7.sheet.spell .sheet-header img.profile,
+.coc7.sheet.talent .sheet-header img.profile {
   border: 1px groove;
   flex: 0 0 64px;
   max-width: 64px;
@@ -77,74 +78,90 @@
   margin-right: 4px;
 }
 .coc7.sheet.book .sheet-header .name input,
-.coc7.sheet.spell .sheet-header .name input {
+.coc7.sheet.spell .sheet-header .name input,
+.coc7.sheet.talent .sheet-header .name input {
   margin: 0;
   padding: 0;
 }
 .coc7.sheet.book .details .editor,
-.coc7.sheet.spell .details .editor {
+.coc7.sheet.spell .details .editor,
+.coc7.sheet.talent .details .editor {
   height: 100px;
 }
 .coc7.sheet.book .details .editor button,
-.coc7.sheet.spell .details .editor button {
+.coc7.sheet.spell .details .editor button,
+.coc7.sheet.talent .details .editor button {
   height: 20px;
 }
 .coc7.sheet.book .details input[type="text"],
 .coc7.sheet.spell .details input[type="text"],
+.coc7.sheet.talent .details input[type="text"],
 .coc7.sheet.book .details select,
-.coc7.sheet.spell .details select {
+.coc7.sheet.spell .details select,
+.coc7.sheet.talent .details select {
   height: 20px;
   border: 1px solid #7a7971;
   background: rgba(0, 0, 0, 0.05);
 }
 .coc7.sheet.book .details .form-group,
-.coc7.sheet.spell .details .form-group {
+.coc7.sheet.spell .details .form-group,
+.coc7.sheet.talent .details .form-group {
   border: 0;
   margin: 0;
 }
 .coc7.sheet.book .details .form-group span,
-.coc7.sheet.spell .details .form-group span {
+.coc7.sheet.spell .details .form-group span,
+.coc7.sheet.talent .details .form-group span {
   text-align: center;
   line-height: 20px;
 }
 .coc7.sheet.book .details .form-group.input-select select,
-.coc7.sheet.spell .details .form-group.input-select select {
+.coc7.sheet.spell .details .form-group.input-select select,
+.coc7.sheet.talent .details .form-group.input-select select {
   flex: 1.8;
 }
 .coc7.sheet.book .details .form-group.input-select-select select,
-.coc7.sheet.spell .details .form-group.input-select-select select {
+.coc7.sheet.spell .details .form-group.input-select-select select,
+.coc7.sheet.talent .details .form-group.input-select-select select {
   flex: 1.5;
 }
 .coc7.sheet.book .details .form-group.uses-per input,
-.coc7.sheet.spell .details .form-group.uses-per input {
+.coc7.sheet.spell .details .form-group.uses-per input,
+.coc7.sheet.talent .details .form-group.uses-per input {
   flex: 1;
 }
 .coc7.sheet.book .details .form-group.uses-per span,
-.coc7.sheet.spell .details .form-group.uses-per span {
+.coc7.sheet.spell .details .form-group.uses-per span,
+.coc7.sheet.talent .details .form-group.uses-per span {
   flex: 0 0 16px;
 }
 .coc7.sheet.book .details .form-group.uses-per select,
-.coc7.sheet.spell .details .form-group.uses-per select {
+.coc7.sheet.spell .details .form-group.uses-per select,
+.coc7.sheet.talent .details .form-group.uses-per select {
   flex: 3;
 }
 .coc7.sheet.book .details span.sep,
-.coc7.sheet.spell .details span.sep {
+.coc7.sheet.spell .details span.sep,
+.coc7.sheet.talent .details span.sep {
   flex: 0 0 8px;
 }
 .coc7.sheet.book .details .prepared,
-.coc7.sheet.spell .details .prepared {
+.coc7.sheet.spell .details .prepared,
+.coc7.sheet.talent .details .prepared {
   flex: 1.3 !important;
   text-align: right;
   padding-right: 10px;
 }
 .coc7.sheet.book .details .spell-materials,
-.coc7.sheet.spell .details .spell-materials {
+.coc7.sheet.spell .details .spell-materials,
+.coc7.sheet.talent .details .spell-materials {
   flex: 0 0 100%;
   margin: 0.25em 0;
   justify-content: flex-end;
 }
 .coc7.sheet.book .details .spell-materials label,
-.coc7.sheet.spell .details .spell-materials label {
+.coc7.sheet.spell .details .spell-materials label,
+.coc7.sheet.talent .details .spell-materials label {
   flex: 0 0 64px;
   text-align: right;
   margin-right: 5px;
@@ -152,54 +169,65 @@
   line-height: 24px;
 }
 .coc7.sheet.book .details .spell-materials input[type="text"],
-.coc7.sheet.spell .details .spell-materials input[type="text"] {
+.coc7.sheet.spell .details .spell-materials input[type="text"],
+.coc7.sheet.talent .details .spell-materials input[type="text"] {
   flex: 0 0 48px;
   margin-right: 10px;
 }
 .coc7.sheet.book .sheet-navigation,
-.coc7.sheet.spell .sheet-navigation {
+.coc7.sheet.spell .sheet-navigation,
+.coc7.sheet.talent .sheet-navigation {
   margin-bottom: 5px;
 }
 .coc7.sheet.book .sheet-navigation .item,
-.coc7.sheet.spell .sheet-navigation .item {
+.coc7.sheet.spell .sheet-navigation .item,
+.coc7.sheet.talent .sheet-navigation .item {
   font-size: 18px;
 }
 .coc7.sheet.book .sheet-body,
-.coc7.sheet.spell .sheet-body {
+.coc7.sheet.spell .sheet-body,
+.coc7.sheet.talent .sheet-body {
   overflow: hidden;
 }
 .coc7.sheet.book .sheet-body .tab,
-.coc7.sheet.spell .sheet-body .tab {
+.coc7.sheet.spell .sheet-body .tab,
+.coc7.sheet.talent .sheet-body .tab {
   padding: 0 5px;
   overflow: hidden auto;
 }
 .coc7.sheet.book .sheet-body .item-properties,
-.coc7.sheet.spell .sheet-body .item-properties {
+.coc7.sheet.spell .sheet-body .item-properties,
+.coc7.sheet.talent .sheet-body .item-properties {
   flex: 0 0 120px;
   margin: 5px 5px 5px 0;
   padding-right: 5px;
   border-right: 2px groove #eeede0;
 }
 .coc7.sheet.book .sheet-body .item-properties .form-group,
-.coc7.sheet.spell .sheet-body .item-properties .form-group {
+.coc7.sheet.spell .sheet-body .item-properties .form-group,
+.coc7.sheet.talent .sheet-body .item-properties .form-group {
   margin: 0;
 }
 .coc7.sheet.book .sheet-body .item-properties .form-group label,
-.coc7.sheet.spell .sheet-body .item-properties .form-group label {
+.coc7.sheet.spell .sheet-body .item-properties .form-group label,
+.coc7.sheet.talent .sheet-body .item-properties .form-group label {
   line-height: 20px;
 }
 .coc7.sheet.book .sheet-body .item-properties .form-group input,
-.coc7.sheet.spell .sheet-body .item-properties .form-group input {
+.coc7.sheet.spell .sheet-body .item-properties .form-group input,
+.coc7.sheet.talent .sheet-body .item-properties .form-group input {
   text-align: right;
 }
 .coc7.sheet.book .sheet-body .item-properties .properties-list,
-.coc7.sheet.spell .sheet-body .item-properties .properties-list {
+.coc7.sheet.spell .sheet-body .item-properties .properties-list,
+.coc7.sheet.talent .sheet-body .item-properties .properties-list {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 .coc7.sheet.book .sheet-body .item-properties .properties-list li,
-.coc7.sheet.spell .sheet-body .item-properties .properties-list li {
+.coc7.sheet.spell .sheet-body .item-properties .properties-list li,
+.coc7.sheet.talent .sheet-body .item-properties .properties-list li {
   margin: 3px 0;
   padding: 0 2px;
   background: rgba(0, 0, 0, 0.05);
@@ -209,7 +237,8 @@
   line-height: 18px;
 }
 .coc7.sheet.book .sheet-body .spell-list,
-.coc7.sheet.spell .sheet-body .spell-list {
+.coc7.sheet.spell .sheet-body .spell-list,
+.coc7.sheet.talent .sheet-body .spell-list {
   list-style: none;
   margin: 0;
   padding: 0 5px;
@@ -217,47 +246,56 @@
   scrollbar-width: thin;
 }
 .coc7.sheet.book .sheet-body .spell-list .spell,
-.coc7.sheet.spell .sheet-body .spell-list .spell {
+.coc7.sheet.spell .sheet-body .spell-list .spell,
+.coc7.sheet.talent .sheet-body .spell-list .spell {
   line-height: 16px;
   padding: 0 2px;
   border-bottom: 1px solid #c9c7b8;
 }
 .coc7.sheet.book .sheet-body .spell-list .spell:last-child,
-.coc7.sheet.spell .sheet-body .spell-list .spell:last-child {
+.coc7.sheet.spell .sheet-body .spell-list .spell:last-child,
+.coc7.sheet.talent .sheet-body .spell-list .spell:last-child {
   border-bottom: none;
 }
 .coc7.sheet.book .sheet-body .spell-list .spell .spell-name,
-.coc7.sheet.spell .sheet-body .spell-list .spell .spell-name {
+.coc7.sheet.spell .sheet-body .spell-list .spell .spell-name,
+.coc7.sheet.talent .sheet-body .spell-list .spell .spell-name {
   cursor: pointer;
   max-height: 24px;
   overflow: hidden;
 }
 .coc7.sheet.book .sheet-body .spell-list .spell .spell-name .spell-image,
-.coc7.sheet.spell .sheet-body .spell-list .spell .spell-name .spell-image {
+.coc7.sheet.spell .sheet-body .spell-list .spell .spell-name .spell-image,
+.coc7.sheet.talent .sheet-body .spell-list .spell .spell-name .spell-image {
   flex: 0 0 16px;
   background-size: 16px;
   margin-right: 5px;
 }
 .coc7.sheet.book .sheet-body .spell-list .spell .spell-name h4,
-.coc7.sheet.spell .sheet-body .spell-list .spell .spell-name h4 {
+.coc7.sheet.spell .sheet-body .spell-list .spell .spell-name h4,
+.coc7.sheet.talent .sheet-body .spell-list .spell .spell-name h4 {
   margin: 0;
   white-space: nowrap;
   overflow-x: hidden;
 }
 .coc7.sheet.book .sheet-body .spell-list .spell .spell-name.rollable:hover .item-image,
-.coc7.sheet.spell .sheet-body .spell-list .spell .spell-name.rollable:hover .item-image {
+.coc7.sheet.spell .sheet-body .spell-list .spell .spell-name.rollable:hover .item-image,
+.coc7.sheet.talent .sheet-body .spell-list .spell .spell-name.rollable:hover .item-image {
   background-image: url("/icons/svg/d20-grey.svg") !important;
 }
 .coc7.sheet.book .sheet-body .spell-list .spell .spell-name.rollable .item-image:hover,
-.coc7.sheet.spell .sheet-body .spell-list .spell .spell-name.rollable .item-image:hover {
+.coc7.sheet.spell .sheet-body .spell-list .spell .spell-name.rollable .item-image:hover,
+.coc7.sheet.talent .sheet-body .spell-list .spell .spell-name.rollable .item-image:hover {
   background-image: url("/icons/svg/d20-black.svg") !important;
 }
 .coc7.sheet.book .sheet-body .spell-list .spell .spell-name i.attuned,
-.coc7.sheet.spell .sheet-body .spell-list .spell .spell-name i.attuned {
+.coc7.sheet.spell .sheet-body .spell-list .spell .spell-name i.attuned,
+.coc7.sheet.talent .sheet-body .spell-list .spell .spell-name i.attuned {
   color: #7a7971;
 }
 .coc7.sheet.book .sheet-body .spell-list .item-controls,
-.coc7.sheet.spell .sheet-body .spell-list .item-controls {
+.coc7.sheet.spell .sheet-body .spell-list .item-controls,
+.coc7.sheet.talent .sheet-body .spell-list .item-controls {
   flex: 0 0 32px;
   display: flex;
   flex-direction: row;
@@ -266,34 +304,41 @@
   justify-content: flex-end;
 }
 .coc7.sheet.book .sheet-body .spell-list .item-controls > *,
-.coc7.sheet.spell .sheet-body .spell-list .item-controls > * {
+.coc7.sheet.spell .sheet-body .spell-list .item-controls > *,
+.coc7.sheet.talent .sheet-body .spell-list .item-controls > * {
   flex: 1;
 }
 .coc7.sheet.book .sheet-body .spell-list .item-controls .flex1,
-.coc7.sheet.spell .sheet-body .spell-list .item-controls .flex1 {
+.coc7.sheet.spell .sheet-body .spell-list .item-controls .flex1,
+.coc7.sheet.talent .sheet-body .spell-list .item-controls .flex1 {
   flex: 1;
 }
 .coc7.sheet.book .sheet-body .spell-list .item-controls .flex2,
-.coc7.sheet.spell .sheet-body .spell-list .item-controls .flex2 {
+.coc7.sheet.spell .sheet-body .spell-list .item-controls .flex2,
+.coc7.sheet.talent .sheet-body .spell-list .item-controls .flex2 {
   flex: 2;
 }
 .coc7.sheet.book .sheet-body .spell-list .item-controls .flex3,
-.coc7.sheet.spell .sheet-body .spell-list .item-controls .flex3 {
+.coc7.sheet.spell .sheet-body .spell-list .item-controls .flex3,
+.coc7.sheet.talent .sheet-body .spell-list .item-controls .flex3 {
   flex: 3;
 }
 .coc7.sheet.book .sheet-body .spell-list .item-controls .flex4,
-.coc7.sheet.spell .sheet-body .spell-list .item-controls .flex4 {
+.coc7.sheet.spell .sheet-body .spell-list .item-controls .flex4,
+.coc7.sheet.talent .sheet-body .spell-list .item-controls .flex4 {
   flex: 4;
 }
 .coc7.sheet.book .sheet-body .spell-list .item-controls a,
-.coc7.sheet.spell .sheet-body .spell-list .item-controls a {
+.coc7.sheet.spell .sheet-body .spell-list .item-controls a,
+.coc7.sheet.talent .sheet-body .spell-list .item-controls a {
   flex: 0 0 16px;
   font-size: 10px;
   text-align: center;
   color: #7a7971;
 }
 .coc7.sheet.book .sheet-body .spell-list .item-summary,
-.coc7.sheet.spell .sheet-body .spell-list .item-summary {
+.coc7.sheet.spell .sheet-body .spell-list .item-summary,
+.coc7.sheet.talent .sheet-body .spell-list .item-summary {
   flex: 0 0 100%;
   font-size: 12px;
   line-height: 13px;

--- a/lang/en.json
+++ b/lang/en.json
@@ -19,11 +19,13 @@
 "CHARAC.Education": "Education",
 
 "CoC7.Name": "Name",
+"CoC7.Archetype": "Archetype",
 "CoC7.Occupation": "Occupation",
 "CoC7.Age": "Age",
 "CoC7.Sex": "Sex",
 "CoC7.Residence": "Residence",
 "CoC7.Birthplace": "Birthplace",
+"CoC7.Organization": "Organization",
 "CoC7.HitPoints": "Hit Points",
 "CoC7.HP": "HP",
 "CoC7.MagicPoints": "Magic Points",
@@ -306,6 +308,16 @@
 "CoC7.OccultBook": "Occult Tome",
 "CoC7.Unidentified": "Unidentified description",
 
+"CoC7.PulpTalents": "Pulp Talents",
+"CoC7.TalentType": "Talent Type",
+"CoC7.PhysicalTalent": "Physical",
+"CoC7.MentalTalent": "Mental",
+"CoC7.CombatTalent": "Combat",
+"CoC7.MiscellaneousTalent": "Miscellaneous",
+"CoC7.BasicTalent": "Basic",
+"CoC7.InsaneTalent": "Insane",
+"CoC7.OtherTalent": "Other",
+
 "CoC7.Items": "Items",
 "CoC7.Books": "Books",
 
@@ -326,6 +338,6 @@
 "SETTINGS.InitiativeRuleOptional": "Optional",
 "SETTINGS.displayInitDices": "Display init dice",
 "SETTINGS.displayInitDicesHint": "Display the dices when rolling for initiative (Optional rules only)",
-"SETTINGS.PulpRules" : "Use Pulp HP",
-"SETTINGS.PulpRulesHint" : "Use Pulp Rules for HP calculation"
+"SETTINGS.PulpRules" : "Pulp rules",
+"SETTINGS.PulpRulesHint" : "Alow the usage of Pulp Rules (Archetype, Talent, HP), !early implementation!"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -339,5 +339,9 @@
 "SETTINGS.displayInitDices": "Display init dice",
 "SETTINGS.displayInitDicesHint": "Display the dices when rolling for initiative (Optional rules only)",
 "SETTINGS.PulpRules" : "Pulp rules",
-"SETTINGS.PulpRulesHint" : "Alow the usage of Pulp Rules (Archetype, Talent, HP), !early implementation!"
+"SETTINGS.PulpRulesHint" : "Alow the usage of Pulp Rules (Archetype, Talent, HP), !early implementation!",
+"SETTINGS.DisregardAmmo": "Disregard Ammo count.",
+"SETTINGS.DisregardAmmoHint": "Enabling this will not take in account the number of bullets loaded in the gun.",
+"SETTINGS.DisregardUsePerRound": "Disregard Uses per Rounds.",
+"SETTINGS.DisregardUsePerRoundHint": "Enabling this will allow you to fire as much as you want, regardless of the uses per round of the weapon."
 }

--- a/less/book.less
+++ b/less/book.less
@@ -1,5 +1,6 @@
 .coc7.sheet.book,
-.coc7.sheet.spell {
+.coc7.sheet.spell,
+.coc7.sheet.talent {
 	.sheet-header {
 		img.profile {
 			border: 1px groove;

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -29,6 +29,8 @@ export class CoC7ActorSheet extends ActorSheet {
 		data.isDead = this.actor.dead;
 		data.isDying = this.actor.dying;
 
+		data.pulpCharacter = game.settings.get('CoC7', 'pulpRules');
+
 		if( data.items){
 			for (const item of data.items) {
 				//si c'est une formule et qu'on peut l'evaluer
@@ -579,7 +581,7 @@ export class CoC7ActorSheet extends ActorSheet {
 			summary.slideUp(200, () => summary.remove());
 		} else {
 			let div = $(`<div class="item-summary">${chatData.description.value}</div>`);
-			if( item.data.data.properties.spcl) {
+			if( item.data.data.properties?.spcl) {
 				let specialDiv = $(`<div class="item-summary">${chatData.description.special}</div>`);
 				div.append(specialDiv);
 			}

--- a/module/chat.js
+++ b/module/chat.js
@@ -43,6 +43,7 @@ export class CoC7Chat{
 		html.on('click', '.panel-switch', CoC7Chat._onChatCardToggleSwitch.bind(this));
 
 		html.on('click', '.simple-flag', CoC7Chat._onChatCardToggleSwitch.bind(this));
+		html.on('click', '.volley-size', CoC7Chat._onChatCardVolleySize.bind(this));
 
 		html.on('click', '.dropdown-element', CoC7Chat._onDropDownElementSelected.bind(this));
 		html.on('click', '.simple-toggle', CoC7Chat._onToggleSelected.bind(this));
@@ -652,6 +653,19 @@ export class CoC7Chat{
 			}
 		}
 		event.currentTarget.parentElement.dataset.selected = event.currentTarget.dataset.property;
+	}
+
+	static async _onChatCardVolleySize( event){
+		const card = event.currentTarget.closest('.chat-card');
+		
+		if( card.classList.contains( 'range')){
+			if( card.classList.contains('initiator')){
+				const rangeCard = CoC7RangeInitiator.getFromCard( card);
+				if( event.currentTarget.classList.contains('increase')) rangeCard.changeVolleySize( 1);
+				else if( event.currentTarget.classList.contains('decrease'))  rangeCard.changeVolleySize( -1);
+			}
+		}
+
 	}
 
 	static async _onChatCardToggleSwitch( event){

--- a/module/chat/rangecombat.js
+++ b/module/chat/rangecombat.js
@@ -201,6 +201,30 @@ export class CoC7RangeInitiator{
 		return false;
 	}
 
+	get volleySize(){
+		if( ! this.weapon.data.data.properties.auto) return 1;
+		if( this._volleySize) return this._volleySize;
+		const size = Math.floor(this.autoWeaponSkill.data.data.value/10);
+		return (size < 3) ? 3:size;
+	}
+
+	set volleySize(x){
+		if( x >= Math.floor(this.autoWeaponSkill.data.data.value/10)) this._volleySize = Math.floor(this.autoWeaponSkill.data.data.value/10);
+		else if ( x <= 3) this._volleySize = 3;
+		this._volleySize = parseInt(x);
+	}
+
+	get isVolleyMinSize(){
+		if( 3 == this.volleySize ) return true;
+		return false;
+	}
+
+	get isVolleyMaxSize(){
+		const maxSize = Math.floor(this.autoWeaponSkill.data.data.value/10) < 3 ? 3 : Math.floor(this.autoWeaponSkill.data.data.value/10);
+		if( maxSize == this.volleySize ) return true;
+		return false;
+	}
+
 	getTargetFromKey( key){
 		return this._targets.find( t => key === t.actorKey);
 	}
@@ -286,7 +310,7 @@ export class CoC7RangeInitiator{
 					shot.transit = true;
 				}
 			}
-			shot.bulletsShot = Math.floor(this.autoWeaponSkill.data.data.value/10);
+			shot.bulletsShot = this.volleySize;
 			if( shot.bulletsShot <= 3) shot.bulletsShot = 3;
 			if( shot.bulletsShot >= bulletLeft){
 				shot.bulletsShot = bulletLeft;
@@ -461,6 +485,12 @@ export class CoC7RangeInitiator{
 
 		return initiator;
 	}
+
+	
+	changeVolleySize( x){
+		this.volleySize = this.volleySize + x;
+		this.updateChatCard();
+	}
 	
 	static updateCardSwitch( event, publishUpdate = true){
 		const card = event.currentTarget.closest('.range.initiator');
@@ -556,13 +586,14 @@ export class CoC7RangeInitiator{
 		this.damage = [];
 		const hits=this.successfulHits;
 		
-		let volleySize = 1;
-		if( this.fullAuto) {
-			volleySize = Math.floor(this.autoWeaponSkill.data.data.value/10);
-			if(volleySize < 3) volleySize = 3;
-		}
-		if( this.burst) volleySize = parseInt(this.weapon.data.data.usesPerRound.burst);
+		// let volleySize = 1;
+		// if( this.fullAuto) {
+		// 	volleySize = this.volleySize;
+		// 	if(volleySize < 3) volleySize = 3;
+		// }
+		// if( this.burst) volleySize = parseInt(this.weapon.data.data.usesPerRound.burst);
 		hits.forEach( h => {
+			const volleySize = parseInt(h.shot.bulletsShot);
 			const damageRolls = [];
 			
 			const damageFormula = h.shot.damage;

--- a/module/chat/rangecombat.js
+++ b/module/chat/rangecombat.js
@@ -191,12 +191,22 @@ export class CoC7RangeInitiator{
 		return this.weapon.data.data.usesPerRound.max? parseInt( this.weapon.data.data.usesPerRound.max) : 1;
 	}
 
+	get ignoreAmmo(){
+		return game.settings.get('CoC7', 'disregardAmmo');
+	}
+
+	get ignoreUsesPerRound(){
+		return game.settings.get('CoC7', 'disregardUsePerRound');
+	}
+
 	get outOfAmmo(){
+		if( this.ignoreAmmo) return false;
 		if( this.totalBulletsFired >= this.weapon.getBulletLeft()) return true;
 		return false;
 	}
 
 	get outOfShots(){
+		if( this.ignoreUsesPerRound) return false;
 		if( this.shots) return this.shots.length >= this.maxShots;
 		return false;
 	}
@@ -302,7 +312,7 @@ export class CoC7RangeInitiator{
 				if( previousShot.actorKey != this.activeTarget.actorKey){
 					const distance = chatHelper.getDistance( chatHelper.getTokenFromKey(previousShot.actorKey), chatHelper.getTokenFromKey(this.activeTarget.actorKey));
 					shot.transitBullets = Math.floor( chatHelper.toYards(distance));
-					if( shot.transitBullets >= bulletLeft) {
+					if( shot.transitBullets >= bulletLeft && !this.ignoreAmmo) {
 						shot.transitBullets = bulletLeft;
 						bulletLeft = 0;
 					}
@@ -312,14 +322,14 @@ export class CoC7RangeInitiator{
 			}
 			shot.bulletsShot = this.volleySize;
 			if( shot.bulletsShot <= 3) shot.bulletsShot = 3;
-			if( shot.bulletsShot >= bulletLeft){
+			if( shot.bulletsShot >= bulletLeft && !this.ignoreAmmo){
 				shot.bulletsShot = bulletLeft;
 				bulletLeft = 0;
 			}
 		}
 		if( this.burst){
 			shot.bulletsShot = parseInt( this.weapon.data.data.usesPerRound.burst)? parseInt( this.weapon.data.data.usesPerRound.burst):1;
-			if( shot.bulletsShot >= bulletLeft){
+			if( shot.bulletsShot >= bulletLeft  && !this.ignoreAmmo){
 				shot.bulletsShot = bulletLeft;
 				bulletLeft = 0;
 			}

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -107,6 +107,24 @@ Hooks.once('init', async function() {
 		default: true,
 		type: Boolean
 	});
+		
+	game.settings.register('CoC7', 'disregardAmmo', {
+		name: 'SETTINGS.DisregardAmmo',
+		hint: 'SETTINGS.DisregardAmmoHint',
+		scope: 'world',
+		config: true,
+		default: false,
+		type: Boolean
+	});
+		
+	game.settings.register('CoC7', 'disregardUsePerRound', {
+		name: 'SETTINGS.DisregardUsePerRound',
+		hint: 'SETTINGS.DisregardUsePerRoundHint',
+		scope: 'world',
+		config: true,
+		default: false,
+		type: Boolean
+	});
 
 	function _setInitiativeOptions(rule)
 	{

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -17,6 +17,7 @@ import { CoC7Chat } from './chat.js';
 import { CoC7Combat, rollInitiative } from './combat.js';
 import { CoC7BookSheet } from './items/sheets/book.js';
 import { CoC7SpellSheet } from './items/sheets/spell.js';
+import { CoC7TalentSheet } from './items/sheets/talent.js';
 import { COC7 } from './config.js';
 // import { CoC7ActorSheet } from './actors/sheets/base.js';
 
@@ -133,10 +134,12 @@ Hooks.once('init', async function() {
 	Actors.registerSheet('CoC7', CoC7NPCSheet, { types: ['npc'] });
 	Actors.registerSheet('CoC7', CoC7CreatureSheet, { types: ['creature'] });
 	Actors.registerSheet('CoC7', CoC7CharacterSheet, { types: ['character'], makeDefault: true });
+	
 	Items.unregisterSheet('core', ItemSheet);
 	Items.registerSheet('CoC7', CoC7WeaponSheet, { types: ['weapon'], makeDefault: true});
 	Items.registerSheet('CoC7', CoC7BookSheet, { types: ['book'], makeDefault: true});
 	Items.registerSheet('CoC7', CoC7SpellSheet, { types: ['spell'], makeDefault: true});
+	Items.registerSheet('CoC7', CoC7TalentSheet, { types: ['talent'], makeDefault: true});
 	Items.registerSheet('CoC7', CoCItemSheet, { makeDefault: true});
 	preloadHandlebarsTemplates();
 });
@@ -145,7 +148,7 @@ Hooks.on('renderCombatTracker', (app, html, data) => CoC7Combat.renderCombatTrac
 Hooks.once('setup', function() {
 
 	// Localize CONFIG objects once up-front
-	const toLocalize = [ 'spellProperties', 'bookType'];
+	const toLocalize = [ 'spellProperties', 'bookType', 'talentType'];
 
 	for ( let o of toLocalize ) {
 		const localized = Object.entries(COC7[o]).map(e => {

--- a/module/config.js
+++ b/module/config.js
@@ -82,6 +82,16 @@ COC7.bookType = {
 	other: 'CoC7.Other'
 };
 
+COC7.talentType = {
+	physical: 'CoC7.PhysicalTalent',
+	mental: 'CoC7.MentalTalent',
+	combat: 'CoC7.CombatTalent',
+	miscellaneous: 'CoC7.MiscellaneousTalent',
+	basic: 'CoC7.BasicTalent',
+	insane: 'CoC7.InsaneTalent',
+	other: 'CoC7.OtherTalent'
+};
+
 COC7.formula = {};
 
 COC7.formula.actor = {

--- a/module/items/sheets/talent.js
+++ b/module/items/sheets/talent.js
@@ -1,0 +1,43 @@
+import  { COC7 } from '../../config.js';
+// import { CoCActor } from '../../actors/actor.js';
+
+/**
+ * Extend the basic ItemSheet with some very simple modifications
+ */
+export class CoC7TalentSheet extends ItemSheet {
+	/**
+	 * 
+	 */
+	static get defaultOptions() {
+		return mergeObject(super.defaultOptions, {
+			classes: ['coc7', 'sheet', 'talent'],
+			width: 520,
+			height: 480,
+			resizable: false,
+			scrollY: ['.tab.description'],
+			tabs: [{navSelector: '.sheet-navigation', contentSelector: '.sheet-body', initial: 'description'}]
+		});
+	}
+
+	/**
+	 * 
+	 */
+	get template() {
+		return 'systems/CoC7/templates/items/talent.html';
+	}
+
+	/* Prepare data for rendering the Item sheet
+	* The prepared data object contains both the actor data as well as additional sheet options
+	*/
+	getData() {
+		// this.item.checkSkillProperties();
+		const data = super.getData();
+
+		data.itemProperties = [];
+		
+		for (let [key, value] of Object.entries(data.data.type)) {
+			if( value) data.itemProperties.push( COC7.talentType[key]?COC7.talentType[key]:null);
+		}
+		return data;
+	}
+}

--- a/styles/coc7.css
+++ b/styles/coc7.css
@@ -650,7 +650,7 @@
 
 .coc7.sheet.actor .info-fields .form-group,
 .coc7.sheet.actor .info-fields .form-group-stacked {
-    margin: 0 0 1px 0;
+    margin: 0;
     justify-content: space-between;
 }
 

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
 	"name": "CoC7",
 	"title": "The Call of Cthulhu 7th edition",
 	"description": "The Call of Cthulhu 7th edition simple game system",
-	"version": "0.3.5",
+	"version": "0.3.6",
 	"author": "HavelockV",
 	"minimumCoreVersion": "0.5.2",
 	"compatibleCoreVersion": "0.6.6",
@@ -72,6 +72,6 @@
 	"secondaryTokenAttribute": "power",
 	"url": "https://github.com/HavlockV/CoC7-FoundryVTT/",
 	"manifest": "https://github.com/HavlockV/CoC7-FoundryVTT/raw/master/system.json",
-	"download": "https://github.com/HavlockV/CoC7-FoundryVTT/archive/0.3.5.zip"
+	"download": "https://github.com/HavlockV/CoC7-FoundryVTT/archive/0.3.6.zip"
   }
   

--- a/template.json
+++ b/template.json
@@ -277,6 +277,7 @@
                 "burst": null
             },
             "bullets": null,
+            "ammo": 0,
             "malfunction": null,
             "blastRadius": null,
             "properties": {},

--- a/template.json
+++ b/template.json
@@ -160,7 +160,9 @@
                 "age": "",
                 "sex": "",
                 "residence": "",
-                "birthplace": ""
+                "birthplace": "",
+                "archetype": "",
+                "organization": ""
             },
             "flags": {
                 "locked": true,
@@ -228,13 +230,7 @@
         }
     },
     "Item": {
-        "types": [
-            "item",
-            "weapon",
-            "skill",
-            "book",
-            "spell"
-        ],
+        "types": [ "item", "weapon", "skill", "book", "spell", "talent"],
         "item": {
             "description": "",
             "quantity": 1,
@@ -356,6 +352,22 @@
             "spells": [],
             "properties": {},
             "flags": {}
+        },
+        "talent":{
+            "source": null,
+            "description": {
+                "value": "",
+                "chat": "",
+                "notes": ""},
+            "type":{
+                "physical": false,
+                "mental": false,
+                "combat": false,
+                "miscellaneous": false,
+                "basic": false,
+                "insane": false,
+                "other": false
+            }
         }
 
     }

--- a/templates/actors/character-sheet.html
+++ b/templates/actors/character-sheet.html
@@ -8,6 +8,16 @@
 					<label style="width: fit-content; flex: unset; line-height: 18px;">{{ localize 'CoC7.Name' }} :</label>
 					<input name="name" type="text" value="{{actor.name}}" placeholder="{{ localize 'CoC7.Name' }}"/>
 				</div>
+				{{#if pulpCharacter}}
+				<div class="form-group">
+					<label>{{ localize 'CoC7.Archetype' }} :</label>
+					<input name="data.infos.archetype" type="text" value="{{data.infos.archetype}}"/>
+				</div>
+				<div class="form-group">
+					<label>{{ localize 'CoC7.Oragnization' }} :</label>
+					<input name="data.infos.organization" type="text" value="{{data.infos.organization}}"/>
+				</div>
+				{{/if}}
 				<div class="form-group">
 					<label>{{ localize 'CoC7.Occupation' }} :</label>
 					<input name="data.infos.occupation" type="text" value="{{data.infos.occupation}}"/>
@@ -240,6 +250,29 @@
 							{{/each}}
 							</ol>
 						</div>
+						{{#if pulpCharacter}}
+							{{#if  itemsByType.talent}}
+								<div class="inventory-section">
+									<li class="flexrow inventory-header">
+										<div class="item-name flexrow">
+											<h3>{{localize 'CoC7.PulpTalents'}}</h3>
+										</div>
+									</li>
+									<ol class="item-list">
+									{{#each itemsByType.talent as |item id|}}
+										<li class="item flexrow" data-item-id="{{item._id}}">
+											<div class="item-image" style="background-image: url({{item.img}})"></div>
+											<h4 class="item-name show-detail">{{item.name}}</h4>
+											<div class="item-controls">
+												<a class="item-control item-edit" title="{{localize 'CoC7.EditItem'}}"><i class="fas fa-edit"></i></a>
+												<a class="item-control item-delete" title="{{localize 'CoC7.DeleteItem'}}"><i class="fas fa-trash"></i></a>
+											</div>
+										</li>
+									{{/each}}
+									</ol>
+								</div>
+							{{/if}}
+						{{/if}}
 					</ol>
 				</div>
 				<div class="flexcol flex2 cash" style="border: 1px groove;">

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -12,6 +12,12 @@
 					<label>{{localize 'CoC7.Occupation'}}</label>
 					<input name="data.infos.occupation" type="text" value="{{data.infos.occupation}}"/>
 				</div>
+				{{#if pulpCharacter}}
+				<div class="flexrow flex2">
+					<label>{{localize 'CoC7.Organization'}}</label>
+					<input name="data.infos.organization" type="text" value="{{data.infos.organization}}"/>
+				</div>
+				{{/if}}
 				<div class="flexrow flex1">
 					<label>{{localize 'CoC7.Age'}}</label>
 					<input name="data.infos.age" type="text" value="{{data.infos.age}}"/>
@@ -360,6 +366,29 @@
 						{{/each}}
 						</ol>
 					</div>
+					{{/if}}
+					{{#if pulpCharacter}}
+						{{#if  itemsByType.talent}}
+							<div class="inventory-section">
+								<li class="flexrow inventory-header">
+									<div class="item-name flexrow">
+										<h3>{{localize 'CoC7.PulpTalents'}}</h3>
+									</div>
+								</li>
+								<ol class="item-list">
+								{{#each itemsByType.talent as |item id|}}
+									<li class="item flexrow" data-item-id="{{item._id}}">
+										<div class="item-image" style="background-image: url({{item.img}})"></div>
+										<h4 class="item-name show-detail">{{item.name}}</h4>
+										<div class="item-controls">
+											<a class="item-control item-edit" title="{{localize 'CoC7.EditItem'}}"><i class="fas fa-edit"></i></a>
+											<a class="item-control item-delete" title="{{localize 'CoC7.DeleteItem'}}"><i class="fas fa-trash"></i></a>
+										</div>
+									</li>
+								{{/each}}
+								</ol>
+							</div>
+						{{/if}}
 					{{/if}}
 				</ol>
 			</div>

--- a/templates/chat/combat/range-initiator.html
+++ b/templates/chat/combat/range-initiator.html
@@ -20,7 +20,8 @@
 	data-damage-dealt="{{damageDealt}}"
 	data-total-bullets-fired="{{totalBulletsFired}}"
 	data-roll-mode="{{rollMode}}"
-	data-is-blind="false">
+	data-is-blind="false"
+	data-volley-size="{{volleySize}}">
 	
 	<header class="card-header flexcol">
 		<div class="flexrow">
@@ -52,6 +53,9 @@
 		<div class='total-bullets'>
 			<span class='tag'>Bullets fired : {{totalBulletsFired}}/{{totalAmmo}}</span>
 			<span class='tag'>Shots fired : {{shotFired}}{{#unless fullAuto}}/{{maxShots}}{{/unless}}</span>
+			{{#if fullAuto}}
+				<span class='tag'>Volley size: {{#unless isVolleyMinSize}}<i class="volley-size decrease far fa-minus-square"></i> {{/unless}}{{volleySize}}{{#unless isVolleyMaxSize}} <i class="volley-size increase far fa-plus-square"></i>{{/unless}}</span>
+			{{/if}}
 		</div>
 		<div class="flexrow range-selection">
 			{{#if item.singleShot}}

--- a/templates/items/talent.html
+++ b/templates/items/talent.html
@@ -1,0 +1,80 @@
+<form class="{{cssClass}} flexcol" autocomplete="off">
+    <header class="sheet-header flexrow" style="flex: 0 0 64px;padding-bottom: 2px;">
+        <div class="header-details flexrow">
+            <h1 class="name" style="height: 48px;">
+                <input name="name" type="text" value="{{item.name}}" placeholder="{{ localize 'CoC7.Name' }}"/>
+            </h1>
+
+            <ul class="summary flexrow">
+                <li class="flex1">
+                    <input type="text" name="data.source" value="{{data.source}}" placeholder="{{ localize 'CoC7.Source' }}"/>
+                </li class="flex1">
+            </ul>
+
+        </div>
+        <img class="profile" src="{{item.img}}" data-edit="img" title="{{item.name}}" height="64" width="64"/>
+
+    </header>
+    {{!-- Item Sheet Navigation --}}
+    <nav style="flex: 0 0 24px;margin-bottom: 4px;font-family: 'Modesto Condensed', 'Palatino Linotype', serif;font-size: 16px;font-weight: 700;"
+      class="sheet-navigation tabs" data-group="primary">
+        <a style="line-height: 24px;" class="item active" data-tab="description">{{ localize "CoC7.ItemDescription" }}</a>
+        <a style="line-height: 24px;" class="item" data-tab="details">{{ localize "CoC7.Details" }}</a>
+    </nav>
+
+    
+    {{!-- Item Sheet Body --}}
+    <section class="sheet-body">
+
+        {{!-- Description Tab --}}
+        <div class="tab flexrow active" data-group="primary" data-tab="description">
+
+            <div class="item-properties">
+                <ol class="properties-list">
+                    {{#each itemProperties}}
+                    <li>{{this}}</li>
+                    {{/each}}
+                </ol>
+            </div>
+        
+            {{editor content=data.description.value target="data.description.value" button=true owner=owner editable=editable}}
+        </div>
+
+        {{!-- Details Tab --}}
+        <div class="tab details" data-group="primary" data-tab="details">
+
+            <h3 class="form-header">{{ localize "CoC7.Details" }}</h3>
+            {{!-- Talent Type --}}
+            <div class="spell-type form-group stacked">
+                <label>{{ localize "CoC7.TalentType" }}</label>
+                <div class="flexrow">
+                    <label class="checkbox">
+                        <input type="checkbox" name="data.type.physical" {{checked data.type.physical}}/> {{ localize "CoC7.PhysicalTalent" }}
+                    </label>
+                    <label class="checkbox">
+                        <input type="checkbox" name="data.type.mental" {{checked data.type.mental}}/> {{ localize "CoC7.MentalTalent" }}
+                    </label>
+                    <label class="checkbox">
+                        <input type="checkbox" name="data.type.combat" {{checked data.type.combat}}/> {{ localize "CoC7.CombatTalent" }}
+                    </label>
+                    <label class="checkbox">
+                        <input type="checkbox" name="data.type.miscellaneous" {{checked data.type.miscellaneous}}/> {{ localize "CoC7.MiscellaneousTalent" }}
+                    </label>
+                    <label class="checkbox">
+                        <input type="checkbox" name="data.type.basic" {{checked data.type.basic}}/> {{ localize "CoC7.BasicTalent" }}
+                    </label>
+                    <label class="checkbox">
+                        <input type="checkbox" name="data.type.insane" {{checked data.type.insane}}/> {{ localize "CoC7.InsaneTalent" }}
+                    </label>
+                    <label class="checkbox">
+                        <input type="checkbox" name="data.type.other" {{checked data.type.other}}/> {{ localize "CoC7.OtherTalent" }}
+                    </label>
+                </div>
+            </div>
+
+            <h3 class="form-header">{{ localize "CoC7.Notes"}}</h3>
+            {{editor content=data.description.notes target="data.description.notes" button=true owner=owner editable=editable}}
+        </div>
+    </section>
+
+</form>


### PR DESCRIPTION
* Addition of pulp talents (To be tested, I’m not familiar with Pulp Cthulhu, all of this is mainly cosmetic, no automation implemented so far)
  * There's a new sheet for pulp talents.
  * Talents can be dragged/dropped on actors (PC & NPC).
  * Talents are displayed as a section of the "Gear&Cash" tab.
  * Talents have no effect in play (e.g. the "Resilient" talent will NOT be taken in account for sanity loss, you'll have to do it "manually")
* Two fields added to the character sheet for pulp heroes (Archetype and Organization).
  * To have those displayed, as well as the auto HP calculation you will have to enable the "Pulp Rules" option from the system's options.
* Bug correction: Ammo loaded in weapons is now correctly saved between sessions.
* On the combat chat card you can now increase/decrease the volley size in full-auto mode.
* Added option to ignore bullets limitation.
* Added option to ignore uses per round limitation.