### PR TITLE
Configure TinyMCE and disable source code editing

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -798,6 +798,8 @@
   "SETTINGS.AdviseAllPlayer": "Notify all players",
   "SETTINGS.OneBlockBackStory": "One block backstory",
   "SETTINGS.OneBlockBackStoryHint": "Turn backstory to one editor block, but you can format/add links.",
+  "SETTINGS.EnablePlayerSourceCode": "Enable code editing for players.",
+  "SETTINGS.EnablePlayerSourceCodeyHint": "!WARNING! When Enabling this, players will be able to see and edit 'keeper only' blocks.",
   "SETTINGS.EnableStatusIcons": "Enable status icons",
   "SETTINGS.EnableStatusIconsHint": "Set if combat and sanity effects icons are shown in tokens."
 }

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -212,20 +212,8 @@ Hooks.on('ready', async () => {
   activateGlobalListener()
 
   // setGlobalCssVar()
-  if (game.user.isGM) {
-    CONFIG.TinyMCE.content_css.push('/systems/CoC7/assets/mce.css')
-    CONFIG.TinyMCE.style_formats.push({
-      title: 'CoC7',
-      items: [
-        {
-          title: 'Keeper Only',
-          block: 'section',
-          classes: 'keeper-only',
-          wrapper: true
-        }
-      ]
-    })
-  } else CONFIG.TinyMCE.content_style = '.keeper-only {display: none}'
+
+  configureTinyMCE()
 
   game.socket.on('system.CoC7', async data => {
     if (data.type === 'updateChar') CoC7Utilities.updateCharSheets()
@@ -409,21 +397,51 @@ Hooks.on('renderSceneControls', CoC7Menu.renderMenu)
 
 Hooks.on('dropCanvasData', CoC7Canvas.onDropSomething)
 
-tinyMCE.PluginManager.add('CoC7_Editor_OnDrop', function (editor) {
-  editor.on('drop', event => CoC7Parser.onEditorDrop(event, editor))
-})
-
-// tinyMCE.PluginManager.add('CoC7_Editor_OnInit', function (editor) {
-//   editor.on('init', () => CoC7Parser.onInitEditor( editor))
-// })
-
-// CONFIG.TinyMCE.plugins = `CoC7_Editor_OnInit CoC7_Editor_OnDrop ${CONFIG.TinyMCE.plugins}`
-CONFIG.TinyMCE.plugins = `CoC7_Editor_OnDrop ${CONFIG.TinyMCE.plugins}`
-
 function activateGlobalListener () {
   const body = $('body')
   body.on('click', 'a.coc7-inline-check', CoC7Check._onClickInlineRoll)
   document.addEventListener('mousedown', _onLeftClick)
+}
+
+/**
+ * Configuration of TinyMCE editor
+ */
+function configureTinyMCE () {
+
+  // Add on drop event to tinyMCE to hendle the links drop
+  tinyMCE.PluginManager.add('CoC7_Editor_OnDrop', function (editor) {
+    editor.on('drop', event => CoC7Parser.onEditorDrop(event, editor))
+  })
+
+  // Intercept MCE init
+  // tinyMCE.PluginManager.add('CoC7_Editor_OnInit', function (editor) {
+  //   editor.on('init', () => CoC7Parser.onInitEditor( editor))
+  // })
+
+  // Add custom plugins to list of plugins.
+  // CONFIG.TinyMCE.plugins = `CoC7_Editor_OnInit CoC7_Editor_OnDrop ${CONFIG.TinyMCE.plugins}`
+  CONFIG.TinyMCE.plugins = `CoC7_Editor_OnDrop ${CONFIG.TinyMCE.plugins}`
+
+  if (game.user.isGM) { // Define css and menu for keeper only blocks
+    CONFIG.TinyMCE.content_css.push('/systems/CoC7/assets/mce.css')
+    CONFIG.TinyMCE.style_formats.push({
+      title: 'CoC7',
+      items: [
+        {
+          title: 'Keeper Only',
+          block: 'section',
+          classes: 'keeper-only',
+          wrapper: true
+        }
+      ]
+    })
+  } else {
+    // Prevent player to edit and view source code if settings is disabled
+    if (!game.settings.get('CoC7', 'enablePlayerSourceCode'))
+      CONFIG.TinyMCE.toolbar = CONFIG.TinyMCE.toolbar.replace(' code', '')
+    // Hide keeper only blocks to players
+    CONFIG.TinyMCE.content_style = '.keeper-only {display: none}'
+  }
 }
 
 // function setGlobalCssVar(){

--- a/module/scripts/register-settings.js
+++ b/module/scripts/register-settings.js
@@ -218,6 +218,14 @@ export function registerSettings () {
     default: false,
     type: Boolean
   })
+  game.settings.register('CoC7', 'enablePlayerSourceCode', {
+    name: 'SETTINGS.EnablePlayerSourceCode',
+    hint: 'SETTINGS.EnablePlayerSourceCodeyHint',
+    scope: 'world',
+    config: true,
+    default: false,
+    type: Boolean
+  })
   game.settings.register('CoC7', 'overrideSheetArtwork', {
     name: 'SETTINGS.OverrideSheetArtwork',
     hint: 'SETTINGS.OverrideSheetArtworkHint',


### PR DESCRIPTION
Add a settings to disable code source editing for players (Default editing not allowed)

## Description.


## Motivation and Context.

When a player was editing source code of an editor block he was able to see the keeper only sections.
That settings allow keeper to disable source code editing for their players.

## Screenshots.

<!-- If appropriate. -->

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
