### PR TITLE
Implement HavlockV san loss from creature not being rolled fix

### DIFF
--- a/module/chat/cards/san-check.js
+++ b/module/chat/cards/san-check.js
@@ -95,7 +95,7 @@ export class SanCheckCard extends ChatCardActor {
           : this.sanData.sanMin
       }
 
-      const formula = this.creature?.sanLoss ? this.sanCheck.passed : 0
+      const formula = this.creature?.sanLoss(this.sanCheck.passed) || 0
       if (formula) {
         if (!isNaN(Number(formula))) return Number(formula)
         return formula


### PR DESCRIPTION
## Description.

If rolling sanity check from a creature targeted token roll only returned 0 or 1 sanity loss.
Fix provided by @HavlockV

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
