### PR TITLE
Add message to character sheet when in investigator development / creation

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -390,6 +390,7 @@
   "CoC7.DevFailure": "{item} NOT upgraded ({die}/{score}%)",
   "CoC7.LuckIncreased": "Luck recovered ({die}/{score}) by {augment} points",
   "CoC7.LuckNotIncreased": "Luck NOT recovered ({die}/{score})",
+  "CoC7.DevelopAttribWarn": "You can not access some attributes in development/creation",
   "CoC7.SkillDetail": "Detail",
   "CoC7.EditSkill": "Edit skill",
   "CoC7.DeleteSkill": "Delete skill",

--- a/module/scripts/register-settings.js
+++ b/module/scripts/register-settings.js
@@ -406,7 +406,7 @@ export function registerSettings () {
     scope: 'world',
     config: false,
     type: Number,
-    default: '0.3'
+    default: '0.2'
   })
   game.settings.register('CoC7', 'xpEnabled', {
     name: 'Enable XP gain',

--- a/styles/sheets/development.less
+++ b/styles/sheets/development.less
@@ -27,6 +27,13 @@
     .validation {
       margin-top: 8px;
     }
+
+    .missing-attrib-warning {
+      white-space: normal;
+      line-height: 1;
+      font-size: 90%;
+      margin-top: 5px;
+    }
   }
 
   .development {

--- a/templates/actors/parts/development-controls.html
+++ b/templates/actors/parts/development-controls.html
@@ -86,4 +86,6 @@
         </div>
         {{/if}}
     </div>
+
+    <label class="missing-attrib-warning">{{localize 'CoC7.DevelopAttribWarn'}}</label>
 </div>


### PR DESCRIPTION
## Motivation and Context.
A common question about the character sheet is missing hp and luck, add a small message to the page to indicate they are hidden due to "Development phase enabled" and/or "Character creation mode enabled"

## Screenshots.
![message](https://user-images.githubusercontent.com/43982555/131919995-d9b018fc-eaaf-46e2-a6d8-a989552e588f.jpg)

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
