### PR TITLE
edit setup sheet to allow a template for one-block backstory

### DIFF
--- a/coc7g.css
+++ b/coc7g.css
@@ -670,7 +670,7 @@
 .coc7.sheet.item .details .editor,
 .coc7.sheet.occupation .details .editor,
 .coc7.sheet.setup .details .editor {
-  height: 100px;
+  height: 200px;
 }
 .coc7.sheet.skill .details .editor button,
 .coc7.sheet.item .details .editor button,

--- a/less/items.less
+++ b/less/items.less
@@ -30,7 +30,7 @@
 	.details {
 
 		.editor {
-			height: 100px;
+			height: 200px;
 
 			button {
 				height: 20px;

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -679,8 +679,12 @@ export class CoCActor extends Actor {
 			const othersItems = data.data.items.filter( it => 'skill' != it.type);
 			await this.addUniqueItems( skills);
 			await this.addItems( othersItems);
-			for( const sectionName of data.data.bioSections){
-				if( !this.data.data.biography.find( el => sectionName == el.title) && sectionName) await this.createBioSection( sectionName);
+			if (game.settings.get( 'CoC7', 'oneBlockBackstory')) {
+				await this.update({'data.backstory': data.data.backstory});
+			} else {
+				for( const sectionName of data.data.bioSections){
+					if( !this.data.data.biography.find( el => sectionName == el.title) && sectionName) await this.createBioSection( sectionName);
+				}
 			}
 			break;
 		}

--- a/module/items/sheets/setup.js
+++ b/module/items/sheets/setup.js
@@ -127,7 +127,7 @@ export class CoC7SetupSheet extends ItemSheet {
 		return mergeObject(super.defaultOptions, {
 			classes: ['coc7', 'sheet', 'setup'],
 			width: 520,
-			height: 480,
+			height: 530,
 			resizable: false,
 			dragDrop: [{dragSelector: '.item'}],
 			scrollY: ['.tab.description'],
@@ -187,6 +187,9 @@ export class CoC7SetupSheet extends ItemSheet {
 		for (let entry of Object.entries(data.data.eras)) {
 			if( entry[1].selected) data.itemProperties.push( entry[1].name);
 		}
+
+		data.oneBlockBackStory = game.settings.get( 'CoC7', 'oneBlockBackstory');
+
 		return data;
 	}
 

--- a/template.json
+++ b/template.json
@@ -428,6 +428,7 @@
             "enableCharacterisitics": true,
             "items": [],
             "bioSections": [],
+            "backstory": "",
             "attributes": {},
             "properties": {},
             "eras": {},

--- a/templates/items/setup.html
+++ b/templates/items/setup.html
@@ -62,17 +62,25 @@
                 {{/each}}
 			</div>
 
-			<h3 class="form-header">
-				{{ localize "CoC7.BioSections" }}
-				<a class="item-control add-bio"><i class="fas fa-plus"></i></a>
-			</h3>
-
+			{{#if oneBlockBackStory}}
+				<h3 class="form-header">
+				{{ localize "CoC7.Background" }}
+				</h3>
+				<div class="backstory-editor">
+				{{editor content=data.backstory target="data.backstory" button=true owner=owner editable=editable}}
+				</div>
+			{{else}}
+				<h3 class="form-header">
+					{{ localize "CoC7.BioSections" }}
+					<a class="item-control add-bio"><i class="fas fa-plus"></i></a>
+				</h3>
 			{{#each data.bioSections as |value index|}}
-			<div class="form-group item" data-index="{{index}}">
-				<input type="text" name="data.bioSections.{{index}}" value="{{value}}" placeholder="{{ localize 'CoC7.BioSectionName' }}"/>
-				<a class="item-control remove-section"><i class="fas fa-minus" style="line-height: 20px;"></i></a>
-			</div>
+				<div class="form-group item" data-index="{{index}}">
+					<input type="text" name="data.bioSections.{{index}}" value="{{value}}" placeholder="{{ localize 'CoC7.BioSectionName' }}"/>
+					<a class="item-control remove-section"><i class="fas fa-minus" style="line-height: 20px;"></i></a>
+				</div>
 			{{/each}}
+			{{/if}}
 
 			<div class='droppable main-skills'>
 				<h3 class="form-header">{{ localize "CoC7.Items" }}</h3>


### PR DESCRIPTION
I have added an editor to the setup sheet, instead of bio sections, when oneBlockBackStory setting is enabled. When the setup is dropped into the character sheet, this backstory text is used.
This is useful if the GM wants to suggest a template for the characters' background.