### PR TITLE
Skill specializations display full names in character sheet sometimes resolves #575

### DIFF
--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -2372,7 +2372,7 @@ export class CoCActor extends Actor {
 					},
 					// tint: '#ff0000',
 					disabled: false
-				}])
+				}]);
 			}
 				
 			break;

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -645,6 +645,11 @@ export class CoCActor extends Actor {
 					}
 				}
 				// }
+			} else {
+				const specialization = data.data.specialization;
+				if (specialization) {
+					data.name = CoC7Item.getNameWithoutSpec(data);
+				}
 			}
 
 			return await super.createEmbeddedDocuments(embeddedName, [data], options);

--- a/module/items/item.js
+++ b/module/items/item.js
@@ -178,10 +178,10 @@ export class CoC7Item extends Item {
 		if( 'skill' != this.type || !this.data.data?.properties?.special) return super.name;
 		if (this.data.name.toLowerCase().includes( this.data.data.specialization?.toLowerCase())) {
 			// Restore names that have already been processed
-			if (super.name === this.data.name) {
+			if (this.isOwned && super.name === this.data.name) {
 				let re = new RegExp('^' + this.data.data.specialization.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&") + ' \\((.+)\\)$')
 				let match = re.exec(this.data.name)
-				if (typeof match[1] !== 'undefined') {
+				if (typeof match !== 'undefined' && typeof match[1] !== 'undefined') {
 					return match[1]
 				}
 			}

--- a/module/items/item.js
+++ b/module/items/item.js
@@ -181,7 +181,7 @@ export class CoC7Item extends Item {
 			if (this.isOwned && super.name === this.data.name) {
 				let re = new RegExp('^' + this.data.data.specialization.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&') + ' \\((.+)\\)$');
 				let match = re.exec(this.data.name);
-				if (typeof match !== 'undefined' && typeof match[1] !== 'undefined') {
+				if (match !== null && typeof match[1] !== 'undefined') {
 					return match[1];
 				}
 			}

--- a/module/items/item.js
+++ b/module/items/item.js
@@ -176,7 +176,20 @@ export class CoC7Item extends Item {
 
 	get name() {
 		if( 'skill' != this.type || !this.data.data?.properties?.special) return super.name;
-		if( this.data.name.toLowerCase().includes( this.data.data.specialization?.toLowerCase())) return super.name;
+		if (this.data.name.toLowerCase().includes( this.data.data.specialization?.toLowerCase())) {
+			// Restore names that have already been processed
+			if (super.name === this.data.name) {
+				let re = new RegExp('^' + this.data.data.specialization.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&") + ' \\((.+)\\)$')
+				let match = re.exec(this.data.name)
+				if (typeof match[1] !== 'undefined') {
+					return match[1]
+				}
+			}
+			return super.name
+		}
+		if (this.isOwned) {
+			return super.name
+		}
 		return `${this.data.data.specialization} (${this.data.name})`;
 	}
 

--- a/module/items/item.js
+++ b/module/items/item.js
@@ -179,16 +179,16 @@ export class CoC7Item extends Item {
 		if (this.data.name.toLowerCase().includes( this.data.data.specialization?.toLowerCase())) {
 			// Restore names that have already been processed
 			if (this.isOwned && super.name === this.data.name) {
-				let re = new RegExp('^' + this.data.data.specialization.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&") + ' \\((.+)\\)$')
-				let match = re.exec(this.data.name)
+				let re = new RegExp('^' + this.data.data.specialization.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&') + ' \\((.+)\\)$');
+				let match = re.exec(this.data.name);
 				if (typeof match !== 'undefined' && typeof match[1] !== 'undefined') {
-					return match[1]
+					return match[1];
 				}
 			}
-			return super.name
+			return super.name;
 		}
 		if (this.isOwned) {
-			return super.name
+			return super.name;
 		}
 		return `${this.data.data.specialization} (${this.data.name})`;
 	}
@@ -585,10 +585,10 @@ export class CoC7Item extends Item {
 			};
 		}
 		if (typeof data.description.value === 'undefined') {
-			data.description.value = ''
+			data.description.value = '';
 		}
 		if (typeof data.description.special === 'undefined') {
-			data.description.special = ''
+			data.description.special = '';
 		}
 		const labels = [];
 


### PR DESCRIPTION
If the name has already been altered to Specialization (Name) restore it to Name.
If the item is owned don't change Name to Specialization (Name)