### PR TITLE
Fall back for copy to clipboard

### DIFF
--- a/module/apps/link-creation-dialog.js
+++ b/module/apps/link-creation-dialog.js
@@ -3,6 +3,7 @@ import { CoCActor } from '../actors/actor.js'
 import { chatHelper } from '../chat/helper.js'
 import { CoC7Check } from '../check.js'
 import { CoC7Link } from './link.js'
+import { CoC7Utilities } from '../utilities.js'
 
 export class CoC7LinkCreationDialog extends FormApplication {
   /** @override */
@@ -203,7 +204,7 @@ export class CoC7LinkCreationDialog extends FormApplication {
     }
     switch (action) {
       case 'clipboard':
-        navigator.clipboard.writeText(this.link.link)
+        CoC7Utilities.copyToClipboard(this.link.link)
         break
 
       case 'chat':

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -639,4 +639,27 @@ export class CoC7Utilities {
       return []
     }
   }
+
+  static async copyToClipboard (text) {
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        return navigator.clipboard.writeText(text)
+      } else {
+        const textArea = document.createElement('textarea')
+        textArea.value = text
+        textArea.style.position = 'fixed'
+        textArea.style.left = '-999px'
+        textArea.style.top = '-999px'
+        document.body.appendChild(textArea)
+        textArea.focus()
+        textArea.select()
+        return new Promise((resolve, reject) => {
+          document.execCommand('copy') ? resolve() : reject(new Error('Unable to copy to clipboard, this is likely due to your browser security settings.'))
+          textArea.remove()
+        }).catch(err => ui.notifications.error(err))
+      }
+    } catch (err) {
+      ui.notifications.error('Unable to copy to clipboard, this is likely due to your browser security settings.')
+    }
+  }
 }


### PR DESCRIPTION
## Description.
When not on https or localhost navigator.clipboard.writeText does not work. Create multiple fall back steps and show an error message if unable to copy to clipboard

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
