### PR TITLE
Bug/corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ version 0.3.7 :
 * On the range chat-card, the fast option is not default anymore.
   * When targeting a target with MOV of 8+, the fast option will not be selected by default. Instead, selecting fast for a target with MOV less than 8 will trigger a warning. You will still be able to select it.
 * Added distance to target on the range chat-card.
-  * Distance are calculated center of token to center of token. This may have an incidence on what the ruler display if for example your token is 2x2 on a square grid (in that case you can't put the ruler end on the center of the token).
+  * Distance are calculated center of token to center of token. This may have an incidence on what the ruler displays if, for example, your token is 2x2 on a square grid (in that case you can't put the ruler end on the center of the token).
   * You can now see the distance from the target below the target selector in the chat-card and on the tool-tip of the target.
 * Added an option to restrict measurement to grid space.
   * By default, for combat range calculation, the distance measured is the euclidean distance. To see that distance using the ruler you'll need to hold shift while measuring. An option is added to use grid spaces instead of euclidean distance. By selecting it, distance will be calculated as per the default ruler for that grid type (Grid less; Square, Hex...)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,15 @@ Compendium 'Weapons' contains a single test weapon.
 
 version 0.3.7 :
 
-* Bug correction typo on the character sheet.
+* Bug correction:
+  * Typo on the character sheet.
+  * Typo correction on the range chat-card.
+  * Typo correction malus->penalty.
+  * Calculation of bullets fired was wrongly deducted from the weapon magazine.
+* Added distance to target on the range chat-card.
+  * You can now see the distance from the taget below the target selector in the chat-card and on the tooltip of the target.
+* Added an option to restrict measurement to grid space.
+  * By default, for combat range calculation, the distance measured is the euclidean distance. To see that distance using the ruller you'll need to hold shift while measuring. An option is added to use grid spaces instead of euclidean distance. By selecting it, distance will be calculated as per the default ruler for that grid type (Grid less; Square, Hex...)
 
 version 0.3.6 :
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Compendium 'Weapons' contains a single test weapon.
 
 ## What is working
 
+version 0.3.7 :
+
+* Bug correction typo on the character sheet.
+
 version 0.3.6 :
 
 * Addition of pulp talents (To be tested, I’m not familiar with Pulp Cthulhu, all of this is mainly cosmetic, no automation implemented so far)

--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ version 0.3.7 :
   * Typo correction on the range chat-card.
   * Typo correction malus->penalty.
   * Calculation of bullets fired was wrongly deducted from the weapon magazine.
+* On the range chat-card, the fast option is not default anymore.
+  * When targeting a target with MOV of 8+, the fast option will not be selected by default. Instead, selecting fast for a target with MOV less thant 8 will trigger a warning. You will still be able to select it.
 * Added distance to target on the range chat-card.
   * You can now see the distance from the taget below the target selector in the chat-card and on the tooltip of the target.
 * Added an option to restrict measurement to grid space.
   * By default, for combat range calculation, the distance measured is the euclidean distance. To see that distance using the ruller you'll need to hold shift while measuring. An option is added to use grid spaces instead of euclidean distance. By selecting it, distance will be calculated as per the default ruler for that grid type (Grid less; Square, Hex...)
+* Spanish translation updated thanks to Lozalojo.
 
 version 0.3.6 :
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ version 0.3.7 :
   * Typo correction malus->penalty.
   * Calculation of bullets fired was wrongly deducted from the weapon magazine.
 * On the range chat-card, the fast option is not default anymore.
-  * When targeting a target with MOV of 8+, the fast option will not be selected by default. Instead, selecting fast for a target with MOV less thant 8 will trigger a warning. You will still be able to select it.
+  * When targeting a target with MOV of 8+, the fast option will not be selected by default. Instead, selecting fast for a target with MOV less than 8 will trigger a warning. You will still be able to select it.
 * Added distance to target on the range chat-card.
-  * You can now see the distance from the taget below the target selector in the chat-card and on the tooltip of the target.
+  * Distance are calculated center of token to center of token. This may have an incidence on what the ruler display if for example your token is 2x2 on a square grid (in that case you can't put the ruler end on the center of the token).
+  * You can now see the distance from the target below the target selector in the chat-card and on the tool-tip of the target.
 * Added an option to restrict measurement to grid space.
-  * By default, for combat range calculation, the distance measured is the euclidean distance. To see that distance using the ruller you'll need to hold shift while measuring. An option is added to use grid spaces instead of euclidean distance. By selecting it, distance will be calculated as per the default ruler for that grid type (Grid less; Square, Hex...)
+  * By default, for combat range calculation, the distance measured is the euclidean distance. To see that distance using the ruler you'll need to hold shift while measuring. An option is added to use grid spaces instead of euclidean distance. By selecting it, distance will be calculated as per the default ruler for that grid type (Grid less; Square, Hex...)
 * Spanish translation updated thanks to Lozalojo.
 
 version 0.3.6 :

--- a/lang/en.json
+++ b/lang/en.json
@@ -136,7 +136,7 @@
 "CoC7.Advantage": "Advantage",
 "CoC7.Disadvantage": "Disadvantage",
 "CoC7.TitleAdvantage": "Add 1 bonus die (target is prone, restrained...)",
-"CoC7.TitleDisadvantage": "Add 1 malus die (for being prone, restrained...)",
+"CoC7.TitleDisadvantage": "Add 1 panalty die (for being prone, restrained...)",
 "CoC7.TitleOutNumbered":"Add 1 bonus dice for outnumbered target",
 "CoC7.TitleSurprised": "Add 1 bonus dice for surprised target",
 "CoC7.TitleAutoSuccess": "Attack automaticaly hit",

--- a/lang/en.json
+++ b/lang/en.json
@@ -343,5 +343,7 @@
 "SETTINGS.DisregardAmmo": "Disregard Ammo count.",
 "SETTINGS.DisregardAmmoHint": "Enabling this will not take in account the number of bullets loaded in the gun.",
 "SETTINGS.DisregardUsePerRound": "Disregard Uses per Rounds.",
-"SETTINGS.DisregardUsePerRoundHint": "Enabling this will allow you to fire as much as you want, regardless of the uses per round of the weapon."
+"SETTINGS.DisregardUsePerRoundHint": "Enabling this will allow you to fire as much as you want, regardless of the uses per round of the weapon.",
+"SETTINGS.RestrictGridSpaces": "Restrict measurement to grid spaces",
+"SETTINGS.RestrictGridSpacesHint": "For range combat, if selected the distances will be mesured in grid spaces, if not the 'real' (euclidean) distance will be used."
 }

--- a/module/chat/helper.js
+++ b/module/chat/helper.js
@@ -104,10 +104,12 @@ export class chatHelper{
 
 	static getDistance( startToken, endToken){
 		const ray = new Ray( startToken.center, endToken.center);
+		const segment = [{ray}];
 		const distance = {
-			gridUnit: ray.distance/game.scenes.active.data.grid,
-			value: (ray.distance/game.scenes.active.data.grid)*game.scenes.active.data.gridDistance,
-			unit: game.scenes.active.data.gridUnits
+			gridUnit: ray.distance/canvas.scene.data.grid,
+			// value: (ray.distance/canvas.scene.data.grid)*canvas.scene.data.gridDistance,
+			value: canvas.grid.measureDistances(segment, {gridSpaces:game.settings.get('CoC7', 'gridSpaces')})[0],
+			unit: canvas.scene.data.gridUnits
 		};
 		return distance;
 	}

--- a/module/chat/rangecombat.js
+++ b/module/chat/rangecombat.js
@@ -413,8 +413,8 @@ export class CoC7RangeInitiator{
 			let weaponMalfunction = false;
 			let index = 0;
 			while( !weaponMalfunction && this.shots.length > index){
-				const roll = this.shootAtTarget(this.shots[index]);
-				await this.weapon.shootBullets( this.shots[index].bulletsShot + this.shots[index].transitBullets );
+				const roll = this.shootAtTarget( this.shots[index]);
+				await this.weapon.shootBullets( parseInt(this.shots[index].bulletsShot) + parseInt(this.shots[index].transitBullets));
 				if( roll.hasMalfunction){
 					roll.isSuccess = false;
 					weaponMalfunction = true;
@@ -770,8 +770,8 @@ export class CoC7RangeTarget{
 
 	get sizeText(){
 		if( this.big) return '1 bonus die for big target (Build > +4)';
-		if( this.small) return '1 malus die for a small target';
-		return 'Target has a normal size, no bonus/malus';
+		if( this.small) return '1 penalty die for a small target';
+		return 'Target has a normal size, no bonus/penalty';
 	}
 
 	get sizeLabel(){

--- a/module/chat/rangecombat.js
+++ b/module/chat/rangecombat.js
@@ -52,7 +52,8 @@ export class CoC7RangeInitiator{
 			this._targets.forEach( t =>{
 				if( t.token && this.token){
 					t.distance = chatHelper.getDistance( t.token, this.token);
-					const distInYd = chatHelper.toYards( t.distance);
+					t.distance.rounded = Math.round(t.distance.value * 100)/100;
+					const distInYd = Math.round(chatHelper.toYards( t.distance)* 100)/100;
 					if( distInYd){
 						if( this.actor){
 							t.pointBlankRange = false;
@@ -730,11 +731,17 @@ export class CoC7RangeTarget{
 		this._big = false;
 		this._small = false;
 	}
+
+	get isFast(){
+		if( this.actor && this.actor.mov) return this.actor.mov >= 8;
+		return false;
+	}
 	
 	get fast(){
 		if( undefined === this._fast){
-			if( this.actor && this.actor.mov) this._fast = this.actor.mov >= 8;
-			else this._fast = false;
+			// if( this.actor && this.actor.mov) this._fast = this.actor.mov >= 8;
+			// else this._fast = false;
+			this._fast = false;
 		} 
 		return this._fast;
 	}
@@ -835,5 +842,6 @@ export class CoC7RangeTarget{
 			else this.small = true;
 		}
 		else this[flag] = !this[flag];
+		if( 'fast' === flag && this.fast && !this.isFast) ui.notifications.warn( `Fast selected on a target with less than 8 MOV. (MOV: ${this.actor.mov})`);
 	}
 }

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -39,6 +39,14 @@ Hooks.once('init', async function() {
 	CONFIG.Item.entityClass = CoC7Item;
 	Combat.prototype.rollInitiative = rollInitiative;
 
+	game.settings.register('CoC7', 'gridSpaces', {
+		name: 'SETTINGS.RestrictGridSpaces',
+		hint: 'SETTINGS.RestrictGridSpacesHint',
+		scope: 'world',
+		config: true,
+		default: false,
+		type: Boolean
+	});	
 	
 	game.settings.register('CoC7', 'pulpRules', {
 		name: 'SETTINGS.PulpRules',

--- a/templates/chat/combat/melee-target.html
+++ b/templates/chat/combat/melee-target.html
@@ -71,7 +71,7 @@
             data-flag="advantage" 
             data-selected={{advantage}}>{{localize 'CoC7.Advantage'}}</span>
             <span class="flex1 toggle-switch disadvantage {{#unless rolled}}simple-flag{{/unless}} {{#if disadvantage}}switched-on{{/if}} gm-select-only"
-            title="Add 1 malus die (for being prone, restrained...)" 
+            title="Add 1 penalty die (for being prone, restrained...)" 
             style="text-align:center" 
             data-flag="disadvantage" 
             data-selected={{disadvantage}}>{{localize 'CoC7.Disadvantage'}}</span>

--- a/templates/chat/combat/range-initiator.html
+++ b/templates/chat/combat/range-initiator.html
@@ -114,9 +114,9 @@
 		{{#each targets as |trgt key|}}
 			<div class="target-selector" style="flex: none;" data-key="{{key}}">
 				{{#if trgt.active}}
-					<img class="open-actor" data-actor-key="{{trgt.actorKey}}" style="flex: none;" src="{{trgt.img}}" title="{{trgt.name}}" alt="{{trgt.name}}" width="24" height="24"/>
+					<img class="open-actor" data-actor-key="{{trgt.actorKey}}" style="flex: none;" src="{{trgt.img}}" title="{{trgt.name}}, {{trgt.distance.rounded}} {{trgt.distance.unit}}." alt="{{trgt.name}}" width="24" height="24"/>
 				{{else}}
-					<img class="open-actor" data-actor-key="{{trgt.actorKey}}" style="flex: none;border:none" src="{{trgt.img}}" title="{{trgt.name}}" alt="{{trgt.name}}" width="24" height="24"/>
+					<img class="open-actor" data-actor-key="{{trgt.actorKey}}" style="flex: none;border:none" src="{{trgt.img}}" title="{{trgt.name}}, {{trgt.distance.rounded}} {{trgt.distance.unit}}." alt="{{trgt.name}}" width="24" height="24"/>
 				{{/if}}
 			</div>
 		{{/each}}
@@ -143,7 +143,7 @@
 			data-is-blind="false"
 			{{#unless trgt.active}}style='display: none;'{{/unless}}>
 			<div class="target-name">
-				<label>Target : {{trgt.name}}</label>
+				<label>Target : {{trgt.name}} ({{trgt.distance.rounded}} {{trgt.distance.unit}})</label>
 			</div>
 
 			<div class='gm-visible-only' style="margin-bottom: 2px;">
@@ -345,7 +345,7 @@
 				  data-bullets-shot="{{shot.bulletsShot}}"
 				  data-transit-bullets="{{shot.transitBullets}}"
 				  data-transit="{{shot.transit}}">
-					({{key}})Shoot {{shot.bulletsShot}} {{#if shot.transit}}+ {{shot.transitBullets}}{{/if}} bullets at target {{shot.actorName}}.
+					({{key}})Shot {{shot.bulletsShot}} {{#if shot.transit}}+ {{shot.transitBullets}}{{/if}} bullets at target {{shot.actorName}}.
 				</div>
 			{{/each}}
 		</div>

--- a/templates/chat/combat/range-initiator.html
+++ b/templates/chat/combat/range-initiator.html
@@ -46,7 +46,7 @@
 				{{#if burst}}			<span class="tag" title="Bursts">{{localize 'CoC7.rangeCombatCard.Burst'}}</span>{{/if}}
 				{{#if fullAuto}}		<span class="tag" title="Full auto">{{localize 'CoC7.rangeCombatCard.FullAuto'}}</span> {{/if}}
 				{{#if advantage}}		<span class="tag" title="Add 1 bonus die (target is prone, restrained...)">{{localize 'CoC7.Advantage'}}</span>{{/if}}
-				{{#if disadvantage}}	<span class="tag" title="Add 1 malus die (for being prone, restrained...)">{{localize 'CoC7.Disadvantage'}}</span>{{/if}}
+				{{#if disadvantage}}	<span class="tag" title="Add 1 penalty die (for being prone, restrained...)">{{localize 'CoC7.Disadvantage'}}</span>{{/if}}
 				{{#if aimed}}			<span class="tag" title="Add 1 bonus die for the first shot">{{localize 'CoC7.rangeCombatCard.aiming'}}</span>{{/if}}
 			</div>
 		{{else}}
@@ -95,7 +95,7 @@
 			data-flag="advantage" 
 			data-selected={{advantage}}>{{localize 'CoC7.Advantage'}}</span>
 			<span class="flex1 toggle-switch disadvantage {{#unless rolled}}simple-flag{{/unless}} {{#if disadvantage}}switched-on{{/if}} gm-select-only"
-			title="Add 1 malus die (for being prone, restrained...)" 
+			title="Add 1 penalty die (for being prone, restrained...)" 
 			style="text-align:center" 
 			data-flag="disadvantage" 
 			data-selected={{disadvantage}}>{{localize 'CoC7.Disadvantage'}}</span>
@@ -161,7 +161,7 @@
 						title="{{localize 'CoC7.rangeCombatCard.OutOfRange'}}"
 						>{{localize 'CoC7.rangeCombatCard.OutOfRange'}}</span>
 					<span class="{{#if trgt.cover}}tag{{else}}invisible{{/if}}"
-						title="1 malus die. The target is under cover or successfully dived for cover" 
+						title="1 penalty die. The target is under cover or successfully dived for cover" 
 						>{{localize 'CoC7.rangeCombatCard.Cover'}}</span>
 					<span class="{{#if trgt.surprised}}tag{{else}}invisible{{/if}}"
 						title="1 bonus die for surprised target"
@@ -173,13 +173,13 @@
 						title="1 bonus die for big target (Build > +4)" 
 						>{{localize 'CoC7.rangeCombatCard.BigTarget'}}</span>
 					<span class="{{#if trgt.small}}tag{{else}}invisible{{/if}}"
-						title="1 malus die for a small target"
+						title="1 penalty die for a small target"
 						>{{localize 'CoC7.combatCard.SmallTarget'}}</span>
 					<span class="{{#if trgt.inMelee}}tag{{else}}invisible{{/if}}"
-						title="1 malus die. Target is engaged in melee combat"
+						title="1 penalty die. Target is engaged in melee combat"
 						>{{localize 'CoC7.rangeCombatCard.InMelee'}}</span>
 					<span class="{{#if trgt.fast}}tag{{else}}invisible{{/if}}"
-						title="1 malus dir. Target is fast (mov +8) and moving at full speed"
+						title="1 penalty dir. Target is fast (mov +8) and moving at full speed"
 						>{{localize 'CoC7.rangeCombatCard.FastMovingTarget'}}</span>
 				{{else}}
 					<div class="flexrow range-selection">
@@ -202,7 +202,7 @@
 
 					<div class="flexrow bonus-selection">
 						<span class="flex1 toggle-switch cover target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.cover}}switched-on{{/if}} gm-select-only"
-							title="1 malus die. The target is under cover or successfully dived for cover" 
+							title="1 penalty die. The target is under cover or successfully dived for cover" 
 							style="text-align:center" 
 							data-flag="cover" 
 							data-selected={{trgt.cover}}>{{localize 'CoC7.rangeCombatCard.Cover'}}</span>
@@ -230,12 +230,12 @@
 								{{trgt.sizeLabel}}
 							</span>
 						<span class="flex1 toggle-switch inMelee target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.inMelee}}switched-on{{/if}} gm-select-only"
-							title="1 malus die for a target engage in melee"
+							title="1 penalty die for a target engage in melee"
 							style="text-align:center"
 							data-flag="in-melee"
 							data-selected={{trgt.inMelee}}>{{localize 'CoC7.rangeCombatCard.InMelee'}}</span>
 						<span class="flex1 toggle-switch fast target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.fast}}switched-on{{/if}} gm-select-only"
-							title="1 malus dir. Target is fast (mov +8) and moving at full speed"
+							title="1 penalty dir. Target is fast (mov +8) and moving at full speed"
 							style="text-align:center"
 							data-flag="fast"
 							data-selected={{trgt.fast}}>{{localize 'CoC7.rangeCombatCard.FastMovingTarget'}}</span>
@@ -258,7 +258,7 @@
 						title="{{localize 'CoC7.rangeCombatCard.OutOfRange'}}"
 						>{{localize 'CoC7.rangeCombatCard.OutOfRange'}}</span>
 					<span class="{{#if trgt.cover}}tag{{else}}invisible{{/if}}"
-						title="1 malus die. The target is under cover or successfully dived for cover" 
+						title="1 penalty die. The target is under cover or successfully dived for cover" 
 						>{{localize 'CoC7.rangeCombatCard.Cover'}}</span>
 					<span class="{{#if trgt.surprised}}tag{{else}}invisible{{/if}}"
 						title="1 bonus die for surprised target"
@@ -270,13 +270,13 @@
 						title="1 bonus die for big target (Build > +4)" 
 						>{{localize 'CoC7.rangeCombatCard.BigTarget'}}</span>
 					<span class="{{#if trgt.small}}tag{{else}}invisible{{/if}}"
-						title="1 malus die for a small target"
+						title="1 penalty die for a small target"
 						>{{localize 'CoC7.combatCard.SmallTarget'}}</span>
 					<span class="{{#if trgt.inMelee}}tag{{else}}invisible{{/if}}"
-						title="1 malus die. Target is engaged in melee combat"
+						title="1 penalty die. Target is engaged in melee combat"
 						>{{localize 'CoC7.rangeCombatCard.InMelee'}}</span>
 					<span class="{{#if trgt.fast}}tag{{else}}invisible{{/if}}"
-						title="1 malus dir. Target is fast (mov +8) and moving at full speed"
+						title="1 penalty die. Target is fast (mov +8) and moving at full speed"
 						>{{localize 'CoC7.rangeCombatCard.FastMovingTarget'}}</span>
 				</div>
 			</div>


### PR DESCRIPTION
* Bug correction:
  * Typo on the character sheet.
  * Typo correction on the range chat-card.
  * Typo correction malus->penalty.
  * Calculation of bullets fired was wrongly deducted from the weapon magazine.
* On the range chat-card, the fast option is not default anymore.
  * When targeting a target with MOV of 8+, the fast option will not be selected by default. Instead, selecting fast for a target with MOV less than 8 will trigger a warning. You will still be able to select it.
* Added distance to target on the range chat-card.
  * Distance are calculated center of token to center of token. This may have an incidence on what the ruler displays if, for example, your token is 2x2 on a square grid (in that case you can't put the ruler end on the center of the token).
  * You can now see the distance from the target below the target selector in the chat-card and on the tool-tip of the target.
* Added an option to restrict measurement to grid space.
  * By default, for combat range calculation, the distance measured is the euclidean distance. To see that distance using the ruler you'll need to hold shift while measuring. An option is added to use grid spaces instead of euclidean distance. By selecting it, distance will be calculated as per the default ruler for that grid type (Grid less; Square, Hex...)
* Spanish translation updated thanks to Lozalojo.