### PR TITLE
Remove unused script and devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "build": "webpack --mode production",
     "format": "prettier-standard --format --changed",
-    "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "husky install",
     "watch": "webpack --mode development",
     "translations": "node generate-translations.js"
@@ -32,11 +31,9 @@
     "less": "^4.1.1",
     "less-loader": "^10.0.1",
     "mini-css-extract-plugin": "^2.2.0",
-    "postcss": "^8.3.6",
     "prettier-standard": "^16.4.1",
     "terser-webpack-plugin": "^5.1.4",
     "thread-loader": "^3.0.4",
-    "uglifyjs-webpack-plugin": "^2.2.0",
     "webpack": "^5.50.0",
     "webpack-cli": "^4.8.0",
     "webpackbar": "^5.0.0-3",


### PR DESCRIPTION
## Description.
Packages uglifyjs-webpack-plugin and postcss are no longer used.
The remaining scripts appear to run without errors

## Motivation and Context.
uglifyjs-webpack-plugin is deprecated and no longer used but installed package versions with vulnerabilities

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to change).
