### PR TITLE
Fix item.base immediate returns

### DIFF
--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -308,11 +308,11 @@ export class CoC7ActorSheet extends ActorSheet {
                 : 0
               let updatedExp = exp + parseInt(item.data.value) - skill.value
               if (updatedExp <= 0) updatedExp = null
-              await this.actor.updateEmbeddedEntity('OwnedItem', {
+              await this.actor.updateEmbeddedDocuments('Item', [{
                 _id: item._id,
                 'data.adjustments.experience': updatedExp,
                 'data.value': null
-              })
+              }])
               if (!item.data.adjustments) item.data.adjustments = {}
               item.data.adjustments.experience = updatedExp
               item.data.value = value

--- a/module/items/item.js
+++ b/module/items/item.js
@@ -545,8 +545,8 @@ export class CoC7Item extends Item {
   }
 
   get _base () {
-    if (this.type !== 'skill') return null
-    if (typeof this.data.data.base !== 'string') return this.data.data.base
+    if (this.type !== 'skill') return [null, false]
+    if (typeof this.data.data.base !== 'string') return [this.data.data.base, false]
     if (this.data.data.base.includes('@')) {
       const parsed = {}
       for (const [key, value] of Object.entries(COC7.formula.actorsheet)) {


### PR DESCRIPTION
Further updates for Foundry 0.9

## Description.
Further issues caused with async base calculations when returning immediately were not returning arrays

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
