### PR TITLE
Unnecessary changes to armour calculations

### DIFF
--- a/module/chat/cards/damage.js
+++ b/module/chat/cards/damage.js
@@ -73,11 +73,13 @@ export class DamageCard extends InteractiveChatCard {
       this.isDamageNumber ? this.damageFormula : this.roll.total
     )
     if (!this.ignoreArmor) {
-      if (!isNaN(Number(this.armor)) && damage - Number(this.armor) <= 0) {
-        return game.i18n.localize('CoC7.ArmorAbsorbsDamage')
-      }
       if (isNaN(Number(this.armor)) || Number(this.armor) > 0) {
         damage = damage - Number(this.armor)
+      }
+      if (!isNaN(Number(this.armor))) {
+        if (damage <= 0) {
+          return game.i18n.localize('CoC7.ArmorAbsorbsDamage')
+        }
       }
     }
     return damage
@@ -88,11 +90,11 @@ export class DamageCard extends InteractiveChatCard {
       const damage = this.isDamageNumber ? this.damageFormula : this.roll.total
       if (!this.ignoreArmor) {
         if (!isNaN(Number(this.armor))) {
-          return damage - Number(this.armor) <= 0
+          return !!(damage - Number(this.armor) <= 0)
         }
         return false
       } else {
-        return damage <= 0
+        return !!(damage <= 0)
       }
     } else return false
   }
@@ -202,12 +204,17 @@ export class DamageCard extends InteractiveChatCard {
 
   async dealDamage (options = { update: true }) {
     if (this.isArmorForula) await this.rollArmor()
-    if (isNaN(Number(this.totalDamageString))) {
-      ui.notifications.error('Error evaluating damage')
-      return
+    let damage = this.totalDamageString
+    if (isNaN(Number(damage))) {
+      if (game.i18n.localize('CoC7.ArmorAbsorbsDamage') === damage) {
+        damage = 0
+      } else {
+        ui.notifications.error('Error evaluating damage')
+        return
+      }
     }
     if (this.targetActor) {
-      await this.targetActor.dealDamage(Number(this.totalDamageString), {
+      await this.targetActor.dealDamage(Number(damage), {
         ignoreArmor: true
       })
     }

--- a/templates/chat/cards/damage.html
+++ b/templates/chat/cards/damage.html
@@ -73,16 +73,12 @@
         {{!-- <div class='card-result'>Damage roll: {{{_htmlInlineRoll}}}</div> --}}
         {{{_htmlRoll}}}
         {{#if targetKey}}
-            {{#if noDamage}}
-                {{localize 'CoC7.NoDamage'}}            
+            {{#if damageInflicted}}
+                <div class='card-result'>{{ localize 'CoC7.DamageInflicted'}} : {{totalDamageString}}</div>
             {{else}}
-                {{#if damageInflicted}}
-                    <div class='card-result'>{{ localize 'CoC7.DamageInflicted'}} : {{totalDamageString}}</div>
-                {{else}}
-                    <div class="card-buttons gm-visible-only">
-                        <button data-action="dealDamage">{{ localize 'CoC7.InflictPain' }} ({{totalDamageString}})</button>
-                    </div>
-                {{/if}}
+                <div class="card-buttons gm-visible-only">
+                    <button data-action="dealDamage">{{ localize 'CoC7.InflictPain' }} ({{totalDamageString}})</button>
+                </div>
             {{/if}}
         {{else}}
         <div class='card-result'>{{ localize 'CoC7.TotalDamage' }} : {{totalDamageString}}
@@ -92,7 +88,7 @@
                     <i class="fas fa-user-minus noRemove"></i>
                 </button>
             </span>
-            </div> 
+            </div>
         </div>
         {{/if}}
     {{else}}
@@ -103,19 +99,19 @@
 
     <!-- <div class="flexrow gm-select-only ic-radio">
         <span class="flex1 ic-radio-switch gm-select-only {{#if advantageAttacker}}switched-on{{/if}} "
-        title="{{localize CoC7.AdvantageAttacker}}" 
-        data-flag="advantageAttacker" 
+        title="{{localize CoC7.AdvantageAttacker}}"
+        data-flag="advantageAttacker"
         data-selected={{advantageAttacker}}>{{localize 'CoC7.AdvantageAttacker'}}</span>
         <span class="flex1 ic-radio-switch gm-select-only {{#if advantageDefender}}switched-on{{/if}}"
-        title="{{localize CoC7.AdvantageDefender}}" 
-        data-flag="advantageDefender" 
+        title="{{localize CoC7.AdvantageDefender}}"
+        data-flag="advantageDefender"
         data-selected={{advantageDefender}}>{{localize 'CoC7.AdvantageDefender'}}</span>
     </div>
 
     <div class="flexrow">
         <span class="flex1 ic-switch gm-select-only {{#if switchTest}}switched-on{{/if}} "
-        title="{{localize CoC7.switchTest}}" 
-        data-flag="switchTest" 
+        title="{{localize CoC7.switchTest}}"
+        data-flag="switchTest"
         data-selected={{switchTest}}>{{localize 'CoC7.AdvantageAttacker'}}</span>
     </div> -->
 


### PR DESCRIPTION
Update noDamage to always return boolean
Remove missing 'CoC7.NoDamage' allow sending 'Damage inflicted : Armor absorbs total damage' to chat

## Description.
DamageCard.NoDamage now always return a boolean result
Update card message, clicking "Damage inflicted : Armor absorbs total damage" would show an error message and leave the chat message unresolvable, replace missing CoC7.NoDamage message with this message when clicked

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
