### PR TITLE
Fix: Daily San

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -626,6 +626,8 @@
 "CoC7.French": "French",
 "CoC7.SelectSourceLanguage": "Select the source text language",
 
+"CoC7.initialvalue": "Daily initial San value",
+
 "SETTINGS.DebugMode": "System Debug Mode",
 "SETTINGS.DebugModeHint": "!!RESTART REQUIRED!!",
 "SETTINGS.DefaultDifficulty": "Default check difficulty",

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -2419,6 +2419,7 @@ export class CoCActor extends Actor {
 
 	async resetCounter( counter){
 		await this.update( {[counter]: 0});
+		await this.update( { 'data.attribs.san.initialvalue': this.data.data.attribs.san.value});
 	}
 
 	async setOneFifthSanity (oneFifthSanity) {

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -351,6 +351,12 @@ export class CoC7ActorSheet extends ActorSheet {
 		if( data.data.attribs.mp.value < 0) data.data.attribs.mp.value = null;
 		if( data.data.attribs.san.value < 0) data.data.attribs.san.value = null;
 		// data.data.attribs.san.fiftyOfCurrent = data.data.attribs.san.value >= 0 ? ' / '+Math.floor(data.data.attribs.san.value/5):'';
+
+		if( data.data.attribs.san.value >0 && !data.data.attribs.san.initialvalue) data.data.attribs.san.initialvalue = data.data.attribs.san.value;
+		if( data.data.attribs.san.value >0 && !data.data.attribs.san.dailyLoss) data.data.attribs.san.dailyLoss = 0;
+		data.data.attribs.san.fiftyOfCurrent = data.data.attribs.san.initialvalue >= 0 ? ' / '+Math.max(1, Math.floor(data.data.attribs.san.initialvalue/5)):'';
+
+		
 		if( data.data.attribs.hp.auto ){
 			//TODO if any is null set max back to null.
 			if ( data.data.characteristics.siz.value != null && data.data.characteristics.con.value != null)

--- a/templates/actors/parts/vitals.html
+++ b/templates/actors/parts/vitals.html
@@ -54,7 +54,7 @@
             </div>
         </div>
         <div>
-            <label>{{localize 'CoC7.DailyLoss'}}: {{data.attribs.san.dailyLoss}}{{data.attribs.san.oneFifthSanity}}</label>
+            <label>{{localize 'CoC7.DailyLoss'}}:  <input style="width: 5px;" type="text" name="data.attribs.san.initialvalue" value="{{data.attribs.san.initialvalue}}" title="{{localize 'CoC7.initialvalue'}}"  readonly data-dtype="Number"/>/  {{data.attribs.san.dailyLoss}}{{data.attribs.san.fiftyOfCurrent}}</label>
         </div>
         <div class="status">
             <div class="invisible">


### PR DESCRIPTION
add a text box to input initial san value. initial san value mean the san when day start.
fiftyOfCurrent san count by initial value.
When click the resetCounter, the initial san value will reset too.
if there is san value, and dailyLoss is null, dailyLoss show 0
if there is san value, and initialvalue is null, initialvalue became san value
![image](https://user-images.githubusercontent.com/23254376/120937279-433efa80-c73f-11eb-937a-2058ea466661.png)
.