### PR TITLE
Handle 00 special case for penalty/bonus rolls fixes #756

### DIFF
--- a/module/dice.js
+++ b/module/dice.js
@@ -41,8 +41,27 @@ export class CoC7Dice {
     })
     if (modif < 0) {
       result.tens.total = Math.max(...result.tens.results)
+      // Handle the 00 special case
+      if (result.unit.total === 0 && result.tens.results.includes(0)) {
+        result.tens.total = 0
+      }
     } else {
       result.tens.total = Math.min(...result.tens.results)
+      // Handle the 00 special case
+      if (result.unit.total === 0 && result.tens.results.includes(0)) {
+        let tens_results_non_zero = []
+        result.tens.results.forEach(r => {
+          if (r !== 0) {
+            tens_results_non_zero.push(r)
+          }
+        })
+        if (tens_results_non_zero.length === 0) {
+          // All the tens dices are 0
+          result.tens.total = 0
+        } else {
+          result.tens.total = Math.min(...tens_results_non_zero)
+        }
+      }
     }
     result.total = result.unit.total + result.tens.total
     if (result.total === 0) {

--- a/module/dice.js
+++ b/module/dice.js
@@ -40,33 +40,14 @@ export class CoC7Dice {
       }
     })
     if (modif < 0) {
-      result.tens.total = Math.max(...result.tens.results)
-      // Handle the 00 special case
-      if (result.unit.total === 0 && result.tens.results.includes(0)) {
-        result.tens.total = 0
-      }
+      result.tens.total = result.unit.total === 0 && result.tens.results.includes(0) ? 100 : Math.max(...result.tens.results)
+    } else if (result.unit.total === 0) {
+      const dice = result.tens.results.filter(t => t > 0)
+      result.tens.total = dice.length === 0 ? 100 : Math.min(...dice)
     } else {
       result.tens.total = Math.min(...result.tens.results)
-      // Handle the 00 special case
-      if (result.unit.total === 0 && result.tens.results.includes(0)) {
-        let tens_results_non_zero = []
-        result.tens.results.forEach(r => {
-          if (r !== 0) {
-            tens_results_non_zero.push(r)
-          }
-        })
-        if (tens_results_non_zero.length === 0) {
-          // All the tens dices are 0
-          result.tens.total = 0
-        } else {
-          result.tens.total = Math.min(...tens_results_non_zero)
-        }
-      }
     }
     result.total = result.unit.total + result.tens.total
-    if (result.total === 0) {
-      result.total = 100
-    }
     return result
   }
 


### PR DESCRIPTION
Handle properly the special case for `00` when rolling with penalty or bonus dices

## Description.

This is a fix for bug #756 

## Screenshots.

Now with bonus dices the result is `40` instead of `100` 

![2 bonus dices 00 fixed](https://user-images.githubusercontent.com/322850/132590632-b3a193fe-4902-433b-a785-1a8a7ed03084.png)

And with penalty dices the `100` is rolled:

![2 penalty die (00) fixed](https://user-images.githubusercontent.com/322850/132590669-2f23126f-a727-48f2-9cbf-dfaea074c3e4.png)

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
