### PR TITLE
Start compendium translation information

### DIFF
--- a/coc7g.css
+++ b/coc7g.css
@@ -3116,3 +3116,11 @@ html {
 #controls .scene-control.custom-control .control-tool.xp_toggle.active {
   color: goldenrod;
 }
+a.compendium-translation {
+    border-top: 2px groove #444;
+    padding-top: 4px;
+    font-size: 20px;
+    text-align: center;
+    line-height: 32px;
+    display: block;
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -624,6 +624,13 @@
 "CoC7.French": "French",
 "CoC7.SelectSourceLanguage": "Select the source text language",
 
+"CoC7.HowToTranslateTitle": "How to translate?",
+"CoC7.HowToTranslateWarning": "Do not install any modules you do not trust.",
+"CoC7.HowToTranslateInstallBabele": "Install/Update Babele module from Foundry's module manager.",
+"CoC7.HowToTranslateInstallTranslation": "Install/Update Translation from Foundry's module manager.",
+"CoC7.HowToTranslateEnableTranslation": "Inside the Game World, under Configuration/Manage Modules activate both Babele and the translations.",
+"CoC7.HowToTranslateNoTranslation": "Instructions for creating new language translations are available on existing translation modules.",
+
 "SETTINGS.DebugMode": "System Debug Mode",
 "SETTINGS.DebugModeHint": "!!RESTART REQUIRED!!",
 "SETTINGS.DefaultDifficulty": "Default check difficulty",

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -779,39 +779,37 @@ Hooks.on('targetToken', function (user, token, targeted) {
 });
 
 class CompendiumDirectoryCoC7 extends CompendiumDirectory {
-  activateListeners (html) {
-    super.activateListeners(html)
-    let translated = false
-    if (game.i18n.lang === 'en') {
-      translated = true
-    } else if (typeof game.babele !== 'undefined') {
-      for (const [k, v] of Object.entries(game.babele.modules)) {
-        if (v.lang === game.i18n.lang) {
-          translated = true
-        }
-      }
-    }
-    if (!translated) {
-      html.find('footer.directory-footer').append('<a class="compendium-translation" title="' + game.i18n.localize('CoC7.HowToTranslateTitle') + '">' + game.i18n.localize('CoC7.HowToTranslateTitle') + '</a>')
-      html.find('.compendium-translation').click((e) => {
-        const message = '<p>' + game.i18n.localize('CoC7.HowToTranslateWarning') + '</p>' +
-          '<p>' + game.i18n.localize('CoC7.HowToTranslateInstallBabele') + '</p>' +
-          '<p>' + game.i18n.localize('CoC7.HowToTranslateInstallTranslation') + '</p>' +
-          '<p>' + game.i18n.localize('CoC7.HowToTranslateEnableTranslation') + '</p>' +
-          '<p>' + game.i18n.localize('CoC7.HowToTranslateNoTranslation') + '</p>'
-        new Dialog(
-          {
-            title: game.i18n.localize('CoC7.HowToTranslateTitle'),
-            content: message,
-            buttons: {},
-            default: 'close',
-            close: (html) => {
-            }
-          },
-          {}
-        ).render(true)
-      })
-    }
-  }
+	activateListeners (html) {
+		super.activateListeners(html);
+		let translated = false;
+		if (game.i18n.lang === 'en') {
+			translated = true;
+		} else if (typeof game.babele !== 'undefined') {
+			for (const v of Object.values(game.babele.modules)) {
+				if (v.lang === game.i18n.lang) {
+					translated = true;
+				}
+			}
+		}
+		if (!translated) {
+			html.find('footer.directory-footer').append('<a class="compendium-translation" title="' + game.i18n.localize('CoC7.HowToTranslateTitle') + '">' + game.i18n.localize('CoC7.HowToTranslateTitle') + '</a>');
+			html.find('.compendium-translation').click(() => {
+				const message = '<p>' + game.i18n.localize('CoC7.HowToTranslateWarning') + '</p>' +
+					'<p>' + game.i18n.localize('CoC7.HowToTranslateInstallBabele') + '</p>' +
+					'<p>' + game.i18n.localize('CoC7.HowToTranslateInstallTranslation') + '</p>' +
+					'<p>' + game.i18n.localize('CoC7.HowToTranslateEnableTranslation') + '</p>' +
+					'<p>' + game.i18n.localize('CoC7.HowToTranslateNoTranslation') + '</p>';
+				new Dialog(
+					{
+						title: game.i18n.localize('CoC7.HowToTranslateTitle'),
+						content: message,
+						buttons: {},
+						default: 'close'
+					},
+					{}
+				).render(true);
+			});
+		}
+	}
 }
 CONFIG.ui.compendium = CompendiumDirectoryCoC7;

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -33,6 +33,7 @@ import { DamageCard } from './chat/cards/damage.js';
 import { CoC7VehicleSheet } from './actors/sheets/vehicle.js';
 import { CoC7Canvas } from './apps/canvas.js';
 import { CoC7ChaseSheet } from './items/sheets/chase.js';
+import { CoC7CompendiumDirectory } from './compendium-directory.js';
 
 Hooks.once('init', async function() {
 
@@ -778,38 +779,4 @@ Hooks.on('targetToken', function (user, token, targeted) {
 	}
 });
 
-class CompendiumDirectoryCoC7 extends CompendiumDirectory {
-	activateListeners (html) {
-		super.activateListeners(html);
-		let translated = false;
-		if (game.i18n.lang === 'en') {
-			translated = true;
-		} else if (typeof game.babele !== 'undefined') {
-			for (const v of Object.values(game.babele.modules)) {
-				if (v.lang === game.i18n.lang) {
-					translated = true;
-				}
-			}
-		}
-		if (!translated) {
-			html.find('footer.directory-footer').append('<a class="compendium-translation" title="' + game.i18n.localize('CoC7.HowToTranslateTitle') + '">' + game.i18n.localize('CoC7.HowToTranslateTitle') + '</a>');
-			html.find('.compendium-translation').click(() => {
-				const message = '<p>' + game.i18n.localize('CoC7.HowToTranslateWarning') + '</p>' +
-					'<p>' + game.i18n.localize('CoC7.HowToTranslateInstallBabele') + '</p>' +
-					'<p>' + game.i18n.localize('CoC7.HowToTranslateInstallTranslation') + '</p>' +
-					'<p>' + game.i18n.localize('CoC7.HowToTranslateEnableTranslation') + '</p>' +
-					'<p>' + game.i18n.localize('CoC7.HowToTranslateNoTranslation') + '</p>';
-				new Dialog(
-					{
-						title: game.i18n.localize('CoC7.HowToTranslateTitle'),
-						content: message,
-						buttons: {},
-						default: 'close'
-					},
-					{}
-				).render(true);
-			});
-		}
-	}
-}
-CONFIG.ui.compendium = CompendiumDirectoryCoC7;
+CONFIG.ui.compendium = CoC7CompendiumDirectory;

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -777,3 +777,41 @@ Hooks.on('targetToken', function (user, token, targeted) {
 		}
 	}
 });
