### PR TITLE
Add configuration information for VS Code

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -77,7 +77,7 @@ When prompted, enter your Github credentials.
 
 ### Initial Setup.
 
-Preferably, open your brand new local repository in the Integrated Development Environment (IDE) of your choice. We recommend [Visual Studio Code](https://code.visualstudio.com/download).
+Preferably, open your brand new local repository in the Integrated Development Environment (IDE) of your choice. We recommend [Visual Studio Code](#Visual-Studio-Code).
 
 Still in the terminal, install the project dependencies running: `npm install`
 
@@ -122,3 +122,15 @@ This way, Webpack and other dependencies will know whenever you make any relevan
 ### Your First Code Contribution.
 
 Unsure where to begin contributing? You can start by looking through these `beginner` and `help-wanted` issues!
+
+## IDE Configuration
+
+### Visual Studio Code
+
+Install [Visual Studio Code](https://code.visualstudio.com/download).
+
+Install extension [standard.vscode-standard](https://marketplace.visualstudio.com/items?itemName=standard.vscode-standard).
+
+Configure the extension Tick `Standard: Auto Fix On Save`
+
+Before committing your code run `npm run format`

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "webpack --mode production",
     "format": "prettier-standard --format --changed",
+    "lint": "prettier-standard --lint --changed",
     "prepare": "husky install",
     "watch": "webpack --mode development",
     "translations": "node generate-translations.js"
@@ -32,6 +33,7 @@
     "less-loader": "^10.0.1",
     "mini-css-extract-plugin": "^2.2.0",
     "prettier-standard": "^16.4.1",
+    "standard": "^16.0.3",
     "terser-webpack-plugin": "^5.1.4",
     "thread-loader": "^3.0.4",
     "webpack": "^5.50.0",


### PR DESCRIPTION
Running ```npm run format``` only corrects formatting issues. Coding standing standards are not enforced

## Description.
Add configuration information for Visual Studio Code to automatically indicate issues with the code.
I've not been able to find a linter that runs prettier-standard only formatters.
The extension listed will lint against standard and running ```npm run format``` before commit will fix the spaces
Additionally add a ```npm run lint``` command

## Motivation and Context.
Coding standing standards are not applied by ```npm run format```

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
