### PR TITLE
Keeper notes on all sheets

### DIFF
--- a/assets/mce.css
+++ b/assets/mce.css
@@ -1,7 +1,0 @@
-section.keeper-only {
-    padding: 0 5px;
-    background: rgba(0, 255, 0, 0.05);
-    border-top: 1px solid #666;
-    border-bottom: 1px solid #666;
-  }
-  

--- a/lang/en.json
+++ b/lang/en.json
@@ -616,7 +616,7 @@
   "CoC7.DrawGun": "Draw your gun",
 
   "CoC7.GmTools": "Keeper's tools",
-  "CoC7.GmNotes": "GM's notes",
+  "CoC7.GmNotes": "Keeper's notes",
   "CoC7.DevPhase": "Development phase",
   "CoC7.DevPhaseEnabled": "Development phase enabled",
   "CoC7.DevPhaseDisabled": "Development phase disabled",
@@ -798,8 +798,6 @@
   "SETTINGS.AdviseAllPlayer": "Notify all players",
   "SETTINGS.OneBlockBackStory": "One block backstory",
   "SETTINGS.OneBlockBackStoryHint": "Turn backstory to one editor block, but you can format/add links.",
-  "SETTINGS.EnablePlayerSourceCode": "Enable code editing for players.",
-  "SETTINGS.EnablePlayerSourceCodeyHint": "!WARNING! When Enabling this, players will be able to see and edit 'keeper only' blocks.",
   "SETTINGS.EnableStatusIcons": "Enable status icons",
   "SETTINGS.EnableStatusIconsHint": "Set if combat and sanity effects icons are shown in tokens."
 }

