### PR TITLE
Fix opposed check JavaScript error if one of the Actors has been deleted

### DIFF
--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -3350,7 +3350,7 @@ export class CoCActor extends Actor {
 
   get characterUser () {
     return (
-      game.users.entities.filter(u => u.character?.id === this.id)[0] || null
+      game.users.contents.filter(u => u.character?.id === this.id)[0] || null
     )
   }
 

--- a/module/apps/parser.js
+++ b/module/apps/parser.js
@@ -80,7 +80,7 @@ export class CoC7Parser {
       if (data.pack) {
         const pack = game.packs.get(data.pack)
         if (pack.metadata.entity !== 'Item') return
-        item = await pack.getEntity(data.id)
+        item = await pack.getDocument(data.id)
       } else if (data.data) {
         item = data.data
       } else {

--- a/module/check.js
+++ b/module/check.js
@@ -1340,7 +1340,7 @@ export class CoC7Check {
   get flavor () {
     if (this._flavor) return this._flavor
     let flavor = ''
-    if (this.actor) {
+    if (this.actor?.data) {
       if (this.skill) {
         flavor = game.i18n.format('CoC7.CheckResult', {
           name: this.skill.name,

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -338,7 +338,7 @@ export class CoC7Utilities {
       const pack = game.packs.get(data.pack)
       if (pack.metadata.entity !== 'Item') return
       packName = data.pack
-      item = await pack.getEntity(data.id)
+      item = await pack.getDocument(data.id)
       origin = 'pack'
     } else if (data.data) {
       item = data.data
@@ -362,7 +362,7 @@ export class CoC7Utilities {
     let command
 
     if (item.type === 'weapon') {
-      command = `game.CoC7.macros.weaponCheck({name:'${item.name}', id:'${item._id}', origin:'${origin}', pack: '${packName}'}, event);`
+      command = `game.CoC7.macros.weaponCheck({name:'${item.name}', id:'${item.id}', origin:'${origin}', pack: '${packName}'}, event);`
     }
 
     if (item.type === 'skill') {
@@ -371,11 +371,11 @@ export class CoC7Utilities {
           game.i18n.localize('CoC7.WarnNoGlobalSpec')
         )
       }
-      command = `game.CoC7.macros.skillCheck({name:'${item.name}', id:'${item._id}', origin:'${origin}', pack: '${packName}'}, event);`
+      command = `game.CoC7.macros.skillCheck({name:'${item.name}', id:'${item.id}', origin:'${origin}', pack: '${packName}'}, event);`
     }
 
     // Create the macro command
-    let macro = game.macros.entities.find(
+    let macro = game.macros.contents.find(
       m => m.name === item.name && m.command === command
     )
     if (!macro) {
@@ -626,7 +626,7 @@ export class CoC7Utilities {
         if (dataList.pack) {
           const pack = game.packs.get(dataList.pack)
           if (pack.metadata.entity !== entityType) return []
-          return [await pack.getEntity(dataList.id)]
+          return [await pack.getDocument(dataList.id)]
         } else if (dataList.data) {
           return [dataList]
         } else {


### PR DESCRIPTION
## Description.
Fix error "check.js:1360 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'data')" if you have a deleted character in an open opposed check

Fix some 0.9.0 warnings WorldCollection#entities / Collection#contents, CompendiumCollection#getEntity / CompendiumCollection#getDocument, and Document#_id / Document#id

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
