### PR TITLE
Bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Compendium 'Roll Requests' contains numerous links for all your needs.
 
 ## What is working
 
+version 0.5.4 :
+
+* Bug correction:
+  * Changes from px to rem in some part of the sheet.
+  * #416 Damage bonus is now correctly applied.
+  * GM modified rolls are now properly set when revealed.
+  * when revealed, blind GM roll are shown to the player involved only, unless CTRL is pressed.
+* A toggle allowing character to gain XP is added on the keeper's tools.
+* An option is added to replace backstory entries with one big editor block with formatting and links support.
+
 version 0.5.3 :
 
 * Bug correction:

--- a/coc7g.css
+++ b/coc7g.css
@@ -1124,7 +1124,7 @@
 .coc7.sheet.actor .development.header {
   flex: initial;
   border-bottom: 1px groove;
-  line-height: 20px;
+  line-height: 1.25rem;
 }
 .coc7.sheet.actor .development.header .header-section {
   border-right: 1px groove;
@@ -1136,7 +1136,7 @@
   border-right: none;
 }
 .coc7.sheet.actor .development.header input {
-  width: 30px;
+  width: 1.875rem;
   padding: 0;
   margin: 0;
 }
@@ -1149,12 +1149,12 @@
   color: goldenrod;
 }
 .coc7.sheet.actor .development .item {
-  flex: 0 0 10px;
+  flex: 0 0 0.625rem;
 }
 .coc7.sheet.actor .development .item .skill-name {
   flex: 1;
-  font-size: 12px;
-  height: 16px;
+  font-size: 0.75rem;
+  height: 1rem;
   padding: 0;
   text-align: left;
 }