+
+class CompendiumDirectoryCoC7 extends CompendiumDirectory {
+  activateListeners (html) {
+    super.activateListeners(html)
+    let translated = false
+    if (game.i18n.lang === 'en') {
+      translated = true
+    } else if (typeof game.babele !== 'undefined') {
+      for (const [k, v] of Object.entries(game.babele.modules)) {
+        if (v.lang === game.i18n.lang) {
+          translated = true
+        }
+      }
+    }
+    if (!translated) {
+      html.find('footer.directory-footer').append('<a class="compendium-translation" title="' + game.i18n.localize('CoC7.HowToTranslateTitle') + '">' + game.i18n.localize('CoC7.HowToTranslateTitle') + '</a>')
+      html.find('.compendium-translation').click((e) => {
+        const message = '<p>' + game.i18n.localize('CoC7.HowToTranslateWarning') + '</p>' +
+          '<p>' + game.i18n.localize('CoC7.HowToTranslateInstallBabele') + '</p>' +
+          '<p>' + game.i18n.localize('CoC7.HowToTranslateInstallTranslation') + '</p>' +
+          '<p>' + game.i18n.localize('CoC7.HowToTranslateEnableTranslation') + '</p>' +
+          '<p>' + game.i18n.localize('CoC7.HowToTranslateNoTranslation') + '</p>'
+        new Dialog(
+          {
+            title: game.i18n.localize('CoC7.HowToTranslateTitle'),
+            content: message,
+            buttons: {},
+            default: 'close',
+            close: (html) => {
+            }
+          },
+          {}
+        ).render(true)
+      })
+    }
+  }
+}
+CONFIG.ui.compendium = CompendiumDirectoryCoC7;

