### PR TITLE
Change message type on update (Fix blind rolls)

### DIFF
--- a/module/check.js
+++ b/module/check.js
@@ -1420,7 +1420,7 @@ export class CoC7Check {
     if (this.rollMode === 'blindroll') chatData.blind = true
 
     // ChatMessage.applyRollMode( chatData, this.rollMode);
-    if (this.dice?.roll) {
+    if (this.dice?.roll && !this.dice?.hideDice) {
       chatData.roll = this.dice.roll
       chatData.type = CONST.CHAT_MESSAGE_TYPES.ROLL
       chatData.rollMode = this.isBlind ? 'blindroll' : this.rollMode
@@ -1454,6 +1454,12 @@ export class CoC7Check {
     }
 
     const chatData = { flavor: this.flavor, content: newContent }
+    if (CONST.CHAT_MESSAGE_TYPES.ROLL == message.data.type) {
+      if (message.data.whisper?.length)
+        chatData.type = CONST.CHAT_MESSAGE_TYPES.WHISPER
+      else chatData.type = CONST.CHAT_MESSAGE_TYPES.OTHER
+    }
+
     if (makePublic) {
       chatData.whisper = []
       chatData.blind = false

--- a/module/dice.js
+++ b/module/dice.js
@@ -29,6 +29,8 @@ export class CoC7Dice {
       total: 0,
       roll: roll
     }
+    if (rollMode) result.rollMode = rollMode
+    if (hideDice) result.hideDice = hideDice
     roll.dice.forEach(d => {
       if (d instanceof CONFIG.Dice.terms.t) {
         result.tens.results.push(d.total)


### PR DESCRIPTION
Fix blind GM rolls

## Description.
Force pass and fail will now display correctly Fail or Pass to the player
Reveal check will reveal the check to the player (whisper)
CTRL+Reveal check will reveal the check to everyone

## Motivation and Context.
Blind GM rolls were not displayed properly

## Screenshots.

<!-- If appropriate. -->

## Types of Changes.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