--- a/module/actors/sheets/creature-sheet.js
+++ b/module/actors/sheets/creature-sheet.js
@@ -137,7 +137,7 @@ export class CoC7CreatureSheet extends CoC7ActorSheet {
   static forceAuto (app, html) {
     const cell = html.find('.description.pannel.expanded')
     if (cell.length) {
-      cell.height(Math.max(130, html.height() - cell.position().top - 8) + 'px')
+      cell.height(Math.max(130, (html.height() - cell.position().top - 8) / cell.length) + 'px')
     }
   }
 

--- a/module/actors/sheets/npc-sheet.js
+++ b/module/actors/sheets/npc-sheet.js
@@ -59,7 +59,7 @@ export class CoC7NPCSheet extends CoC7ActorSheet {
   static forceAuto (app, html) {
     const cell = html.find('.description.pannel.expanded')
     if (cell.length) {
-      cell.height(Math.max(200, html.height() - cell.position().top - 8) + 'px')
+      cell.height(Math.max(200, (html.height() - cell.position().top - 8) / cell.length) + 'px')
     }
   }
 

--- a/module/apps/actor-importer.js
+++ b/module/apps/actor-importer.js
@@ -342,9 +342,6 @@ export class CoC7ActorImporter {
         await npc
           .createEmbeddedDocuments('Item', [mainAttackSkill])
           .then(async newSkills => {
-            console.debug('newskills', newSkills)
-            // const newSkill = newSkills[0].clone()
-            // newSkill.data.data.value = attack.data.range.normal.value
             await npc
               .createEmbeddedDocuments('Item', [attack])
               .then(async createdAttacks => {
@@ -398,12 +395,6 @@ export class CoC7ActorImporter {
    * @param {CoC7Item} skill
    */
   async setMainAttackSkill (weapon, skill) {
-    if (Array.isArray(skill) && skill.length >0) {
-      skill = skill[0]
-    }
-    if (Array.isArray(weapon) && weapon.length >0) {
-      weapon = weapon[0]
-    }
     return await weapon.update({
       'data.skill.main.id': skill.id,
       'data.skill.main.name': skill.name,

--- a/module/apps/parser.js
+++ b/module/apps/parser.js
@@ -120,11 +120,6 @@ export class CoC7Parser {
     }
   }
 
-  static async onInitEditor (editor) {
-    // editor con
-    ui.notifications.info('EDITOR IS INITIATED')
-  }
-
   static ParseMessage (
     message,
     html,
@@ -217,16 +212,6 @@ export class CoC7Parser {
       }
     }
 
-    for (const element of html.find('.keeper-only')) {
-      if (!game.user.isGM) element.style.display = 'none'
-    }
-
-    // for (const element of html.find('div.editor-content')){
-    //   if (element.outerHTML.toLocaleLowerCase().includes('[gm-only]')){
-    //     element.outerHTML = CoC7Parser.procesGMOnly( element.outerHTML)
-    //   }
-    // }
-
     // Bind the click to execute the check.
     // html.on('click', 'a.coc7-link', CoC7Parser._onCheck.bind(this));
     html
@@ -264,30 +249,6 @@ export class CoC7Parser {
     TextEditor._replaceTextContent(text, rgx, CoC7Parser._createLink)
     return html.innerHTML
   }
-
-  // static procesGMOnly (content){
-  //   // const gmOnlyRgx = new RegExp(
-  //   //   '(?:\[gm-only\])(.|\n)*?(?:\[\/gm-only\])',
-  //   //   'gi'
-  //   // )
-
-  //   let replaced = content
-
-  //   const searchAndReplace = [
-  //     { search: '<p>[gm-only]', replace: '<div class="gm-secret"><p>'},
-  //     { search: '[/gm-only]</p>', replace: '</p></div>'},
-  //     { search: '[gm-only]', replace: '<div class="gm-secret>'},
-  //     { search: '[/gm-only]', replace: '</div'}
-  //   ]
-
-  //   searchAndReplace.forEach( e => {
-  //     const esc = e.search.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-  //     const searchRegEx = new RegExp(esc, 'ig')
-  //     replaced = replaced.replaceAll( searchRegEx, e.replace)
-  //   })
-
-  //   return content
-  // }
 
   static bindEventsHandler (html) {
     html

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -407,47 +407,15 @@ function activateGlobalListener () {
  * Configuration of TinyMCE editor
  */
 function configureTinyMCE () {
-
   // Add on drop event to tinyMCE to hendle the links drop
   tinyMCE.PluginManager.add('CoC7_Editor_OnDrop', function (editor) {
     editor.on('drop', event => CoC7Parser.onEditorDrop(event, editor))
   })
 
-  // Intercept MCE init
-  // tinyMCE.PluginManager.add('CoC7_Editor_OnInit', function (editor) {
-  //   editor.on('init', () => CoC7Parser.onInitEditor( editor))
-  // })
-
   // Add custom plugins to list of plugins.
   // CONFIG.TinyMCE.plugins = `CoC7_Editor_OnInit CoC7_Editor_OnDrop ${CONFIG.TinyMCE.plugins}`
   CONFIG.TinyMCE.plugins = `CoC7_Editor_OnDrop ${CONFIG.TinyMCE.plugins}`
-
-  if (game.user.isGM) { // Define css and menu for keeper only blocks
-    CONFIG.TinyMCE.content_css.push('/systems/CoC7/assets/mce.css')
-    CONFIG.TinyMCE.style_formats.push({
-      title: 'CoC7',
-      items: [
-        {
-          title: 'Keeper Only',
-          block: 'section',
-          classes: 'keeper-only',
-          wrapper: true
-        }
-      ]
-    })
-  } else {
-    // Prevent player to edit and view source code if settings is disabled
-    if (!game.settings.get('CoC7', 'enablePlayerSourceCode'))
-      CONFIG.TinyMCE.toolbar = CONFIG.TinyMCE.toolbar.replace(' code', '')
-    // Hide keeper only blocks to players
-    CONFIG.TinyMCE.content_style = '.keeper-only {display: none}'
-  }
 }
-
-// function setGlobalCssVar(){
-//   const body = $('body')
-//   body.css('--keeper-display', game.user.isGM ? '' : 'none')
-// }
 
 function _onLeftClick (event) {
   return event.shiftKey

--- a/module/items/sheets/archetype.js
+++ b/module/items/sheets/archetype.js
@@ -179,6 +179,8 @@ export class CoC7ArchetypeSheet extends ItemSheet {
     // for (let [key, value] of Object.entries(data.data.type)) {
     //   if( value) data.itemProperties.push( COC7.occupationProperties[key]?COC7.occupationProperties[key]:null);
     // }
+
+    data.isKeeper = game.user.isGM
     return data
   }
 

--- a/module/items/sheets/chase.js
+++ b/module/items/sheets/chase.js
@@ -91,6 +91,8 @@ export class CoC7ChaseSheet extends ItemSheet {
           prev.mov > current.mov ? prev : current
         ).mov
       : -1
+
+    data.isKeeper = game.user.isGM
     return data
   }
 
@@ -572,10 +574,11 @@ export class _participant {
 
   get dex () {
     if (!this.data.dex) {
-      if (this.hasVehicle && this.hasDriver)
+      if (this.hasVehicle && this.hasDriver) {
         this.data.dex = this.driver.characteristics.dex.value
-      else if (this.hasActor)
+      } else if (this.hasActor) {
         this.data.dex = this.actor.characteristics.dex.value
+      }
     }
 
     if (this.data.dex) {

--- a/module/items/sheets/item-sheet.js
+++ b/module/items/sheets/item-sheet.js
@@ -13,7 +13,7 @@ export class CoC7ItemSheet extends CoC7ItemSheetV2 {
   static get defaultOptions () {
     return mergeObject(super.defaultOptions, {
       width: 520,
-      height: 480
+      height: 506
     })
   }
 }

--- a/module/items/sheets/item-sheetV2.js
+++ b/module/items/sheets/item-sheetV2.js
@@ -1,4 +1,4 @@
-/* global ItemSheet, mergeObject */
+/* global game, ItemSheet, mergeObject */
 
 import { COC7 } from '../../config.js'
 
@@ -19,12 +19,13 @@ export class CoC7ItemSheetV2 extends ItemSheet {
     return mergeObject(super.defaultOptions, {
       classes: ['coc7', 'sheetV2', 'item'],
       width: 290,
-      height: 300,
+      height: 326,
+      scrollY: ['.tab.description'],
       tabs: [
         {
-          navSelector: '.sheet-tabs',
+          navSelector: '.sheet-navigation',
           contentSelector: '.sheet-body',
-          initial: 'skills'
+          initial: 'description'
         }
       ]
     })
@@ -80,6 +81,8 @@ export class CoC7ItemSheetV2 extends ItemSheet {
         !this.item.data.data.properties.firearm &&
         !this.item.data.data.properties.fighting
     }
+
+    data.isKeeper = game.user.isGM
     return data
   }
 

--- a/module/items/sheets/occupation.js
+++ b/module/items/sheets/occupation.js
@@ -282,6 +282,8 @@ export class CoC7OccupationSheet extends ItemSheet {
         )
       }
     }
+
+    data.isKeeper = game.user.isGM
     return data
   }
 

--- a/module/items/sheets/setup.js
+++ b/module/items/sheets/setup.js
@@ -208,6 +208,7 @@ export class CoC7SetupSheet extends ItemSheet {
 
     data.oneBlockBackStory = game.settings.get('CoC7', 'oneBlockBackstory')
 
+    data.isKeeper = game.user.isGM
     return data
   }
 

--- a/module/items/sheets/skill.js
+++ b/module/items/sheets/skill.js
@@ -1,4 +1,4 @@
-/* global ItemSheet, mergeObject */
+/* global game, ItemSheet, mergeObject */
 
 import { COC7 } from '../../config.js'
 
@@ -20,11 +20,12 @@ export class CoC7SkillSheet extends ItemSheet {
       classes: ['coc7', 'sheet', 'item'],
       width: 520,
       height: 480,
+      scrollY: ['.tab.description'],
       tabs: [
         {
-          navSelector: '.sheet-tabs',
+          navSelector: '.sheet-navigation',
           contentSelector: '.sheet-body',
-          initial: 'skills'
+          initial: 'description'
         }
       ]
     })
@@ -80,6 +81,8 @@ export class CoC7SkillSheet extends ItemSheet {
         !this.item.data.data.properties.firearm &&
         !this.item.data.data.properties.fighting
     }
+
+    data.isKeeper = game.user.isGM
     return data
   }
 

--- a/module/items/sheets/spell.js
+++ b/module/items/sheets/spell.js
@@ -83,6 +83,8 @@ export class CoC7SpellSheet extends ItemSheet {
         )
       }
     }
+
+    data.isKeeper = game.user.isGM
     return data
   }
 }

--- a/module/items/sheets/status.js
+++ b/module/items/sheets/status.js
@@ -1,4 +1,4 @@
-/* global ItemSheet, mergeObject */
+/* global game, ItemSheet, mergeObject */
 
 import { COC7 } from '../../config.js'
 // import { CoCActor } from '../../actors/actor.js';
@@ -54,6 +54,8 @@ export class CoC7StatusSheet extends ItemSheet {
         )
       }
     }
+
+    data.isKeeper = game.user.isGM
     return data
   }
 }

--- a/module/items/sheets/talent.js
+++ b/module/items/sheets/talent.js
@@ -1,4 +1,4 @@
-/* global ItemSheet, mergeObject */
+/* global game, ItemSheet, mergeObject */
 
 import { COC7 } from '../../config.js'
 // import { CoCActor } from '../../actors/actor.js';
@@ -54,6 +54,8 @@ export class CoC7TalentSheet extends ItemSheet {
         )
       }
     }