@@ -1162,9 +1162,9 @@
   cursor: pointer;
 }
 .coc7.sheet.actor .development .item .item-controls {
-  flex: 0 0 30px;
-  line-height: 16px;
-  font-size: 10px;
+  flex: 0 0 1.875rem;
+  line-height: 1rem;
+  font-size: 0.625rem;
   padding: 0 2px;
 }
 .coc7.sheet.actor .development .item .item-controls .item-control:hover {
@@ -1176,16 +1176,16 @@
 .coc7.sheet.actor .development .adjustment-value {
   border-right: groove 1px;
   flex: 0;
-  height: 16px;
-  line-height: 16px;
+  height: 1rem;
+  line-height: 1rem;
 }
 .coc7.sheet.actor .development .adjustment-value.not-available {
   background: white;
 }
 .coc7.sheet.actor .development .adjustment-value input {
-  font-size: 11px;
-  flex: 0 0 15px;
-  height: 16px;
+  font-size: 0.6875rem;
+  flex: 0 0 0.9375rem;
+  height: 1rem;
   padding: 0 1px;
   margin: 0;
   text-align: right;
@@ -1199,11 +1199,11 @@
 }
 .coc7.sheet.actor .sheet-section .editor {
   width: 100%;
-  height: 200px;
+  height: 12.5rem;
   border: 2px groove #eeede0;
   padding: 0;
   line-height: normal;
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 .coc7.sheet.actor .sheet-section .editor-content {
   overflow-x: hidden;
@@ -1214,7 +1214,7 @@
   background: rgba(0, 0, 0, 0.05);
   border: 2px groove #eeede0;
   font-weight: bold;
-  line-height: 15px;
+  line-height: 0.9375rem;
   height: 100%;
 }
 .coc7.sheet.actor input:read-only:hover,
@@ -1230,8 +1230,8 @@
 .coc7.sheet.actor .info-fields .form-group label {
   width: auto;
   flex: unset;
-  line-height: 18px;
-  height: 18px;
+  line-height: 1.125rem;
+  height: 1.125rem;
   border: 0;
   margin: 0;
   font-weight: bold;
@@ -1681,20 +1681,20 @@ html {
   margin: -1px;
   display: grid;
   grid-template-columns: auto;
-  grid-template-rows: 195px 30px auto;
+  grid-template-rows: 12.1875rem 1.875rem auto;
   width: 100%;
   height: 100%;
 }
 .sheetV2.character form .container .sheet-header {
   width: 100%;
-  height: 180px;
+  height: 11.25rem;
   border: 0;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 .sheetV2.character form .container .sheet-header .sheet-portrait {
-  width: 140px;
+  width: 8.75rem;
   height: 100%;
   padding: 0 0.5rem;
 }
@@ -1706,7 +1706,7 @@ html {
 }
 .sheetV2.character form .container .sheet-header .infos {
   display: inline-block;
-  width: 235px;
+  width: 14.6875rem;
   padding: 0 0.5rem;
   border-right: 2px solid;
   border-color: rgba(43, 55, 83, 0.5);
@@ -2152,8 +2152,8 @@ html {
   background-color: var(--main-sheet-front-color);
   border: 1px solid transparent;
   border-radius: 4px;
-  height: 22px;
-  line-height: 22px;
+  height: 1.375rem;
+  line-height: 1.375rem;
   padding: 0 8px;
   margin: 4px;
 }
@@ -2167,7 +2167,7 @@ html {
   color: white;
 }
 .combat-pane .section-header .add-item {
-  flex: 0 0 20px;
+  flex: 0 0 1.25rem;
   color: white;
 }
 .combat-pane .section-header .add-item:hover {
@@ -2180,15 +2180,15 @@ html {
 }
 .combat-pane .item-list .itemV2 {
   margin-right: 3px !important;
-  width: 160px !important;
+  width: 10rem !important;
 }
 .combat-pane .weapon-list .weapon-row {
   width: 100%;
   height: auto;
   display: grid;
   border-bottom: 1px solid;
-  grid-template-columns: 16px 22px 1fr 168px 44px 44px;
-  grid-template-rows: 22px 1fr;
+  grid-template-columns: 1rem 1.375rem 1fr 10.5rem 2.75rem 2.75rem;
+  grid-template-rows: 1.375rem 1fr;
   grid-template-areas: "expand image name range weaponControl itemControl" "details details details details details details";
 }
 .combat-pane .weapon-list .weapon-row .expand-arrow {
@@ -2204,25 +2204,25 @@ html {
   transition: transform 0.2s ease-out;
 }
 .combat-pane .weapon-list .weapon-row.expanded .expand-arrow {
-  transform: rotate(90deg) translate(6px, -4px);
+  transform: rotate(90deg) translate(0.375rem, -0.25rem);
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
 }
 .combat-pane .weapon-list .weapon-row .item-summary {
   background-color: rgba(255, 255, 255, 0.3);
   font-size: 0.75rem;
-  line-height: 14px;
+  line-height: 0.875rem;
   margin: 4px 0;
   border-radius: 4px;
 }
 .combat-pane .weapon-list .weapon-row .weapon-image {
   grid-area: image;
-  background-size: 22px;
+  background-size: 1.375rem;
 }
 .combat-pane .weapon-list .weapon-row .weapon-name {
   grid-area: name;
-  height: 22px;
-  line-height: 22px;
+  height: 1.375rem;
+  line-height: 1.375rem;
   padding: 0 4px;
 }
 .combat-pane .weapon-list .weapon-row .alternativ-skill {
@@ -2230,30 +2230,30 @@ html {
 }
 .combat-pane .weapon-list .weapon-row .weapon-range {
   grid-area: range;
-  height: 22px;
-  line-height: 22px;
+  height: 1.375rem;
+  line-height: 1.375rem;
   display: grid;
-  grid-template-columns: 56px 56px 56px;
-  grid-template-rows: 22px;
+  grid-template-columns: 3.5rem 3.5rem 3.5rem;
+  grid-template-rows: 1.375rem;
 }
 .combat-pane .weapon-list .weapon-row .weapon-range .weapon-damage {
   text-align: center;
 }
 .combat-pane .weapon-list .weapon-row .weapon-control {
   text-align: center;
-  line-height: 22px;
+  line-height: 1.375rem;
   grid-area: weaponControl;
 }
 .combat-pane .weapon-list .weapon-row .weapon-controls {
-  line-height: 22px;
+  line-height: 1.375rem;
   text-align: center;
   display: grid;
-  grid-template-columns: 22px 22px;
-  grid-template-rows: 22px;
+  grid-template-columns: 1.375rem 1.375rem;
+  grid-template-rows: 1.375rem;
   grid-area: weaponControl;
 }
 .combat-pane .weapon-list .weapon-row .item-controls {
-  line-height: 22px;
+  line-height: 1.375rem;
   display: block;
   text-align: end;
   grid-area: itemControl;
@@ -2281,8 +2281,8 @@ html {
   margin: 0 2px 2px 0;
 }
 .combat-pane .weapon-list .weapon-row .item-summary .item-labels .item-label span {
-  height: 16px;
-  line-height: 16px;
+  height: 1rem;
+  line-height: 1rem;
   padding: 0 3px;
 }
 .combat-pane .weapon-list .weapon-row .item-summary .item-properties {
@@ -2690,4 +2690,7 @@ html {
   border: 1px solid green !important;
   border-bottom: 1px solid #008060 !important;
   box-shadow: 0 0 10px #008060 !important;
+}
+#controls .scene-control.custom-control .control-tool.xp_toggle.active {
+  color: goldenrod;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -515,6 +515,9 @@
 "CoC7.CharCreationMode": "Character creation mode",
 "CoC7.CharCreationEnabled": "Character creation mode enabled",
 "CoC7.CharCreationDisabled": "Character creation mode disabled",
+"CoC7.toggleXP": "XP gain",
+"CoC7.XPGainEnabled": "Character can gain XP",
+"CoC7.XPGainDisabled": "Character cannot gain XP",
 "CoC7.WarnNoActorAvailable": "You do not have any actor controled nor selected",
 "CoC7.WarnMacroIncorrectType": "You can create macro for weapons and skills only",
 "CoC7.WarnNoGlobalSpec": "You can't create macro for unspecified specializations",
@@ -606,5 +609,7 @@
 "SETTINGS.SelfRollWhisperTargetHint": "As a GM, when doing self check roll, who do you want to send a notification to.",
 "SETTINGS.DoNotAdvise": "Keep it for yourself.",
 "SETTINGS.AdviseOwnersOnly": "Notify actor's owner",
-"SETTINGS.AdviseAllPlayer": "Notify all players"
+"SETTINGS.AdviseAllPlayer": "Notify all players",
+"SETTINGS.OneBlockBackStory": "One block backstory",
+"SETTINGS.OneBlockBackStoryHint": "Turn backstory to one editor block, but you can format/add links."
 }

--- a/less/actor.less
+++ b/less/actor.less
@@ -10,7 +10,7 @@
 		&.header{
 			flex: initial;
 			border-bottom: 1px groove;
-			line-height: 20px;
+			line-height: 1.25rem;
 
 			.header-section{
 				border-right: 1px groove;
@@ -21,7 +21,7 @@
 			}
 
 			input {
-				width: 30px;
+				width: 1.875rem;
 				padding: 0;
 				margin: 0;
 			}
@@ -38,12 +38,12 @@
 		}
 
 		.item {
-			flex: 0 0 10px;
+			flex: 0 0 0.625rem;
 
 			.skill-name{ 
 				flex: 1;
-				font-size: 12px;
-				height: 16px;
+				font-size: 0.75rem;
+				height: 1rem;
 				padding: 0;
 				text-align: left;
 				
@@ -55,9 +55,9 @@
 			}
 
 			.item-controls{
-				flex: 0 0 30px;
-				line-height: 16px;
-				font-size: 10px;
+				flex: 0 0 1.875rem;
+				line-height: 1rem;
+				font-size: 0.625rem;
 				padding: 0 2px;
 
 				.item-control{
@@ -82,13 +82,13 @@
 
 			border-right: groove 1px;
 			flex: 0;
-			height: 16px;
-			line-height: 16px;
+			height: 1rem;
+			line-height: 1rem;
 
 			input {
-				font-size: 11px;
-				flex: 0 0 15px;
-				height: 16px;
+				font-size: 0.6875rem;
+				flex: 0 0 0.9375rem;
+				height: 1rem;
 				padding: 0 1px;
 				margin: 0;
 				text-align: right;
@@ -108,11 +108,11 @@
 
 		.editor{
 			width: 100%;
-			height: 200px;
+			height: 12.5rem;
 			border: 2px groove #eeede0;
 			padding: 0;
 			line-height: normal;
-    		font-size: 12px;
+    		font-size: 0.75rem;
 		}
 
 		.editor-content{
@@ -125,7 +125,7 @@
 			background: rgba(0, 0, 0, 0.05);
 			border: 2px groove #eeede0;
 			font-weight: bold;
-			line-height: 15px;
+			line-height: 0.9375rem;
 			height: 100%;
 		}
 	}
@@ -147,8 +147,8 @@
 			label{
 				width: auto;
 				flex: unset;
-				line-height: 18px;
-				height: 18px;
+				line-height: 1.125rem;
+				height: 1.125rem;
 				border: 0;
 				margin: 0;
 				font-weight: bold;

--- a/less/sheets/character.less
+++ b/less/sheets/character.less
@@ -31,20 +31,20 @@
 				margin: -1px;
 				display: grid;
 				grid-template-columns: auto;
-				grid-template-rows: 195px 30px auto;
+				grid-template-rows: 12.1875rem 1.875rem auto;
 				width: 100%;
 				height: 100%;
 
 				.sheet-header{
 					width: 100%;
-					height: 180px;
+					height: 11.25rem;
 					border: 0;
 					display: flex;
 					align-items: center;
 					justify-content: center;
 
 					.sheet-portrait{
-						width: 140px;
+						width: 8.75rem;
 						height: 100%;
 						padding: 0 0.5rem;
 
@@ -58,7 +58,7 @@
 
 					.infos{
 						display: inline-block;
-						width: 235px;
+						width: 14.6875rem;
 						padding: 0 0.5rem;
 						border-right: 2px solid;
 						border-color: @borderColorBlue;

--- a/less/sheets/combat.less
+++ b/less/sheets/combat.less
@@ -13,8 +13,8 @@
         background-color: var(--main-sheet-front-color);
         border: 1px solid transparent;
         border-radius: 4px;
-        height: 22px;
-        line-height: 22px;
+        height: 1.375rem;
+        line-height: 1.375rem;
         padding: 0 8px;
         margin: 4px;
 
@@ -30,7 +30,7 @@
         }
 
         .add-item{
-            flex: 0 0 20px;
+            flex: 0 0 1.25rem;
             color: white;
 
             &:hover{
@@ -42,7 +42,7 @@
     .item-list{
         .itemV2{
             margin-right: 3px !important;
-            width: 160px !important;
+            width: 10rem !important;
         }
 
         display: flex !important;
@@ -57,8 +57,8 @@
             height: auto;
             display: grid;
             border-bottom: 1px solid;
-            grid-template-columns: 16px 22px 1fr 168px 44px 44px;
-            grid-template-rows: 22px 1fr;
+            grid-template-columns: 1rem 1.375rem 1fr 10.5rem 2.75rem 2.75rem;
+            grid-template-rows: 1.375rem 1fr;
             grid-template-areas: "expand image name range weaponControl itemControl"
                                 "details details details details details details";
             
@@ -76,7 +76,7 @@
             }
 
             &.expanded .expand-arrow{
-                transform: rotate(90deg) translate(6px, -4px);
+                transform: rotate(90deg) translate(0.375rem, -0.25rem);
                 border-bottom-right-radius: 0;
                 border-bottom-left-radius: 0;
             }
@@ -84,20 +84,20 @@
             .item-summary{
                 background-color: rgba(255, 255, 255, 0.3);
                 font-size: 0.75rem;
-                line-height: 14px;
+                line-height: 0.875rem;
                 margin: 4px 0;
                 border-radius: 4px;
             }
 
             .weapon-image{
                 grid-area: image;
-                background-size: 22px;
+                background-size: 1.375rem;
             }
 
             .weapon-name{
                 grid-area: name;
-                height: 22px;
-                line-height: 22px;
+                height: 1.375rem;
+                line-height: 1.375rem;
                 padding: 0 4px;
             }
 
@@ -107,11 +107,11 @@
 
             .weapon-range{
                 grid-area: range;
-                height: 22px;
-                line-height: 22px;
+                height: 1.375rem;
+                line-height: 1.375rem;
                 display: grid;
-                grid-template-columns: 56px 56px 56px;
-                grid-template-rows: 22px;
+                grid-template-columns: 3.5rem 3.5rem 3.5rem;
+                grid-template-rows: 1.375rem;
                 
                 .weapon-damage{
                     text-align: center;
@@ -120,21 +120,21 @@
 
             .weapon-control{
                 text-align: center;
-                line-height: 22px;
+                line-height: 1.375rem;
                 grid-area: weaponControl;
             }
 
             .weapon-controls{
-                line-height: 22px;
+                line-height: 1.375rem;
                 text-align: center;
                 display: grid;
-                grid-template-columns: 22px 22px;
-                grid-template-rows: 22px;
+                grid-template-columns: 1.375rem 1.375rem;
+                grid-template-rows: 1.375rem;
                 grid-area: weaponControl;
             }
 
             .item-controls{
-                line-height: 22px;
+                line-height: 1.375rem;
                 display: block;
                 text-align: end;
                 grid-area: itemControl;
@@ -163,8 +163,8 @@
                         margin: 0 2px 2px 0;
 
                         span{
-                            height: 16px;
-                            line-height: 16px;
+                            height: 1rem;
+                            line-height: 1rem;
                             padding: 0 3px;
                         }
                     }

--- a/less/ui/controls.less
+++ b/less/ui/controls.less
@@ -7,5 +7,13 @@
             border-bottom: 1px solid #008060 !important;
             box-shadow: 0 0 10px #008060 !important;
         }
+
+        .control-tool{
+            &.xp_toggle{
+                &.active{
+                    color: goldenrod;
+                }
+            }
+        }
     }
 }

--- a/module/actors/sheets/actor-sheet.js
+++ b/module/actors/sheets/actor-sheet.js
@@ -61,6 +61,8 @@ export class CoC7CharacterSheet extends CoC7ActorSheet {
 			data.credit.assets = `${this.actor.assets*factor}${moneySymbol}`;
 			data.credit.cash = `${this.actor.cash*factor}${moneySymbol}`;
 		}
+		
+		data.oneBlockBackStory = game.settings.get( 'CoC7', 'oneBlockBackstory');
 
 		return data;
 	}

--- a/module/chat/cards/damage.js
+++ b/module/chat/cards/damage.js
@@ -147,7 +147,13 @@ export class DamageCard extends InteractiveChatCard{
 
 	get damageFormula(){
 		const range = this.range;
-		const formula = this.weapon?.data?.data?.range[range]?.damage;
+		let formula = this.weapon?.data?.data?.range[range]?.damage;
+		let db = `${this.actor.db}`;
+
+		if( db && !db.startsWith( '-')) db = '+' + db;
+		if( this.weapon.data.data.properties.addb) formula = formula + db;
+		if( this.weapon.data.data.properties.ahdb) formula = formula + db + '/2';
+
 		if( formula){
 			const maxDamage = Roll.maximize( formula)._total;
 			let rollString;

--- a/module/check.js
+++ b/module/check.js
@@ -867,6 +867,7 @@ export class CoC7Check {
 		this.dices.tens =[];
 		this.dices.unit.value = unitTotal;
 		this.modifiedResult = total;
+		this.dices.total = total;
 		this.dices.tenResult = total - unitTotal;
 
 		let max = (unitTotal == 0)? 100 : 90;

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -82,6 +82,14 @@ Hooks.once('init', async function() {
 		default: 0
 	});
 
+	game.settings.register('CoC7', 'xpEnabled', {
+		name: 'Enable XP gain',
+		scope: 'world',
+		config: false,
+		type: Boolean,
+		default: true
+	});
+
 	game.settings.register('CoC7', 'gridSpaces', {
 		name: 'SETTINGS.RestrictGridSpaces',
 		hint: 'SETTINGS.RestrictGridSpacesHint',
@@ -94,6 +102,15 @@ Hooks.once('init', async function() {
 	game.settings.register('CoC7', 'pulpRules', {
 		name: 'SETTINGS.PulpRules',
 		hint: 'SETTINGS.PulpRulesHint',
+		scope: 'world',
+		config: true,
+		default: false,
+		type: Boolean
+	});
+
+	game.settings.register('CoC7', 'oneBlockBackstory', {
+		name: 'SETTINGS.OneBlockBackStory',
+		hint: 'SETTINGS.OneBlockBackStoryHint',
 		scope: 'world',
 		config: true,
 		default: false,

--- a/module/items/item.js
+++ b/module/items/item.js
@@ -266,17 +266,21 @@ export class CoC7Item extends Item {
 	}
 
 	async flagForDevelopement(){
-		if( !this.data.data.flags){
-			await this.update( { 'data.flags': {}});
+		if( game.settings.get('CoC7', 'xpEnabled') || game.user.isGM){
+			if( !this.data.data.flags){
+				await this.update( { 'data.flags': {}});
+			}
+			await this.update( {'data.flags.developement' : true});
 		}
-		await this.update( {'data.flags.developement' : true});
 	}
 
 	async unflagForDevelopement(){
-		if( !this.data.data.flags){
-			await this.update( { 'data.flags': {}});
+		if( game.settings.get('CoC7', 'xpEnabled') || game.user.isGM){
+			if( !this.data.data.flags){
+				await this.update( { 'data.flags': {}});
+			}
+			await this.update( {'data.flags.developement' : false});
 		}
-		await this.update( {'data.flags.developement' : false});
 	}
 
 
@@ -291,6 +295,11 @@ export class CoC7Item extends Item {
 			await this.update( { 
 				[`data.adjustments.${flagName}`] : null,
 				[name]: flagValue});
+		} else if( 'developement' == flagName){
+			if( game.settings.get('CoC7', 'xpEnabled') || game.user.isGM)
+				await this.update( { [name]: flagValue});
+			else
+				ui.notifications.info('XP Gain disabled.');
 		} else await this.update( { [name]: flagValue});
 	}
 

--- a/module/menu.js
+++ b/module/menu.js
@@ -113,7 +113,8 @@ export class CoC7Menu {
 				let active = isActive && ((s.activeTool === t.name) || (t.toggle && t.active));
 				t.css = [
 					t.toggle ? 'toggle' : null,
-					active ? 'active' : null
+					active ? 'active' : null,
+					t.class ? t.class : null
 				].filter(t => !!t).join(' ');
 				return t;
 			});
@@ -152,6 +153,15 @@ export class CoC7Menu {
 					active: game.settings.get('CoC7', 'charCreationEnabled'), 
 					title: 'CoC7.CharCreationMode',
 					onClick :async () => await CoC7Utilities.toggleCharCreation()
+				},
+				{
+					toggle: true,
+					icon : 'fas fa-certificate',
+					class: 'xp_toggle',
+					name: 'xptoggle',
+					active: game.settings.get('CoC7', 'xpEnabled'), 
+					title: 'CoC7.toggleXP',
+					onClick :async () => await CoC7Utilities.toggleXPGain()
 				},
 				{
 					button: true,

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -339,6 +339,16 @@ export class CoC7Utilities {
 		CoC7Utilities.updateCharSheets();
 	}
 
+	static async toggleXPGain(){
+		const isXPEnabled = game.settings.get('CoC7', 'xpEnabled');
+		await game.settings.set( 'CoC7', 'xpEnabled', !isXPEnabled);
+		let group = game.CoC7.menus.controls.find(b => b.name == 'main-menu');
+		let tool = group.tools.find( t => t.name == 'xptoggle');
+		tool.title = game.settings.get('CoC7', 'xpEnabled')? game.i18n.localize( 'CoC7.XPGainEnabled'): game.i18n.localize( 'CoC7.XPGainDisabled');
+		ui.notifications.info( game.settings.get('CoC7', 'xpEnabled')? game.i18n.localize( 'CoC7.XPGainEnabled'): game.i18n.localize( 'CoC7.XPGainDisabled'));
+		ui.controls.render();
+	}
+
 	static async rollDice( event, options ={}){
 
 		options.askValue = !options.threshold;

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
 	"name": "CoC7",
 	"title": "Call of Cthulhu 7th edition (Unofficial)",
 	"description": "Call of Cthulhu 7th edition (Unofficial) for FoundryVTT",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"author": "HavelockV",
 	"minimumCoreVersion": "0.7.0",
 	"compatibleCoreVersion": "0.7.9",
@@ -106,6 +106,6 @@
 	"secondaryTokenAttribute": "power",
 	"url": "https://github.com/HavlockV/CoC7-FoundryVTT/",
 	"manifest": "https://github.com/HavlockV/CoC7-FoundryVTT/raw/master/system.json",
-	"download": "https://github.com/HavlockV/CoC7-FoundryVTT/archive/0.5.3.zip"
+	"download": "https://github.com/HavlockV/CoC7-FoundryVTT/archive/0.5.4.zip"
 }
   

--- a/template.json
+++ b/template.json
@@ -3,7 +3,8 @@
         "types": [
             "character",
             "npc",
-            "creature"
+            "creature",
+            "vehicule"
         ],
         "templates": {
             "characteristics": {
@@ -189,7 +190,8 @@
                 "archetype": null
             },
             "biography": [],
-            "encounteredCreatures": []
+            "encounteredCreatures": [],
+            "backstory": ""
         },
         "npc": {
             "templates": [
@@ -241,6 +243,9 @@
             "flags": {
                 "locked": false
             }
+        },
+        "vehicule":{
+            "template":[ "attribs"]
         }
     },
     "Item": {

--- a/templates/actors/character-sheet-v2.html
+++ b/templates/actors/character-sheet-v2.html
@@ -182,7 +182,11 @@
 					</div>
 		
 					<div class="tab coc7 sheet actor temp-retro-compat" data-group="primary" data-tab="background">
-						{{> "systems/CoC7/templates/actors/parts/actor-background.html"}}
+						{{#if oneBlockBackStory}}
+							{{editor content=data.backstory target="data.backstory" button=true owner=owner editable=editable}}
+						{{else}}
+							{{> "systems/CoC7/templates/actors/parts/actor-background.html"}}
+						{{/if}}
 					</div>
 				</div>
 			</div>

--- a/templates/actors/character-sheet.html
+++ b/templates/actors/character-sheet.html
@@ -372,7 +372,7 @@
 				<div class='flexcol bio-section' data-index='{{index}}' style='flex: 0 0 50%;'>
 					{{#if ../data.flags.locked}}
 					<div class='flexrow' style='flex: initial;'>
-						<label style='height: 17px;margin: 0;border: 0;font-family: customSheetFont, "Palatino Linotype", serif;font-size: 12px;'>{{section.title}}</label>
+						<label style='height: 1rem;margin: 0;border: 0;font-family: customSheetFont, "Palatino Linotype", serif;font-size: 0.75rem;'>{{section.title}}</label>
 					</div>
 					{{else}}
 					<div class='flexrow' style='flex: initial;'>
@@ -385,7 +385,7 @@
 						</div>
 					</div>
 					{{/if}}
-					<textarea class='bio-section-value' style='height: max-content;resize: none;font-family: customSheetFont, "Palatino Linotype", serif;font-size: 12px;' rows="4" >{{section.value}}</textarea>
+					<textarea class='bio-section-value' style='height: max-content;resize: none;font-family: customSheetFont, "Palatino Linotype", serif;font-size: 0.75rem;' rows="4" >{{section.value}}</textarea>
 					<!-- {{editor content=section.value target="section.value" button=true editable=editable}} -->
 				</div>
 				{{/each}}

--- a/templates/actors/parts/actor-background.html
+++ b/templates/actors/parts/actor-background.html
@@ -8,11 +8,11 @@
 <div class='flexcol bio-section' data-index='{{index}}' style='flex: 0 0 50%;'>
     {{#if ../data.flags.locked}}
     <div class='flexrow' style='flex: initial;'>
-        <label style='height: 17px;margin: 0;border: 0;font-family: customSheetFont, "Palatino Linotype", serif;font-size: 12px;'>{{section.title}}</label>
+        <label style='height: 1rem;margin: 0;border: 0;font-family: customSheetFont, "Palatino Linotype", serif;font-size: .75rem;'>{{section.title}}</label>
     </div>
     {{else}}
     <div class='flexrow' style='flex: initial;'>
-        <input class='bio-section-title' style='height: fit-content;margin: 0;border: 0;font-family: customSheetFont, "Palatino Linotype", serif;font-size: 12px;font-weight: bolder;'  type="text" value="{{section.title}}" placeholder="{{localize 'CoC7.BackgroundSectionNameHolder'}}">
+        <input class='bio-section-title' style='height: fit-content;margin: 0;border: 0;font-family: customSheetFont, "Palatino Linotype", serif;font-size: 0.75rem;font-weight: bolder;'  type="text" value="{{section.title}}" placeholder="{{localize 'CoC7.BackgroundSectionNameHolder'}}">
         <div class="flex1" style='height: fit-content;'></div>
         <div class="item-controls" style='height: fit-content;font-size: 10px;line-height: 18px;'>
             <a class="delete-section" title="{{localize 'CoC7.BackgroundDeleteSection'}}"><i class="fas fa-trash"></i></a>
@@ -21,7 +21,7 @@
         </div>
     </div>
     {{/if}}
-    <textarea class='bio-section-value' style='height: max-content;resize: none;font-family: customSheetFont, "Palatino Linotype", serif;font-size: 12px;' rows="4" >{{section.value}}</textarea>
+    <textarea class='bio-section-value' style='height: max-content;resize: none;font-family: customSheetFont, "Palatino Linotype", serif;font-size: 0.75rem;' rows="4" >{{section.value}}</textarea>
     <!-- {{editor content=section.value target="section.value" button=true editable=editable}} -->
 </div>
 {{/each}}


### PR DESCRIPTION
* Bug correction:
  * Changes from px to rem in some part of the sheet.
  * #416 Damage bonus is now correctly applied.
  * GM modified rolls are now properly set when revealed.
  * when revealed, blind GM roll are shown to the player involved only, unless CTRL is pressed.
* A toggle allowing character to gain XP is added on the keeper's tools.
* An option is added to replace backstory entries with one big editor block with formatting and links support.