### PR TITLE
Option to disable debug and resolve possible NPC sheet JavaScript error

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -616,6 +616,8 @@
 "CoC7.French": "French",
 "CoC7.SelectSourceLanguage": "Select the source text language",
 
+"SETTINGS.DebugMode": "System Debug Mode",
+"SETTINGS.DebugModeHint": "!!RESTART REQUIRED!!",
 "SETTINGS.DefaultDifficulty": "Default check difficulty",
 "SETTINGS.DefaultDifficultyHint": "You can choose the default difficulty for checks. Unknown will roll checks without the player knowing the check difficulty.",
 "SETTINGS.CheckDifficultyRegular": "Default difficulty",

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -203,8 +203,8 @@ export class CoC7ActorSheet extends ActorSheet {
 					let lca;
 					let lcb;
 					if( a.data.properties && b.data.properties) {
-						lca = a.data.properties.special ? a.data.specialization.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase() + a.name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase() : a.name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
-						lcb = b.data.properties.special ? b.data.specialization.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase() + b.name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase() : b.name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+						lca = a.data.properties.special && typeof a.data.specialization !== 'undefined' ? a.data.specialization.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase() + a.name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase() : a.name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+						lcb = b.data.properties.special && typeof b.data.specialization !== 'undefined' ? b.data.specialization.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase() + b.name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase() : b.name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
 					}
 					else {
 						lca = a.name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -56,8 +56,16 @@ Hooks.once('init', async function() {
 		decimals: 4
 	};
 
-	//TODO : remove debug hooks
-	CONFIG.debug.hooks = true;
+	game.settings.register('CoC7', 'debugmode', {
+		name: 'SETTINGS.DebugMode',
+		hint: "SETTINGS.DebugModeHint",
+		scope: 'world',
+		config: true,
+		type: Boolean,
+		default: false
+	});
+
+	CONFIG.debug.hooks = !!game.settings.get('CoC7', 'debugmode');
 	CONFIG.Actor.entityClass = CoCActor;
 	CONFIG.Item.entityClass = CoC7Item;
 	Combat.prototype.rollInitiative = rollInitiative;


### PR DESCRIPTION
Add a new setting for System Debug Mode, defaulted to false
This allows CONFIG.debug.hooks to be controlled instead of being hard coded as true, resolves #437

When opening an actor sheet, items are sorted but item.data.specialization may not always exist on NPC character sheets, check if it does before accessing. Resolves #499