### PR TITLE
Fix JavaScript errors/issues

### DIFF
--- a/module/actors/sheets/character.js
+++ b/module/actors/sheets/character.js
@@ -80,7 +80,7 @@ export class CoC7CharacterSheetV2 extends CoC7CharacterSheet {
         ) {
           let styleSheet, cssRuleIndex
           for (let i = 0; i < document.styleSheets.length; i++) {
-            if (document.styleSheets[i].href.endsWith('coc7g.css')) {
+            if (document.styleSheets[i].href?.endsWith('coc7g.css')) {
               styleSheet = document.styleSheets[i]
               break
             }

--- a/module/apps/char-roll-dialog.js
+++ b/module/apps/char-roll-dialog.js
@@ -155,8 +155,8 @@ export class CharacRollDialog extends Dialog {
     const validation = this._element[0].querySelector('.points')
     if (this.data.data.characteristics.points.enabled) {
       if (
-        this.data.data.characteristics.points.total !==
-        this.data.data.characteristics.points.value
+        Number(this.data.data.characteristics.points.total) !==
+        Number(this.data.data.characteristics.points.value)
       ) {
         validation.classList.add('warning')
       } else {


### PR DESCRIPTION
## Description.
Dropping a point buy Setup item doesn't allow you to validate as types are not the same.
JavaScript errors when Override Sheet Artwork is enable, Background type is not slice, and an inline style tag has been added

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
