### PR TITLE
Style layout changes

### DIFF
--- a/module/actors/sheets/creature-sheet.js
+++ b/module/actors/sheets/creature-sheet.js
@@ -71,18 +71,20 @@ export class CoC7CreatureSheet extends CoC7ActorSheet {
         sanMin: this.actor.data.data.special.sanLoss.checkPassed,
         sanMax: this.actor.data.data.special.sanLoss.checkFailled
       }
-      if (game.settings.get('core', 'rollMode') === 'blindroll')
+      if (game.settings.get('core', 'rollMode') === 'blindroll') {
         linkData.blind = true
+      }
       if (typeof modifier !== 'undefined') linkData.modifier = modifier
       if (typeof difficulty !== 'undefined') linkData.difficulty = difficulty
       const link = CoC7Parser.createCoC7Link(linkData)
-      if (link)
+      if (link) {
         chatHelper.createMessage(
           null,
           game.i18n.format('CoC7.MessageCheckRequestedWait', {
             check: link
           })
         )
+      }
     } else {
       SanCheckCard.checkTargets(this.actor.tokenKey, event.shiftKey)
       // CoC7SanCheck.checkTargets( this.actor.data.data.special.sanLoss.checkPassed, this.actor.data.data.special.sanLoss.checkFailled, event.shiftKey, this.tokenKey);
@@ -105,18 +107,11 @@ export class CoC7CreatureSheet extends CoC7ActorSheet {
     const options = mergeObject(super.defaultOptions, {
       template: 'systems/CoC7/templates/actors/creature-sheet.html',
       width: 580,
-      height: 'auto',
       classes: ['coc7', 'sheet', 'actor', 'npc', 'creature'],
       dragDrop: [{ dragSelector: '.item', dropSelector: null }],
       resizable: true
     })
     return options
-  }
-
-  setPosition (position = {}) {
-    const test = super.setPosition(position)
-    test.height = 'auto'
-    return test
   }
 
   /**

--- a/module/actors/sheets/npc-sheet.js
+++ b/module/actors/sheets/npc-sheet.js
@@ -52,18 +52,11 @@ export class CoC7NPCSheet extends CoC7ActorSheet {
       dragDrop: [{ dragSelector: '.item', dropSelector: null }],
       template: 'systems/CoC7/templates/actors/npc-sheet.html',
       width: 580,
-      height: 'auto',
       resizable: true
     })
   }
 
   static forceAuto (app, html) {
     html[0].style.height = 'auto'
-  }
-
-  setPosition (position = {}) {
-    const test = super.setPosition(position)
-    test.height = 'auto'
-    return test
   }
 }

--- a/module/items/sheets/archetype.js
+++ b/module/items/sheets/archetype.js
@@ -53,8 +53,9 @@ export class CoC7ArchetypeSheet extends ItemSheet {
     if (!item || !(type === item.data.type)) return
 
     if (!CoC7Item.isAnySpec(item)) {
-      if (this.item.data.data.skills.find(el => el.name === item.data.name))
+      if (this.item.data.data.skills.find(el => el.name === item.data.name)) {
         return
+      }
     }
 
     const collection = this.item.data.data[collectionName]
@@ -112,7 +113,6 @@ export class CoC7ArchetypeSheet extends ItemSheet {
       classes: ['coc7', 'sheet', 'occupation'],
       width: 520,
       height: 480,
-      resizable: false,
       dragDrop: [{ dragSelector: '.item' }],
       scrollY: ['.tab.description'],
       tabs: [
@@ -178,8 +178,9 @@ export class CoC7ArchetypeSheet extends ItemSheet {
 
     data.coreCharacteristicsString = ''
     const orString = ` ${game.i18n.localize('CoC7.Or')} `
-    if (coreCharacteristics.length)
+    if (coreCharacteristics.length) {
       data.coreCharacteristicsString += coreCharacteristics.join(orString)
+    }
 
     data.itemProperties = []
 

--- a/module/items/sheets/book.js
+++ b/module/items/sheets/book.js
@@ -116,7 +116,6 @@ export class CoC7BookSheet extends ItemSheet {
       classes: ['coc7', 'sheet', 'book'],
       width: 520,
       height: 480,
-      resizable: false,
       dragDrop: [{ dragSelector: '.spell', dropSelector: null }],
       scrollY: ['.tab.description'],
       tabs: [
@@ -154,8 +153,9 @@ export class CoC7BookSheet extends ItemSheet {
     data.itemProperties = []
 
     for (const [key, value] of Object.entries(data.data.type)) {
-      if (value)
+      if (value) {
         data.itemProperties.push(COC7.bookType[key] ? COC7.bookType[key] : null)
+      }
     }
     return data
   }

--- a/module/items/sheets/chase.js
+++ b/module/items/sheets/chase.js
@@ -347,20 +347,23 @@ export class _participant {
   }
 
   get actor () {
-    if (!this._actor)
+    if (!this._actor) {
       this._actor = chatHelper.getActorFromKey(this.data.actorKey)
+    }
     return this._actor
   }
 
   get driver () {
-    if (!this._driver)
+    if (!this._driver) {
       this._driver = chatHelper.getActorFromKey(this.data.actorKey)
+    }
     return this._driver
   }
 
   get vehicle () {
-    if (this.data.vehicleKey)
+    if (this.data.vehicleKey) {
       this._vehicle = chatHelper.getActorFromKey(this.data.vehicleKey)
+    }
     return this._vehicle
   }
 

--- a/module/items/sheets/item-sheet.js
+++ b/module/items/sheets/item-sheet.js
@@ -1,180 +1,19 @@
-/* global ItemSheet, mergeObject */
+/* global mergeObject */
 
-import { COC7 } from '../../config.js'
+import { CoC7ItemSheetV2 } from './item-sheetV2.js'
 
 /**
  * Extend the basic ItemSheet with some very simple modifications
  */
-export class CoCItemSheet extends ItemSheet {
-  constructor (...args) {
-    super(...args)
-    this._sheetTab = 'items'
-  }
-
+export class CoCItemSheet extends CoC7ItemSheetV2 {
   /**
    * Extend and override the default options used by the Simple Item Sheet
    * @returns {Object}
    */
   static get defaultOptions () {
     return mergeObject(super.defaultOptions, {
-      classes: ['coc7', 'sheetV2', 'item'],
       width: 520,
-      height: 480,
-      tabs: [
-        {
-          navSelector: '.sheet-tabs',
-          contentSelector: '.sheet-body',
-          initial: 'skills'
-        }
-      ]
+      height: 480
     })
   }
-
-  /* -------------------------------------------- */
-
-  /** @override */
-  get template () {
-    if (this.item.data.type === 'item')
-      return 'systems/CoC7/templates/items/item-sheetV2.html'
-    const path = 'systems/CoC7/templates/items'
-    return `${path}/${this.item.data.type}-sheet.html`
-  }
-
-  get width () {
-    return 520
-  }
-
-  /* -------------------------------------------- */
-
-  /* -------------------------------------------- */
-
-  /**
-   * Prepare data for rendering the Item sheet
-   * The prepared data object contains both the actor data as well as additional sheet options
-   */
-  getData () {
-    // this.item.checkSkillProperties();
-    const data = super.getData()
-
-    /** MODIF: 0.8.x **/
-    const itemData = data.data
-    data.data = itemData.data // MODIF: 0.8.x data.data
-    /*****************/
-
-    data.hasOwner = this.item.actor != null
-
-    if (this.item.data.type === 'skill') {
-      data._properties = []
-      for (const [key, value] of Object.entries(COC7.skillProperties)) {
-        const property = {}
-        property.id = key
-        property.name = value
-        property.isEnabled = this.item.data.data.properties[key] === true
-        data._properties.push(property)
-      }
-
-      data._eras = []
-      for (const [key, value] of Object.entries(COC7.eras)) {
-        const era = {}
-        era.id = key
-        era.name = value
-        era.isEnabled = this.item.data.data.eras[key] === true
-        data._eras.push(era)
-      }
-
-      data.isSpecialized = this.item.data.data.properties.special
-      data.canModifySpec =
-        !this.item.data.data.properties.firearm &&
-        !this.item.data.data.properties.fighting
-    }
-    return data
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Activate event listeners using the prepared sheet HTML
-   * @param html {HTML}   The prepared HTML object ready to be rendered into the DOM
-   */
-  activateListeners (html) {
-    super.activateListeners(html)
-    // Everything below here is only needed if the sheet is editable
-    if (!this.options.editable) return
-
-    html.find('.toggle-switch').click(this._onClickToggle.bind(this))
-  }
-
-  /* -------------------------------------------- */
-
-  async _onClickToggle (event) {
-    event.preventDefault()
-    const propertyId = event.currentTarget.closest('.toggle-switch').dataset
-      .property
-    await this.item.toggleProperty(
-      propertyId,
-      event.metaKey ||
-        event.ctrlKey ||
-        event.keyCode === 91 ||
-        event.keyCode === 224
-    )
-  }
-
-  // async _onClickAttributeControl(event) {
-  //   event.preventDefault();
-  //   const a = event.currentTarget;
-  //   const action = a.dataset.action;
-  //   const attrs = this.object.data.data.attributes;
-  //   const form = this.form;
-
-  //   // Add new attribute
-  //   if (action === "create") {
-  //     const nk = Object.keys(attrs).length + 1;
-  //     let newKey = document.createElement("div");
-  //     newKey.innerHTML = `<input type="text" name="data.attributes.attr${nk}.key" value="attr${nk}"/>`;
-  //     newKey = newKey.children[0];
-  //     form.appendChild(newKey);
-  //     await this._onSubmit(event);
-  //   }
-
-  //   // Remove existing attribute
-  //   else if (action === "delete") {
-  //     const li = a.closest(".attribute");
-  //     li.parentElement.removeChild(li);
-  //     await this._onSubmit(event);
-  //   }
-  // }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Implement the _updateObject method as required by the parent class spec
-   * This defines how to update the subject of the form when the form is submitted
-   * @private
-   */
-  // _updateObject(event, formData) {
-  //   // Handle the free-form attributes list
-  //   const ford = expandObject(formData);
-  //   const formAttrs = expandObject(formData).data.attributes || {};
-  //   const attributes = Object.values(formAttrs).reduce((obj, v) => {
-  //     let k = v["key"].trim();
-  //     if (/[\s\.]/.test(k)) return ui.notifications.error("Attribute keys may not contain spaces or periods");
-  //     delete v["key"];
-  //     obj[k] = v;
-  //     return obj;
-  //   }, {});
-
-  //   // Remove attributes which are no longer used
-  //   for (let k of Object.keys(this.object.data.data.attributes)) {
-  //     if (!attributes.hasOwnProperty(k)) attributes[`-=${k}`] = null;
-  //   }
-
-  //   // Re-combine formData
-  //   formData = Object.entries(formData).filter(e => !e[0].startsWith("data.attributes")).reduce((obj, e) => {
-  //     obj[e[0]] = e[1];
-  //     return obj;
-  //   }, { _id: this.object._id, "data.attributes": attributes });
-
-  //   // Update the Item
-  //   return this.object.update(formData);
-  // }
 }

--- a/module/items/sheets/item-sheetV2.js
+++ b/module/items/sheets/item-sheetV2.js
@@ -34,10 +34,7 @@ export class CoC7ItemSheetV2 extends ItemSheet {
 
   /** @override */
   get template () {
-    if (this.item.data.type === 'item')
-      return 'systems/CoC7/templates/items/item-sheetV2.html'
-    const path = 'systems/CoC7/templates/items'
-    return `${path}/${this.item.data.type}-sheet.html`
+    return 'systems/CoC7/templates/items/item-sheetV2.html'
   }
 
   /* -------------------------------------------- */

--- a/module/items/sheets/occupation.js
+++ b/module/items/sheets/occupation.js
@@ -69,14 +69,16 @@ export class CoC7OccupationSheet extends ItemSheet {
     if (optionalSkill) {
       if (!CoC7Item.isAnySpec(item)) {
         // Generic specialization can be included many times
-        if (this.item.data.data.skills.find(el => el.name === item.data.name))
+        if (this.item.data.data.skills.find(el => el.name === item.data.name)) {
           return // If skill is already in main don't add it
+        }
         if (
           this.item.data.data.groups[index].skills.find(
             el => el.name === item.name
           )
-        )
+        ) {
           return // If skill is already in group don't add it
+        }
       }
 
       const groups = duplicate(this.item.data.data.groups)
@@ -85,8 +87,9 @@ export class CoC7OccupationSheet extends ItemSheet {
     } else {
       if (!CoC7Item.isAnySpec(item)) {
         // Generic specialization can be included many times
-        if (this.item.data.data.skills.find(el => el.name === item.data.name))
+        if (this.item.data.data.skills.find(el => el.name === item.data.name)) {
           return
+        }
 
         for (let i = 0; i < this.item.data.data.groups.length; i++) {
           // If the same skill is in one of the group remove it from the groups
@@ -191,7 +194,6 @@ export class CoC7OccupationSheet extends ItemSheet {
       classes: ['coc7', 'sheet', 'occupation'],
       width: 520,
       height: 480,
-      resizable: false,
       dragDrop: [{ dragSelector: '.item' }],
       scrollY: ['.tab.description'],
       tabs: [
@@ -235,10 +237,12 @@ export class CoC7OccupationSheet extends ItemSheet {
     )) {
       if (carac.multiplier) {
         const caracName = game.i18n.localize(`CHARAC.${key.toUpperCase()}`)
-        if (carac.selected && carac.optional)
+        if (carac.selected && carac.optional) {
           optionnal.push(`${caracName}x${carac.multiplier}`)
-        if (carac.selected && !carac.optional)
+        }
+        if (carac.selected && !carac.optional) {
           mandatory.push(`${caracName}x${carac.multiplier}`)
+        }
       }
     }
 
@@ -282,18 +286,21 @@ export class CoC7OccupationSheet extends ItemSheet {
     data.occupationPointsString = ''
     const orString = ` ${game.i18n.localize('CoC7.Or')} `
     if (mandatory.length) data.occupationPointsString += mandatory.join(' + ')
-    if (optionnal.length && mandatory.length)
+    if (optionnal.length && mandatory.length) {
       data.occupationPointsString += ` + (${optionnal.join(orString)})`
-    if (optionnal.length && !mandatory.length)
+    }
+    if (optionnal.length && !mandatory.length) {
       data.occupationPointsString += optionnal.join(orString)
+    }
 
     data.itemProperties = []
 
     for (const [key, value] of Object.entries(data.data.type)) {
-      if (value)
+      if (value) {
         data.itemProperties.push(
           COC7.occupationProperties[key] ? COC7.occupationProperties[key] : null
         )
+      }
     }
     return data
   }

--- a/module/items/sheets/setup.js
+++ b/module/items/sheets/setup.js
@@ -61,12 +61,16 @@ export class CoC7SetupSheet extends ItemSheet {
       item = game.items.get(data.id)
     }
     if (!item || !item.data) return
-    if (!['item', 'weapon', 'skill', 'book', 'spell'].includes(item.data.type))
+    if (
+      !['item', 'weapon', 'skill', 'book', 'spell'].includes(item.data.type)
+    ) {
       return
+    }
 
     if (!CoC7Item.isAnySpec(item)) {
-      if (this.item.data.data.items.find(el => el.name === item.data.name))
+      if (this.item.data.data.items.find(el => el.name === item.data.name)) {
         return
+      }
     }
 
     const collection = this.item.data.data[collectionName]
@@ -146,7 +150,6 @@ export class CoC7SetupSheet extends ItemSheet {
       classes: ['coc7', 'sheet', 'setup'],
       width: 520,
       height: 530,
-      resizable: false,
       dragDrop: [{ dragSelector: '.item' }],
       scrollY: ['.tab.description'],
       tabs: [

--- a/module/items/sheets/skill.js
+++ b/module/items/sheets/skill.js
@@ -34,10 +34,7 @@ export class CoC7SkillSheet extends ItemSheet {
 
   /** @override */
   get template () {
-    if (this.item.data.type === 'item')
-      return 'systems/CoC7/templates/items/item-sheetV2.html'
-    const path = 'systems/CoC7/templates/items'
-    return `${path}/${this.item.data.type}-sheet.html`
+    return `systems/CoC7/templates/items/${this.item.data.type}-sheet.html`
   }
 
   /* -------------------------------------------- */

--- a/module/items/sheets/spell.js
+++ b/module/items/sheets/spell.js
@@ -15,7 +15,6 @@ export class CoC7SpellSheet extends ItemSheet {
       classes: ['coc7', 'sheet', 'spell'],
       width: 520,
       height: 480,
-      resizable: false,
       scrollY: ['.tab.description'],
       tabs: [
         {
@@ -48,34 +47,41 @@ export class CoC7SpellSheet extends ItemSheet {
 
     data.castingCost = ''
 
-    if (data.data.cost.mp)
+    if (data.data.cost.mp) {
       data.castingCost += `${data.data.cost.mp} ${game.i18n.localize(
         'CoC7.MP'
       )};`
-    if (data.data.cost.san)
+    }
+    if (data.data.cost.san) {
       data.castingCost += `${data.data.cost.san} ${game.i18n.localize(
         'CoC7.SAN'
       )};`
-    if (data.data.cost.pow)
+    }
+    if (data.data.cost.pow) {
       data.castingCost += `${data.data.cost.pow} ${game.i18n.localize(
         'CHARAC.POW'
       )};`
-    if (data.data.cost.hp)
+    }
+    if (data.data.cost.hp) {
       data.castingCost += `${data.data.cost.hp} ${game.i18n.localize(
         'CoC7.HP'
       )};`
+    }
     if (data.data.cost.other) data.castingCost += `${data.data.cost.other};`
-    if (data.castingCost.length)
+    if (data.castingCost.length) {
       data.castingCost = data.castingCost.slice(0, -1)
-    else data.castingCost = game.i18n.localize('CoC7.SpellCastingCost')
+    } else {
+      data.castingCost = game.i18n.localize('CoC7.SpellCastingCost')
+    }
 
     data.itemProperties = []
 
     for (const [key, value] of Object.entries(data.data.type)) {
-      if (value)
+      if (value) {
         data.itemProperties.push(
           COC7.spellProperties[key] ? COC7.spellProperties[key] : null
         )
+      }
     }
     return data
   }

--- a/module/items/sheets/status.js
+++ b/module/items/sheets/status.js
@@ -15,7 +15,6 @@ export class CoC7StatusSheet extends ItemSheet {
       classes: ['coc7', 'sheet', 'status'],
       width: 520,
       height: 480,
-      resizable: false,
       scrollY: ['.tab.description'],
       tabs: [
         {
@@ -49,10 +48,11 @@ export class CoC7StatusSheet extends ItemSheet {
     data.itemProperties = []
 
     for (const [key, value] of Object.entries(data.data.type)) {
-      if (value)
+      if (value) {
         data.itemProperties.push(
           COC7.statusType[key] ? COC7.statusType[key] : null
         )
+      }
     }
     return data
   }

--- a/module/items/sheets/talent.js
+++ b/module/items/sheets/talent.js
@@ -15,7 +15,6 @@ export class CoC7TalentSheet extends ItemSheet {
       classes: ['coc7', 'sheet', 'talent'],
       width: 520,
       height: 480,
-      resizable: false,
       scrollY: ['.tab.description'],
       tabs: [
         {
@@ -49,10 +48,11 @@ export class CoC7TalentSheet extends ItemSheet {
     data.itemProperties = []
 
     for (const [key, value] of Object.entries(data.data.type)) {
-      if (value)
+      if (value) {
         data.itemProperties.push(
           COC7.talentType[key] ? COC7.talentType[key] : null
         )
+      }
     }
     return data
   }

--- a/styles/sheets/character.less
+++ b/styles/sheets/character.less
@@ -305,7 +305,7 @@
           }
 
           .restore-list-styles ul,
-          .restore-list-styles ol, {
+          .restore-list-styles ol {
             margin: 0.5em 0;
             padding: 0 0 0 1.5em;
           }

--- a/styles/sheets/character.less
+++ b/styles/sheets/character.less
@@ -304,6 +304,18 @@
             padding: 0;
           }
 
+          .restore-list-styles ul,
+          .restore-list-styles ol, {
+            margin: 0.5em 0;
+            padding: 0 0 0 1.5em;
+          }
+          .restore-list-styles ul {
+            list-style-type: disc;
+          }
+          .restore-list-styles ol {
+            list-style-type: decimal;
+          }
+
           .tab {
             height: 100%;
           }

--- a/templates/actors/character-sheet-v2.html
+++ b/templates/actors/character-sheet-v2.html
@@ -187,7 +187,7 @@
 						{{> "systems/CoC7/templates/actors/parts/actor-inventory.html"}}
 					</div>
 
-					<div class="tab coc7 sheet actor temp-retro-compat" data-group="primary" data-tab="background">
+					<div class="tab coc7 sheet actor temp-retro-compat restore-list-styles" data-group="primary" data-tab="background">
 						{{#if oneBlockBackStory}}
 							{{editor content=data.backstory target="data.backstory" button=true owner=owner editable=editable}}
 						{{else}}


### PR DESCRIPTION
## Description.
Add UL and OL styles to character backstory. Resolves #480
Change book, creature, npc, occupation, setup, spell, status, and talent sheets to be resizable Resolves #506

## Motivation and Context.
Replace item-sheet to extend item-sheetV2 to remove duplication of code.
Remove item-sheet template detection from skill template as it will never be called

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
