### PR TITLE
Fix the setMainAttackSkill of the Actor importer when it receives arrays

### DIFF
--- a/module/apps/actor-importer.js
+++ b/module/apps/actor-importer.js
@@ -342,6 +342,7 @@ export class CoC7ActorImporter {
         await npc
           .createEmbeddedDocuments('Item', [mainAttackSkill])
           .then(async newSkills => {
+            console.debug('newskills', newSkills)
             // const newSkill = newSkills[0].clone()
             // newSkill.data.data.value = attack.data.range.normal.value
             await npc
@@ -397,6 +398,12 @@ export class CoC7ActorImporter {
    * @param {CoC7Item} skill
    */
   async setMainAttackSkill (weapon, skill) {
+    if (Array.isArray(skill) && skill.length >0) {
+      skill = skill[0]
+    }
+    if (Array.isArray(weapon) && weapon.length >0) {
+      weapon = weapon[0]
+    }
     return await weapon.update({
       'data.skill.main.id': skill.id,
       'data.skill.main.name': skill.name,


### PR DESCRIPTION
Fix some breaking changes on the Actor  importer, that were preventing NPCs to be imported properly.

## Description.

This is probably related to the update to `0.8.x` and the changes on `createEmbeddedDocumment`.  On some cases, inside `setMainAttackSkill` there is an error when accessing `skill.data`  if `skill` is an Array.

## Motivation and Context.

Not sure why, but it seems that the `createEmbeddedDocumment` it's returing an `Array` of `Arrays` instead of an `Array` of `Document`, this was breaking the `setMainAttackSkill`, so I've added a couple of checks there to _unwap_  both parameters when they receive an `Array`. 

## Types of Changes.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
