### PR TITLE
Restore CSS file name, to resolve hard coded dynamic edits to the CSS

### DIFF
--- a/system.json
+++ b/system.json
@@ -8,7 +8,7 @@
   "compatibleCoreVersion": "0.8.9",
   "esmodules": ["bundle.js"],
   "templateVersion": 1,
-  "styles": ["style.css", "assets/mce.css"],
+  "styles": ["coc7g.css", "assets/mce.css"],
   "packs": [
     {
       "label": "Skills",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -123,7 +123,7 @@ const bundleScript = {
       ]
     }),
     new MiniCssExtractPlugin({
-      filename: 'style.css',
+      filename: 'coc7g.css',
       insert: 'head'
     }),
     new WebpackBar({})


### PR DESCRIPTION
Resolves #724

## Motivation and Context.
The css file name is hard coded in the sheet render system, restore the old name to allow this system to run as is.

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
