### PR TITLE
Update user detection for melee token targets, "User xxx lacks permission to update ChatMessage xxx"

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -607,6 +607,8 @@
 
 "CoC7.MessageCheckRequestedWait": "Your keeper is requesting a {check}.<br>Wait before clicking!<br>",
 "CoC7.MessageTargetCheckRequested": "Your keeper is requesting a {check} for {name}.",
+"CoC7.MessageTitleSelectSingleUserForTarget": "Which user can respond to this attack",
+"CoC7.MessageSelectSingleUserForTarget": "This token is controlled by multiple users, please select which user can respond to this attack.",
 "CoC7.MessageSelectedTargetIsNotControlled": "The token for {name} is owned by not controlled by a player so will not be able to react to combat actions.",
 "CoC7.MessageBoutOfMadnessTableNotFound": "The result from the madness table was not found, please check all your roll tables are created",
 "CoC7.MessageBoutOfMadnessItemNotFound": "The result from the madness table was not found, please check all your statuses are created",

--- a/module/chat/combat/melee-target.js
+++ b/module/chat/combat/melee-target.js
@@ -139,6 +139,7 @@ export class CoC7MeleeTarget extends ChatCardActor{
 					}
 				}
 			}
+			let content = '';
 			switch (owners.length) {
 				case 0:
 					// GM
@@ -147,22 +148,22 @@ export class CoC7MeleeTarget extends ChatCardActor{
 					user = game.users.get(owners[0]);
 					break;
 				default:
-					let content = '<p>' + game.i18n.localize('CoC7.MessageSelectSingleUserForTarget');
+					content = '<p>' + game.i18n.localize('CoC7.MessageSelectSingleUserForTarget');
 					content = content + '<form id="selectform"><select name="user">';
 					owners.forEach(function (k) {
 						content = content + '<option value="' + k + '">' + game.users.get(k).name + '</option>';
-					})
+					});
 					content = content + '</select></form></p>';
-					let d = await Dialog.prompt({
+					await Dialog.prompt({
 						title: game.i18n.localize('CoC7.MessageTitleSelectSingleUserForTarget'),
 						content: content,
 						callback:(html) => {
 							const formData = new FormData(html[0].querySelector('#selectform'));
 							formData.forEach(function (value, name) {
 							if (name === 'user') {
-								user = game.users.get(value)
+								user = game.users.get(value);
 							}
-						})
+						});
 					}
 				});
 			}

--- a/module/chat/combat/melee-target.js
+++ b/module/chat/combat/melee-target.js
@@ -124,8 +124,51 @@ export class CoC7MeleeTarget extends ChatCardActor{
 		
 		const speaker = ChatMessage.getSpeaker(speakerData);
 		if( this.actor.isToken) speaker.alias = this.actor.token.name;
-		
-		const user = this.actor.user ? this.actor.user : game.user;
+
+		let user = game.user;
+		if (typeof this.actor.user === 'undefined') {
+			let owners = [];
+			const gms = game.users.filter(a => a.isGM).map(a => a.id);
+			for (const [k, v] of Object.entries(this.actor.data.permission)) {
+				if (v === CONST.ENTITY_PERMISSIONS.OWNER) {
+					if (k === 'default') {
+						owners = game.users.map(a => a.id);
+						break;
+					} else if (!gms.includes(k)) {
+						owners.push(k);
+					}
+				}
+			}
+			switch (owners.length) {
+				case 0:
+					// GM
+					break;
+				case 1:
+					user = game.users.get(owners[0]);
+					break;
+				default:
+					let content = '<p>' + game.i18n.localize('CoC7.MessageSelectSingleUserForTarget');
+					content = content + '<form id="selectform"><select name="user">';
+					owners.forEach(function (k) {
+						content = content + '<option value="' + k + '">' + game.users.get(k).name + '</option>';
+					})
+					content = content + '</select></form></p>';
+					let d = await Dialog.prompt({
+						title: game.i18n.localize('CoC7.MessageTitleSelectSingleUserForTarget'),
+						content: content,
+						callback:(html) => {
+							const formData = new FormData(html[0].querySelector('#selectform'));
+							formData.forEach(function (value, name) {
+							if (name === 'user') {
+								user = game.users.get(value)
+							}
+						})
+					}
+				});
+			}
+		} else {
+			user = this.actor.user;
+		}
 
 		const chatData = {
 			user: user.id,


### PR DESCRIPTION
In melee combat, if the token being targeted by an attack is owned but not controlled by a user when trying to dodge, etc they will receives the following error.
"User xxx lacks permission to update ChatMessage xxx"

Only one user can own the chat message, this update changes how the system selects which user to assign the message to.

If the token has a user, set the message owner to that user (no change)
If the token doesn't have a user and no users own it, set the message owner to current user (no change)

If the token doesn't have a user and one non gm player owns it, set the message owner to that user (change)
If the token doesn't have a user and the default permission is owner or multiple users are the owner, show a dialog prompt to select the user that can respond to this attack (change)