### PR TITLE
Add tyni MCE custom style : keeper only

### DIFF
--- a/assets/mce.css
+++ b/assets/mce.css
@@ -1,0 +1,7 @@
+section.keeper-only {
+    padding: 0 5px;
+    background: rgba(0, 255, 0, 0.05);
+    border-top: 1px solid #666;
+    border-bottom: 1px solid #666;
+  }
+  

--- a/module/apps/parser.js
+++ b/module/apps/parser.js
@@ -120,6 +120,11 @@ export class CoC7Parser {
     }
   }
 
+  static async onInitEditor (editor) {
+    // editor con
+    ui.notifications.info('EDITOR IS INITIATED')
+  }
+
   static ParseMessage (
     message,
     html,
@@ -212,6 +217,16 @@ export class CoC7Parser {
       }
     }
 
+    for (const element of html.find('.keeper-only')) {
+      if (!game.user.isGM) element.style.display = 'none'
+    }
+
+    // for (const element of html.find('div.editor-content')){
+    //   if (element.outerHTML.toLocaleLowerCase().includes('[gm-only]')){
+    //     element.outerHTML = CoC7Parser.procesGMOnly( element.outerHTML)
+    //   }
+    // }
+
     // Bind the click to execute the check.
     // html.on('click', 'a.coc7-link', CoC7Parser._onCheck.bind(this));
     html
@@ -249,6 +264,30 @@ export class CoC7Parser {
     TextEditor._replaceTextContent(text, rgx, CoC7Parser._createLink)
     return html.innerHTML
   }
+
+  // static procesGMOnly (content){
+  //   // const gmOnlyRgx = new RegExp(
+  //   //   '(?:\[gm-only\])(.|\n)*?(?:\[\/gm-only\])',
+  //   //   'gi'
+  //   // )
+
+  //   let replaced = content
+
+  //   const searchAndReplace = [
+  //     { search: '<p>[gm-only]', replace: '<div class="gm-secret"><p>'},
+  //     { search: '[/gm-only]</p>', replace: '</p></div>'},
+  //     { search: '[gm-only]', replace: '<div class="gm-secret>'},
+  //     { search: '[/gm-only]', replace: '</div'}
+  //   ]
+
+  //   searchAndReplace.forEach( e => {
+  //     const esc = e.search.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+  //     const searchRegEx = new RegExp(esc, 'ig')
+  //     replaced = replaced.replaceAll( searchRegEx, e.replace)
+  //   })
+
+  //   return content
+  // }
 
   static bindEventsHandler (html) {
     html

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -211,6 +211,22 @@ Hooks.on('ready', async () => {
 
   activateGlobalListener()
 
+  // setGlobalCssVar()
+  if (game.user.isGM) {
+    CONFIG.TinyMCE.content_css.push('/systems/CoC7/assets/mce.css')
+    CONFIG.TinyMCE.style_formats.push({
+      title: 'CoC7',
+      items: [
+        {
+          title: 'Keeper Only',
+          block: 'section',
+          classes: 'keeper-only',
+          wrapper: true
+        }
+      ]
+    })
+  } else CONFIG.TinyMCE.content_style = '.keeper-only {display: none}'
+
   game.socket.on('system.CoC7', async data => {
     if (data.type === 'updateChar') CoC7Utilities.updateCharSheets()
 
@@ -397,6 +413,11 @@ tinyMCE.PluginManager.add('CoC7_Editor_OnDrop', function (editor) {
   editor.on('drop', event => CoC7Parser.onEditorDrop(event, editor))
 })
 
+// tinyMCE.PluginManager.add('CoC7_Editor_OnInit', function (editor) {
+//   editor.on('init', () => CoC7Parser.onInitEditor( editor))
+// })
+
+// CONFIG.TinyMCE.plugins = `CoC7_Editor_OnInit CoC7_Editor_OnDrop ${CONFIG.TinyMCE.plugins}`
 CONFIG.TinyMCE.plugins = `CoC7_Editor_OnDrop ${CONFIG.TinyMCE.plugins}`
 
 function activateGlobalListener () {
@@ -404,6 +425,11 @@ function activateGlobalListener () {
   body.on('click', 'a.coc7-inline-check', CoC7Check._onClickInlineRoll)
   document.addEventListener('mousedown', _onLeftClick)
 }
+
+// function setGlobalCssVar(){
+//   const body = $('body')
+//   body.css('--keeper-display', game.user.isGM ? '' : 'none')
+// }
 
 function _onLeftClick (event) {
   return event.shiftKey

--- a/system.json
+++ b/system.json
@@ -8,7 +8,7 @@
   "compatibleCoreVersion": "0.8.9",
   "esmodules": ["bundle.js"],
   "templateVersion": 1,
-  "styles": ["style.css"],
+  "styles": ["style.css", "assets/mce.css"],
   "packs": [
     {
       "label": "Skills",


### PR DESCRIPTION
Add custom option in tinyMCE editors

## Description.

This add a new style when formatting an editor block.
When this style is applied to a section only the GM will be able to see and edit that section.

## Motivation and Context.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->

## Screenshots.
Keeper view :
Menu and edit
![image](https://user-images.githubusercontent.com/65915923/132261756-5383a9c4-7dba-4202-82eb-9680935c0526.png)
Final
![image](https://user-images.githubusercontent.com/65915923/132261792-3e8bcf89-552c-4a91-a01c-3d976c9b8701.png)


Player view:
Menu and edit
![image](https://user-images.githubusercontent.com/65915923/132261801-40f8be86-2980-462f-be8e-8d1593a9052c.png)
Final
![image](https://user-images.githubusercontent.com/65915923/132261812-106b8624-0fce-4d79-a43e-25480911c0b5.png)

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