+
+    data.isKeeper = game.user.isGM
     return data
   }
 }

--- a/module/items/sheets/weapon-sheet.js
+++ b/module/items/sheets/weapon-sheet.js
@@ -105,6 +105,7 @@ export class CoC7WeaponSheet extends ItemSheet {
       this.item.data.data.properties.brst === true ||
       this.item.data.data.properties.thrown === true
 
+    data.isKeeper = game.user.isGM
     return data
   }
 

--- a/module/scripts/register-settings.js
+++ b/module/scripts/register-settings.js
@@ -218,14 +218,6 @@ export function registerSettings () {
     default: false,
     type: Boolean
   })
-  game.settings.register('CoC7', 'enablePlayerSourceCode', {
-    name: 'SETTINGS.EnablePlayerSourceCode',
-    hint: 'SETTINGS.EnablePlayerSourceCodeyHint',
-    scope: 'world',
-    config: true,
-    default: false,
-    type: Boolean
-  })
   game.settings.register('CoC7', 'overrideSheetArtwork', {
     name: 'SETTINGS.OverrideSheetArtwork',
     hint: 'SETTINGS.OverrideSheetArtworkHint',

--- a/module/updater.js
+++ b/module/updater.js
@@ -4,7 +4,7 @@ export class Updater {
     this.systemUpdateVersion = String(
       game.settings.get('CoC7', 'systemUpdateVersion')
     )
-    if (isNewerVersion('0.3', this.systemUpdateVersion)) {
+    if (isNewerVersion('0.4', this.systemUpdateVersion)) {
       if (game.user.isGM) {
         new Dialog({
           title: game.i18n.localize('CoC7.Migrate.Title'),
@@ -104,7 +104,7 @@ export class Updater {
       }
     }
 
-    game.settings.set('CoC7', 'systemUpdateVersion', '0.3')
+    game.settings.set('CoC7', 'systemUpdateVersion', '0.4')
   }
 
   static migrateActorData (actor) {
@@ -113,6 +113,7 @@ export class Updater {
     // Update World Actor
     Updater._migrateActorCharacterSanity(actor, updateData)
     Updater._migrateActorArtwork(actor, updateData)
+    Updater._migrateActorKeeperNotes(actor, updateData)
 
     // Migrate World Actor Items
     if (actor.items) {
@@ -187,6 +188,7 @@ export class Updater {
     Updater._migrateItemExperience(item, updateData)
     Updater._migrateItemArtwork(item, updateData)
     Updater._migrateItemBookAutomated(item, updateData)
+    Updater._migrateItemKeeperNotes(item, updateData)
 
     return updateData
   }
@@ -206,6 +208,20 @@ export class Updater {
     // Update World Actor
     Updater._migrateTableArtwork(table, updateData)
 
+    return updateData
+  }
+
+  static _migrateItemKeeperNotes (item, updateData) {
+    if (['archetype', 'chase', 'item', 'occupation', 'setup', 'skill', 'spell', 'status', 'talent', 'weapon'].includes(item.type)) {
+      if (typeof item.data.description === 'string') {
+        updateData['data.description'] = {
+          value: item.data.description,
+          keeper: ''
+        }
+      } else if (typeof item.data.description.keeper === 'undefined') {
+        updateData['data.description.keeper'] = ''
+      }
+    }
     return updateData
   }
 
@@ -353,6 +369,17 @@ export class Updater {
           updateData.effects = actor.effects
         }
         updateData.effects[k].icon = 'systems/CoC7/assets/icons/' + image[1]
+      }
+    }
+    return updateData
+  }
+
+  static _migrateActorKeeperNotes (actor, updateData) {
+    if (['character', 'npc', 'creature'].includes(actor.type)) {
+      if (typeof actor.data.description === 'undefined') {
+        updateData['data.description'] = {
+          keeper: ''
+        }
       }
     }
     return updateData

--- a/styles/sheets/book.less
+++ b/styles/sheets/book.less
@@ -195,6 +195,15 @@
           text-shadow: none;
         }
       }
+      a.keeper-only-tab {
+        flex: 0.3;
+      }
+      a.keeper-only-tab span {
+        vertical-align: bottom;
+      }
+      a.keeper-only-tab span i {
+        color: @colorGreen;
+      }
     }
     .body {
       input {

--- a/styles/sheets/character.less
+++ b/styles/sheets/character.less
@@ -252,9 +252,20 @@
             }
 
             &.active {
+              &.keeper-only-tab span {
+                background-color: @colorGreen;
+                color: white;
+              }
               span {
                 color: white;
                 background-color: var(--main-sheet-front-color);
+              }
+            }
+            &.keeper-only-tab span {
+              color: @colorGreen;
+
+              &:hover {
+                border: 1px solid @colorGreen;
               }
             }
           }

--- a/styles/sheets/sheets.less
+++ b/styles/sheets/sheets.less
@@ -2,6 +2,15 @@ html {
   font-size: 16px;
 }
 
+a.keeper-only-tab {
+  flex: 0.3;
+  color: @colorGreen;
+}
+
+h3.keeper-only-tab i {
+  color: @colorGreen;
+}
+
 .permission-limited img {
   height: auto !important;
   width: 580px !important;

--- a/styles/sheets/vehicle.less
+++ b/styles/sheets/vehicle.less
@@ -6,6 +6,24 @@
     color: var(--main-sheet-front-color);
   }
 
+  .sheet-nav {
+    a {
+      &.active {
+        &.keeper-only-tab span {
+          background-color: @colorGreen;
+          color: white;
+        }
+      }
+      &.keeper-only-tab span {
+        color: @colorGreen;
+
+        &:hover {
+          border: 1px solid @colorGreen;
+        }
+      }
+    }
+  }
+
   .armor-infos {
     display: flex;
     flex-direction: row;

--- a/styles/system/variables.less
+++ b/styles/system/variables.less
@@ -40,6 +40,7 @@
 @colorCrimson: #44191a;
 @borderGroove: 2px groove #eeede0;
 @sheetBackground: url('../assets/images/background.webp') repeat;
+@colorGreen: #393;
 
 /* ----------------------------------------- */
 /*  Flexbox                                  */

--- a/template.json
+++ b/template.json
@@ -194,10 +194,16 @@
         "value": 0,
         "max": 0
       },
+      "description": {
+        "keeper": ""
+      },
       "notes": ""
     },
     "npc": {
       "templates": ["characteristics", "attribs", "status", "biography"],
+      "description": {
+        "keeper": ""
+      },
       "infos": {
         "occupation": "",
         "age": "",
@@ -209,6 +215,9 @@
     },
     "creature": {
       "templates": ["characteristics", "attribs", "status", "biography"],
+      "description": {
+        "keeper": ""
+      },
       "special": {
         "attribs": {
           "move": {
@@ -281,7 +290,10 @@
       "chase"
     ],
     "item": {
-      "description": "",
+      "description": {
+        "value": "",
+        "keeper": ""
+      },
       "quantity": 1,
       "weight": 0,
       "attributes": {}
@@ -290,7 +302,8 @@
       "description": {
         "value": "",
         "chat": "",
-        "special": ""
+        "special": "",
+        "keeper": ""
       },
       "wpnType": "",
       "skill": {
@@ -339,7 +352,8 @@
         "value": "",
         "opposingDifficulty": "",
         "pushedFaillureConsequences": "",
-        "chat": ""
+        "chat": "",
+        "keeper": ""
       },
       "base": 0,
       "adjustments": {
@@ -356,7 +370,8 @@
     },
     "occupation": {
       "description": {
-        "value": ""
+        "value": "",
+        "keeper": ""
       },
       "source": null,
       "type": {
@@ -431,7 +446,8 @@
     },
     "archetype": {
       "description": {
-        "value": ""
+        "value": "",
+        "keeper": ""
       },
       "source": null,
       "type": {
@@ -465,7 +481,8 @@
     },
     "setup": {
       "description": {
-        "value": ""
+        "value": "",
+        "keeper": ""
       },
       "characteristics": {
         "points": {
@@ -521,7 +538,8 @@
         "value": "",
         "chat": "",
         "unidentified": "",
-        "notes": ""
+        "notes": "",
+        "keeper": ""
       },
       "type": {
         "call": false,
@@ -577,7 +595,8 @@
       "description": {
         "value": "",
         "chat": "",
-        "notes": ""
+        "notes": "",
+        "keeper": ""
       },
       "type": {
         "physical": false,
@@ -595,7 +614,8 @@
       "description": {
         "value": "",
         "chat": "",
-        "notes": ""
+        "notes": "",
+        "keeper": ""
       },
       "duration": {
         "permanent": true,
@@ -609,6 +629,9 @@
       }
     },
     "chase": {
+      "description": {
+        "keeper": ""
+      },
       "locations": {
         "total": 0,
         "startingRange": 1,

--- a/templates/actors/character-sheet-v2.html
+++ b/templates/actors/character-sheet-v2.html
@@ -142,6 +142,9 @@
 			<a data-tab="combat"><div class="tab-name" ><span>{{localize 'CoC7.Combat'}}</span></div></a>
 			<a data-tab="possession"><div class="tab-name" ><span>{{localize 'CoC7.Possessions'}}</span></div></a>
 			<a data-tab="background"><div class="tab-name" ><span>{{localize 'CoC7.Background'}}</span></div></a>
+      {{#if isGM}}
+        <a class="keeper-only-tab" data-tab="keeper" title="{{localize 'CoC7.GmNotes'}}"><div class="tab-name" ><span><i class="game-icon game-icon-tentacles-skull"></i></span></div></a>
+      {{/if}}
 			{{#if alowUnlock}}
 				{{#if data.flags.locked}}
 					<a class="unlock-control lock" title="{{localize 'CoC7.UnlockActor'}}"> <i class="fas fa-lock"></i> </a>
@@ -194,11 +197,14 @@
 							{{> "systems/CoC7/templates/actors/parts/actor-background.html"}}
 						{{/if}}
 					</div>
+
+          {{#if isGM}}
+            <div class="tab coc7 sheet actor temp-retro-compat restore-list-styles" data-group="primary" data-tab="keeper">
+              {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+            </div>
+          {{/if}}
 				</div>
 			</div>
-
 		</section>
-
-
 	</div>
 </form>

--- a/templates/actors/creature-sheet.html
+++ b/templates/actors/creature-sheet.html
@@ -384,6 +384,16 @@
 		</section>
 		{{/if}}
 
+    {{#if isGM}}
+      <section class="sheet-section">
+        <div class="section-header flexrow" data-pannel="keeper">
+          <h3 class="flex1 keeper-only-tab">{{localize 'CoC7.GmNotes'}} <i class="game-icon game-icon-tentacles-skull"></i></h3>
+        </div>
+        <div class="description pannel expanded resizededitor">
+          {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+        </div>
+      </section>
+    {{/if}}
 
 		<section class="sheet-section">
 			<div class="section-header flexrow" data-pannel="description">

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -406,6 +406,16 @@
       </section>
       {{/if}}
 
+      {{#if isGM}}
+        <section class="sheet-section">
+          <div class="section-header flexrow" data-pannel="keeper">
+            <h3 class="flex1 keeper-only-tab">{{localize 'CoC7.GmNotes'}} <i class="game-icon game-icon-tentacles-skull"></i></h3>
+          </div>
+          <div class="description pannel expanded resizededitor">
+            {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+          </div>
+        </section>
+      {{/if}}
 
       <section class="sheet-section">
         <div class="section-header flexrow" data-pannel="description">

--- a/templates/actors/vehicle.html
+++ b/templates/actors/vehicle.html
@@ -72,7 +72,7 @@
                 <a data-tab="description"><div class="tab-name" ><span>{{ localize "CoC7.Description" }}</span></div></a>
                 {{#if isGM}}
                     <a data-tab="details"><div class="tab-name" ><span>{{ localize "CoC7.Details" }}</span></div></a>
-                    <a data-tab="gmNotes"><div class="tab-name" ><span>{{ localize "CoC7.GmNotes" }}</span></div></a>
+                    <a data-tab="gmNotes" class="keeper-only-tab"><div class="tab-name" ><span><i class="game-icon game-icon-tentacles-skull"></i></span></div></a>
                 {{/if}}
             </nav>
 

--- a/templates/items/archetype.html
+++ b/templates/items/archetype.html
@@ -25,6 +25,9 @@
 		<a style="line-height: 24px;" class="item active" data-tab="description">{{ localize "CoC7.Description" }}</a>
 		<a style="line-height: 24px;" class="item" data-tab="details">{{ localize "CoC7.Details" }}</a>
 		<a style="line-height: 24px;" class="item" data-tab="skills">{{ localize "CoC7.Skills" }}</a>
+    {{#if isKeeper}}
+      <a style="line-height: 24px;" class="item keeper-only-tab" data-tab="keeper" title="{{localize 'CoC7.GmNotes'}}"><i class="game-icon game-icon-tentacles-skull"></i></a>
+    {{/if}}
 	</nav>
 
 
@@ -138,5 +141,10 @@
 				</ol>
 			</div>
 		</div>
+    {{#if isKeeper}}
+      <div class="tab keeper" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+        {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+      </div>
+    {{/if}}
 	</section>
 </form>

--- a/templates/items/book/main.hbs
+++ b/templates/items/book/main.hbs
@@ -124,11 +124,9 @@
         {{/if}}
       {{/if}}
       {{#if isKeeper}}
-        <a data-tab="notes">
+        <a data-tab="notes" class="keeper-only-tab" title="{{localize 'CoC7.GmNotes'}}">
           <div class="tab-name">
-            <span>
-              {{localize "CoC7.Notes"}}
-            </span>
+            <span><i class="game-icon game-icon-tentacles-skull"></i></span>
           </div>
         </a>
       {{/if}}

--- a/templates/items/chase.html
+++ b/templates/items/chase.html
@@ -18,9 +18,12 @@
         </header>
 
         <nav class="sheet-nav tabs" data-group="primary">
-			<a data-tab="participants"><div class="tab-name" ><span>{{localize 'CoC7.Participans'}}</span></div></a>
-			<a data-tab="cut2chase"><div class="tab-name" ><span>{{localize 'CoC7.Cut2Chase'}}</span></div></a>
-			<a data-tab="setup"><div class="tab-name" ><span>{{localize 'CoC7.Setup'}}</span></div></a>
+    			<a data-tab="participants"><div class="tab-name" ><span>{{localize 'CoC7.Participans'}}</span></div></a>
+    			<a data-tab="cut2chase"><div class="tab-name" ><span>{{localize 'CoC7.Cut2Chase'}}</span></div></a>
+    			<a data-tab="setup"><div class="tab-name" ><span>{{localize 'CoC7.Setup'}}</span></div></a>
+          {{#if isKeeper}}
+            <a style="line-height: 24px;" class="keeper-only-tab" data-tab="keeper" title="{{localize 'CoC7.GmNotes'}}"><i class="game-icon game-icon-tentacles-skull"></i></a>
+          {{/if}}
         </nav>
 
         <section class="sheet-body">
@@ -115,7 +118,7 @@
                 </div>
             </div>
             <div class="tab setup" data-group="primary" data-tab="setup">
-                
+
                 <div class="track" style="height: 100px;overflow-x: scroll;background-attachment: local;background-image: linear-gradient(to right, #6fa26f , #ece857);">
                     azertyuiopqsdfghjklmwxcvbnazertyuiopqsdfghjklmwxcvbnazertyuiopqsdfghjklmwxcvbnazertyuiopqsdfghjklmwxcvbnazertyuiopqsdfghjklmwxcvbnazertyuiopqsdfghjklmwxcvbnazertyuiopqsdfghjklmwxcvbnazertyuiopqsdfghjklmwxcvbnazertyuiopqsdfghjklmwxcvbnazertyuiopqsdfghjklmwxcvbnazertyuiopqsdfghjklmwxcvbn
                 </div>
@@ -126,6 +129,11 @@
                 <div>Chasers Min : {{chasersMinMov}}</div>
                 <div>Chasers Min : {{chasersMaxMov}}</div>
             </div>
+            {{#if isKeeper}}
+              <div class="tab keeper" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+                {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+              </div>
+            {{/if}}
         </section>
     </div>
 </form>

--- a/templates/items/item-sheetV2.html
+++ b/templates/items/item-sheetV2.html
@@ -1,5 +1,5 @@
     <form class="{{cssClass}} flexcol" autocomplete="off">
-        <div class="container expanded nonav">
+        <div class="container expanded">
             <header class="sheet-header">
                 <div class="sheet-portrait">
                     <img class="photo" src="{{item.img}}" title="{{item.name}}" data-edit="img"/>
@@ -20,11 +20,23 @@
                 <div class="flex1"></div>
             </header>
 
-            <section class="sheet-body">
+            <nav style="flex: 0 0 24px;margin-bottom: 4px;font-family: 'Modesto Condensed', 'Palatino Linotype', serif;font-size: 16px;font-weight: 700;"
+              class="sheet-navigation tabs" data-group="primary">
+                <a style="line-height: 24px;" class="item active" data-tab="description">{{ localize "CoC7.Description" }}</a>
+                {{#if isKeeper}}
+                  <a style="line-height: 24px;" class="item keeper-only-tab" data-tab="keeper" title="{{localize 'CoC7.GmNotes'}}"><i class="game-icon game-icon-tentacles-skull"></i></a>
+                {{/if}}
+            </nav>
 
-                <div class="tab">
-                    {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+            <section class="sheet-body">
+                <div class="tab description flexrow active" style="border-top: 2px groove #eeede0;padding: 0 0 0 5px;overflow: auto;" data-group="primary" data-tab="description">
+                    {{editor content=data.description.value target="data.description.value" button=true owner=owner editable=editable}}
                 </div>
+                {{#if isKeeper}}
+                  <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+                    {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+                  </div>
+                {{/if}}
             </section>
         </div>
     </form>

--- a/templates/items/occupation.html
+++ b/templates/items/occupation.html
@@ -28,6 +28,9 @@
 		<a style="line-height: 24px;" class="item active" data-tab="description">{{ localize "CoC7.Description" }}</a>
 		{{#unless isOwned}}<a style="line-height: 24px;" class="item" data-tab="details">{{ localize "CoC7.Details" }}</a>{{/unless}}
 		<a style="line-height: 24px;" class="item" data-tab="skills">{{ localize "CoC7.Skills" }}</a>
+    {{#if isKeeper}}
+      <a style="line-height: 24px;" class="item keeper-only-tab" data-tab="keeper" title="{{localize 'CoC7.GmNotes'}}"><i class="game-icon game-icon-tentacles-skull"></i></a>
+    {{/if}}
 	</nav>
 
 
@@ -250,5 +253,10 @@
 			</div>
 			{{/unless}}
 		</div>
+    {{#if isKeeper}}
+      <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+        {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+      </div>
+    {{/if}}
 	</section>
 </form>

--- a/templates/items/setup.html
+++ b/templates/items/setup.html
@@ -23,6 +23,9 @@
 		<a style="line-height: 24px;" class="item" data-tab="details">{{ localize "CoC7.Details" }}</a>
 		{{#if data.enableCharacterisitics}}<a style="line-height: 24px;" class="item" data-tab="characteristics">{{ localize "CoC7.Characteristics" }}</a>{{/if}}
 		<a style="line-height: 24px;" class="item" data-tab="skills">{{ localize "CoC7.Skills" }}</a>
+    {{#if isKeeper}}
+      <a style="line-height: 24px;" class="item keeper-only-tab" data-tab="keeper" title="{{localize 'CoC7.GmNotes'}}"><i class="game-icon game-icon-tentacles-skull"></i></a>
+    {{/if}}
 	</nav>
 
 
@@ -186,12 +189,11 @@
 				<input type="text" name="data.characteristics.rolls.luck" value="{{data.characteristics.rolls.luck}}" data-dtype="String" placeholder="{{ localize 'CoC7.EnterFormula' }}"/>
 			</div>
 			{{/if}}
-
-
-
-
-
 		</div>
-
+    {{#if isKeeper}}
+      <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+        {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+      </div>
+    {{/if}}
 	</section>
 </form>

--- a/templates/items/skill-sheet.html
+++ b/templates/items/skill-sheet.html
@@ -24,31 +24,44 @@
             <div class="skill-value" style="display: flex; flex-direction: row;">
 
             </div>
-            
+
             <div class="skill-attributes" style="display: block;" data-set="properties">
                 {{#each _properties as |property key|}}
                     <span class="toggle-switch {{#if property.isEnabled}} switched-on {{/if}}" data-property="{{property.id}}">{{localize property.name}} </span>
-                    <!-- <div style="display: none;">
-                        <input id="properties-{{property.id}}" type="checkbox" name="data.properties.{{property.id}}" {{checked property.isEnabled}}/>
-                    </div> -->
                 {{/each}}
             </div>
         </div>
         <img class="profile-img" style="flex: 0 0 100px;" src="{{item.img}}" data-edit="img" title="{{item.name}}" height="100" width="100"/>
     </div>
 
-    
-    <!-- <div class="skill-attributes" style="flex: 0 0 25px;" data-set="eras">
+    <nav style="flex: 0 0 24px;margin-bottom: 4px;font-family: 'Modesto Condensed', 'Palatino Linotype', serif;font-size: 16px;font-weight: 700;"
+      class="sheet-navigation tabs" data-group="primary">
+        <a style="line-height: 24px;" class="item active" data-tab="description">{{ localize "CoC7.Description" }}</a>
+        {{#if isKeeper}}
+          <a style="line-height: 24px;" class="item keeper-only-tab" data-tab="keeper" title="{{localize 'CoC7.GmNotes'}}"><i class="game-icon game-icon-tentacles-skull"></i></a>
+        {{/if}}
+    </nav>
+
+    {{!--
+    <div class="skill-attributes" style="flex: 0 0 25px;" data-set="eras">
         {{#each _eras as |era key|}}
             <span class="toggle-switch {{#if era.isEnabled}} switched-on {{/if}}" data-property="{{era.id}}">{{era.name}}</span>
             <div style="display: none;">
                 <input id="eras-{{era.id}}" type="checkbox" name="data.eras.{{era.id}}" {{checked era.isEnabled}}/>
             </div>
         {{/each}}
-    </div> -->
-
-    
-    <div class="form-group" style="display: flex;border: 2px groove #eeede0;padding: 0 0 0 5px;overflow: auto;">
-        {{editor content=data.description.value target="data.description.value" button=true owner=owner editable=editable}}
     </div>
+    --}}
+
+
+    <section class="sheet-body">
+      <div class="tab description flexrow active" style="border-top: 2px groove #eeede0;padding: 0 0 0 5px;overflow: auto;" data-group="primary" data-tab="description">
+          {{editor content=data.description.value target="data.description.value" button=true owner=owner editable=editable}}
+      </div>
+      {{#if isKeeper}}
+        <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+          {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+        </div>
+      {{/if}}
+    </section>
 </form>

--- a/templates/items/spell.html
+++ b/templates/items/spell.html
@@ -26,6 +26,9 @@
       class="sheet-navigation tabs" data-group="primary">
         <a style="line-height: 24px;" class="item active" data-tab="description">{{ localize "CoC7.Description" }}</a>
         <a style="line-height: 24px;" class="item" data-tab="details">{{ localize "CoC7.Details" }}</a>
+        {{#if isKeeper}}
+          <a style="line-height: 24px;" class="item keeper-only-tab" data-tab="keeper" title="{{localize 'CoC7.GmNotes'}}"><i class="game-icon game-icon-tentacles-skull"></i></a>
+        {{/if}}
     </nav>
 
 
@@ -106,6 +109,11 @@
             <h3 class="form-header">{{ localize "CoC7.Notes"}}</h3>
             {{editor content=data.description.notes target="data.description.notes" button=true owner=owner editable=editable}}
         </div>
+      {{#if isKeeper}}
+        <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+          {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+        </div>
+      {{/if}}
     </section>
 
 </form>

--- a/templates/items/status.html
+++ b/templates/items/status.html
@@ -21,6 +21,9 @@
         <a style="line-height: 24px;" class="item active" data-tab="description">{{ localize "CoC7.Description" }}</a>
         <a style="line-height: 24px;" class="item" data-tab="details">{{ localize "CoC7.Details" }}</a>
         <a style="line-height: 24px;" class="item" data-tab="effects">{{ localize "CoC7.Effects" }}</a>
+        {{#if isKeeper}}
+          <a style="line-height: 24px;" class="item keeper-only-tab" data-tab="keeper" title="{{localize 'CoC7.GmNotes'}}"><i class="game-icon game-icon-tentacles-skull"></i></a>
+        {{/if}}
     </nav>
 
 
@@ -64,6 +67,11 @@
         <div class="tab effects" data-group="primary" data-tab="effects">
             <h1>To be implemented</h1>
         </div>
+      {{#if isKeeper}}
+        <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+          {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+        </div>
+      {{/if}}
     </section>
 
 </form>

--- a/templates/items/talent.html
+++ b/templates/items/talent.html
@@ -20,6 +20,9 @@
       class="sheet-navigation tabs" data-group="primary">
         <a style="line-height: 24px;" class="item active" data-tab="description">{{ localize "CoC7.Description" }}</a>
         <a style="line-height: 24px;" class="item" data-tab="details">{{ localize "CoC7.Details" }}</a>
+        {{#if isKeeper}}
+          <a style="line-height: 24px;" class="item keeper-only-tab" data-tab="keeper" title="{{localize 'CoC7.GmNotes'}}"><i class="game-icon game-icon-tentacles-skull"></i></a>
+        {{/if}}
     </nav>
 
 
@@ -75,6 +78,11 @@
             <h3 class="form-header">{{ localize "CoC7.Notes"}}</h3>
             {{editor content=data.description.notes target="data.description.notes" button=true owner=owner editable=editable}}
         </div>
+      {{#if isKeeper}}
+        <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+          {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+        </div>
+      {{/if}}
     </section>
 
 </form>

--- a/templates/items/weapon-sheet.html
+++ b/templates/items/weapon-sheet.html
@@ -20,7 +20,7 @@
 									<option value="{{cbs.id}}">{{cbs.data.name}}</option>
 								{{/each}}
 							{{/if}}
-                        {{/select}}
+            {{/select}}
 					</select>
 
 					{{#if usesAlternateSkill}}
@@ -87,6 +87,9 @@
 	<nav class="sheet-tabs tabs" data-group="primary">
 		<a class="item" data-tab="details">{{localize 'CoC7.ItemDetails'}}</a>
 		<a class="item" data-tab="description">{{localize 'CoC7.Description'}}</a>
+    {{#if isKeeper}}
+      <a class="item keeper-only-tab" data-tab="keeper" title="{{localize 'CoC7.GmNotes'}}"><i class="game-icon game-icon-tentacles-skull"></i></a>
+    {{/if}}
 	</nav>
 
 	{{!-- Sheet Body --}}
@@ -153,8 +156,13 @@
 
 		</div>
 
-		<div class="tab description flexcol" style="display: flex;border: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="description">
+		<div class="tab description flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="description">
 			{{editor content=data.description.value target="data.description.value" button=true owner=owner editable=editable}}
 		</div>
+    {{#if isKeeper}}
+      <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+        {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+      </div>
+    {{/if}}
 	</section>
 </form>


### PR DESCRIPTION
Replace incomplete TinyMCE Keeper only block system with Keeper notes tab on all sheets.
Resolve issue with createEmbeddedDocuments returning array in array.
Add tabs to item and skill sheets.
Make description for item an object to keep inline with other Item types.
Update migration for Keeper notes and Item description value/keeper.

## Description.

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to change).
