### PR TITLE
Prevent rolling on compendium Actors

### DIFF
--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -709,7 +709,7 @@ export class CoC7ActorSheet extends ActorSheet {
     super.activateListeners(html)
 
     // Owner Only Listeners
-    if (this.actor.isOwner) {
+    if (this.actor.isOwner && this.actor.compendium === 'undefined') {
       html
         .find('.characteristic-label')
         .on('dragstart', event => this._onDragCharacteristic(event))


### PR DESCRIPTION
## Description.
Attempting to roll from a compendium Actor causes a JavaScript error, disable sheet listeners

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to change).
