### PR TITLE
Fixed deprecated calls to deleteOwnedItem on actor.js and base.js

### DIFF
--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -1053,7 +1053,7 @@ export class CoCActor extends Actor {
 				await occupationSkill[index].unsetItemFlag('occupation');
 			}
 		}
-		if( this.occupation) await this.deleteOwnedItem(this.occupation.id);
+		if( this.occupation) await this.occupation.delete();
 		await this.update({ 'data.development.occupation': null});
 	}
 
@@ -1064,7 +1064,7 @@ export class CoCActor extends Actor {
 				await archetypeSkill[index].unsetItemFlag('archetype');
 			}
 		}
-		if( this.archetype) await this.deleteOwnedItem(this.archetype.id);
+		if( this.archetype) await this.archetype.delete();
 		await this.update({ 'data.development.archetype': null});
 	}
 

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -496,9 +496,10 @@ export class CoC7ActorSheet extends ActorSheet {
 		});
 
 		// Delete Inventory Item
-		html.find('.item-delete').click(ev => {
+		html.find('.item-delete').click(async ev => {
 			const li = $(ev.currentTarget).parents('.item');
-			this.actor.deleteOwnedItem(li.data('itemId'));
+			const itemToDelete = this.actor.items.get(li.data('itemId'), {strict: true});
+			await itemToDelete.delete();
 			li.slideUp(200, () => this.render(false));
 		});
 


### PR DESCRIPTION
calling `deleteOwnedItem` replaced with calling `delete` on the item to be deleted. 