### PR TITLE
Combined and opposed rolls timeout and deleted Actor fixes

### DIFF
--- a/module/chat/cards/combined-roll.js
+++ b/module/chat/cards/combined-roll.js
@@ -218,7 +218,7 @@ export class CombinedCheckCard extends RollCard {
     }
 
     this.rolls = this.rolls.filter(roll => {
-      return !!roll.actor
+      return (typeof roll.actor.data !== 'undefined') // Check if there's an actor set and if there's one and it doesnt exist remove him.
     })
 
     this._htmlRoll = await this.getHtmlRoll()

--- a/module/chat/cards/opposed-roll.js
+++ b/module/chat/cards/opposed-roll.js
@@ -325,9 +325,9 @@ export class OpposedCheckCard extends RollCard {
       }
     }
 
-    // this.rolls = this.rolls.filter( roll => {
-    //   return !!roll.actor;//Check if there's an actor set and if there's one and it doesnt exist remove him.
-    // });
+    this.rolls = this.rolls.filter(roll => {
+      return (typeof roll.actor.data !== 'undefined') // Check if there's an actor set and if there's one and it doesnt exist remove him.
+    })
 
     if (this.combat) {
       // Sort combat rolls by index.

--- a/module/chat/cards/roll-card.js
+++ b/module/chat/cards/roll-card.js
@@ -67,7 +67,7 @@ export class RollCard {
 
   static async dispatch (data) {
     if (game.user.isGM) {
-      const messages = ui.chat.collection.filter(message => {
+      let messages = ui.chat.collection.filter(message => {
         if (
           this.defaultConfig.type === message.getFlag('CoC7', 'type') &&
           message.getFlag('CoC7', 'state') !== 'resolved'
@@ -77,11 +77,16 @@ export class RollCard {
         return false
       })
 
-      // if( messages.length){
-      //   const timestamp = new Date( messages[0].data.timestamp);
-      //   const now = new Date();
-      //   const timeDiffSec = (now - timestamp) / 1000;
-      // }
+      if (messages.length) {
+        // Old messages can't be used if message is more than a day old mark it as resolved
+        const timestamp = new Date(messages[0].data.timestamp)
+        const now = new Date()
+        const timeDiffSec = (now - timestamp) / 1000
+        if (24 * 60 * 60 < timeDiffSec) {
+          await messages[0].setFlag('CoC7', 'state', 'resolved')
+          messages = []
+        }
+      }
 
       let card
       if (!messages.length) card = new this()


### PR DESCRIPTION
Filter out deleted actors from combined and opposed rolls
If combined / opposed messages are older than 24 hours mark them as resolved to force a new one to be created as older messages can not be edited, duration may need reduced.

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to change).