--- a/module/compendium-directory.js
+++ b/module/compendium-directory.js
@@ -1,0 +1,34 @@
+export class CoC7CompendiumDirectory extends CompendiumDirectory {
+	activateListeners (html) {
+		super.activateListeners(html);
+		let translated = false;
+		if (game.i18n.lang === 'en') {
+			translated = true;
+		} else if (typeof game.babele !== 'undefined') {
+			for (const v of Object.values(game.babele.modules)) {
+				if (v.lang === game.i18n.lang) {
+					translated = true;
+				}
+			}
+		}
+		if (!translated) {
+			html.find('footer.directory-footer').append('<a class="compendium-translation" title="' + game.i18n.localize('CoC7.HowToTranslateTitle') + '">' + game.i18n.localize('CoC7.HowToTranslateTitle') + '</a>');
+			html.find('.compendium-translation').click(() => {
+				const message = '<p>' + game.i18n.localize('CoC7.HowToTranslateWarning') + '</p>' +
+					'<p>' + game.i18n.localize('CoC7.HowToTranslateInstallBabele') + '</p>' +
+					'<p>' + game.i18n.localize('CoC7.HowToTranslateInstallTranslation') + '</p>' +
+					'<p>' + game.i18n.localize('CoC7.HowToTranslateEnableTranslation') + '</p>' +
+					'<p>' + game.i18n.localize('CoC7.HowToTranslateNoTranslation') + '</p>';
+				new Dialog(
+					{
+						title: game.i18n.localize('CoC7.HowToTranslateTitle'),
+						content: message,
+						buttons: {},
+						default: 'close'
+					},
+					{}
+				).render(true);
+			});
+		}
+	}
+}


### PR DESCRIPTION
The following Pull Request and Issues reference translating the Compendium Packs.

#363 "Addition of the Polish compedium"
#541 "Localizable skill and item names in compedium"
#454 "Separate compendiums for translations"
#406 "Translation of character sheets into French"

Foundry doesn't have a way to do this by default, you can install a module called Babele which allows other modules to translate compendiums.

On the Compendium Packs sidebar if the current language is "en" or both Babele and the correct translation are enabled no change is made, otherwise it adds a button to the bottom of the tab to display a dialog with install instructions. Once the contents of this dialog has been decided each language built into this system can be updated with the instructions and maybe point to the curated module on the FoundryVTT website.

The FoundryVTT website currently lists the following modules 
https://foundryvtt.com/packages/call-of-cthulhu-7th-babele-es / Translation: Spanish (Call of Cthulhu 7th)
https://foundryvtt.com/packages/coc7-babele-sv / Translation: Svenska (Call of Cthulhu 7th edition)
https://foundryvtt.com/packages/call-of-cthulhu-7th-babele-de / Translation: Deutsch (Call of Cthulhu 7)
https://foundryvtt.com/packages/call-of-cthulhu-7th-babele-it / Call of Cthulhu 7th Babele (Italian)
https://foundryvtt.com/packages/call-of-cthulhu-7th-babele-pt-BR / Call of Cthulhu 7th Babele Portuguese (Brazilian)
https://foundryvtt.com/packages/CoC7kr / Translation: Korean [The Call of Cthulhu 7th edition]