### PR TITLE
Feature/summarize sheet

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -699,6 +699,9 @@
   "CoC7.Migrate.ButtonSkip": "Skip",
   "CoC7.Migrate.ButtonOkay": "Okay",
 
+  "CoC7.Maximize": "Maximize",
+  "CoC7.Summarize": "Summarize",
+
   "SETTINGS.TitleRules": "Rules",
   "SETTINGS.TitleInitiative": "Initiative Settings",
   "SETTINGS.TitleRoll": "Roll Settings",

--- a/module/actors/sheets/character.js
+++ b/module/actors/sheets/character.js
@@ -21,11 +21,25 @@ export class CoC7CharacterSheetV2 extends CoC7CharacterSheet {
     return buttons
   }
 
+  async toggleSheetMode (event) {
+    console.log(event)
+    this.summarized = !this.summarized
+    await this.close()
+    const options = this.summarized
+      ? {
+          classes: ['coc7', 'actor', 'character', 'summarized'],
+          height: 200,
+          resizable: false,
+          width: 700
+        }
+      : CoC7CharacterSheetV2.defaultOptions
+    await this.render(true, options)
+  }
+
   async getData () {
     const data = await super.getData()
-
+    data.summarized = this.summarized
     data.skillList = []
-
     let previousSpec = ''
     for (const skill of data.skills) {
       if (skill.data.properties.special) {
@@ -50,7 +64,6 @@ export class CoC7CharacterSheetV2 extends CoC7CharacterSheet {
         data.data.infos.playername = user.name
       }
     }
-
     return data
   }
 
@@ -61,7 +74,7 @@ export class CoC7CharacterSheetV2 extends CoC7CharacterSheet {
   static get defaultOptions () {
     return mergeObject(super.defaultOptions, {
       classes: ['coc7', 'sheetV2', 'actor', 'character'],
-      template: 'systems/CoC7/templates/actors/character-sheet-v2.html',
+      template: 'systems/CoC7/templates/actors/character/index.html',
       width: 687,
       height: 623,
       resizable: true,

--- a/module/actors/sheets/character.js
+++ b/module/actors/sheets/character.js
@@ -3,9 +3,23 @@
 import { CoC7CharacterSheet } from './actor-sheet.js'
 
 export class CoC7CharacterSheetV2 extends CoC7CharacterSheet {
-  // constructor(...args) {
-  //   super(...args);
-  // }
+  _getHeaderButtons () {
+    if (!this.summarized) this.summarized = false
+    let buttons = super._getHeaderButtons()
+    buttons = [
+      {
+        label: this.summarized
+          ? game.i18n.localize('CoC7.Maximize')
+          : game.i18n.localize('CoC7.Summarize'),
+        class: 'test-extra-icon',
+        icon: this.summarized
+          ? 'fas fa-window-maximize'
+          : 'fas fa-window-minimize',
+        onclick: event => this.toggleSheetMode(event)
+      }
+    ].concat(buttons)
+    return buttons
+  }
 
   async getData () {
     const data = await super.getData()

--- a/module/actors/sheets/character.js
+++ b/module/actors/sheets/character.js
@@ -53,7 +53,18 @@ export class CoC7CharacterSheetV2 extends CoC7CharacterSheet {
       }
       data.skillList.push(skill)
     }
-
+    data.topSkills = [...data.skills]
+      .sort((a, b) => {
+        return a.data.value - b.data.value
+      })
+      .reverse()
+      .slice(0, 14)
+    data.topWeapons = [...data.meleeWpn, ...data.rangeWpn]
+      .sort((a, b) => {
+        return a.data.skill.main?.value - b.data.skill.main?.value
+      })
+      .reverse()
+      .slice(0, 3)
     data.displayPlayerName = game.settings.get(
       'CoC7',
       'displayPlayerNameOnSheet'

--- a/module/scripts/load-templates.js
+++ b/module/scripts/load-templates.js
@@ -22,6 +22,8 @@ export const preloadHandlebarsTemplates = async function () {
     'systems/CoC7/templates/actors/parts/development-controls.html',
     'systems/CoC7/templates/actors/parts/vitals.html',
     'systems/CoC7/templates/actors/parts/combat.html',
+    'systems/CoC7/templates/actors/character-sheet-v2.html',
+    'systems/CoC7/templates/actors/character/summary.html',
 
     'systems/CoC7/templates/items/book/details.hbs'
   ]

--- a/styles/sheets/summary.less
+++ b/styles/sheets/summary.less
@@ -39,6 +39,18 @@
       .status-monitor.status-on {
         color: darkred;
       }
+      .status {
+        color: grey;
+        text-align: center;
+        a {
+          &.inative-status {
+            &:hover {
+              text-shadow: none !important;
+              cursor: default;
+            }
+          }
+        }
+      }
       .fas {
         font-size: 12px;
       }

--- a/styles/sheets/summary.less
+++ b/styles/sheets/summary.less
@@ -1,0 +1,391 @@
+.coc7.actor.character.summarized {
+  .window-content {
+    background: var(--other-sheet-bg);
+    background-repeat: repeat;
+  }
+  form {
+    background: var(--other-sheet-bg);
+    background-repeat: repeat;
+  }
+  font-family: customSheetFont, "Palatino Linotype", serif;
+  .container {
+    display: grid;
+    grid-template-columns: 1fr 1.35fr 1fr;
+    grid-template-rows: 0.05fr 1fr;
+    gap: 1px;
+    grid-template-areas:
+      "header header header"
+      "characteristics skills other";
+    .rollable {
+      &:hover {
+        color: #000;
+        text-shadow: 0 0 10px red;
+        cursor: pointer;
+      }
+    }
+    .header {
+      grid-area: header;
+      min-height: 25px;
+      label {
+        line-height: 1;
+      }
+      .status-monitor {
+        color: darkgrey;
+        text-align: center;
+      }
+      .status-monitor.invert {
+        transform: rotateZ(180deg);
+      }
+      .status-monitor.status-on {
+        color: darkred;
+      }
+      .fas {
+        font-size: 12px;
+      }
+      .control {
+        line-height: 0.9;
+        max-width: fit-content;
+        margin-left: 5px;
+      }
+      .flexrow {
+        margin: 0 10px;
+        max-width: fit-content;
+      }
+      .current-value {
+        text-align: right;
+        padding-right: 0.25rem;
+        max-width: 25px;
+        input {
+          text-align: center;
+        }
+      }
+      .separator {
+        max-width: fit-content;
+      }
+      .max-value {
+        text-align: left;
+        padding-left: 0.25rem;
+        max-width: fit-content;
+        input {
+          background-color: rgba(0, 0, 0, 0.1);
+          max-width: fit-content;
+        }
+      }
+      span {
+        height: 1rem;
+        line-height: 1rem;
+      }
+      input {
+        background-color: transparent;
+        border: 0;
+        height: auto;
+        padding: 0;
+        font-weight: bold;
+        &:read-only {
+          border: 0px;
+          background-color: transparent;
+          box-shadow: none;
+          cursor: default;
+        }
+      }
+    }
+    .characteristics {
+      grid-area: characteristics;
+      flex: 1;
+      font-weight: bold;
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      .header {
+        flex: 1;
+      }
+      .footer {
+        flex: 1;
+        display: flex;
+        flex-direction: row;
+        .attribute {
+          flex: 0 0 25%;
+          display: grid;
+          grid-template-columns: auto 2rem;
+          align-items: center;
+          justify-content: center;
+        }
+        .attribute-label {
+          min-width: 0;
+          h2 {
+            border: 0;
+            padding: 0;
+            margin: 0;
+            line-height: 1.375rem;
+            font-size: 0.75rem;
+            color: var(--main-sheet-front-color);
+            font-weight: normal;
+            text-align: right;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
+          }
+        }
+        .attribute-value {
+          text-align: center;
+          font-size: 0.75rem;
+          color: var(--main-sheet-front-color);
+          font-weight: normal;
+          input {
+            border: 0;
+            padding: 0;
+            font-size: 0.75rem;
+            color: var(--main-sheet-front-color);
+            background-color: @greyBackground;
+            font-weight: normal;
+          }
+        }
+      }
+      .char-boxes {
+        flex: 0 0 6rem;
+        justify-content: center;
+        display: grid;
+        grid-template-columns: repeat(4, 3.75rem);
+        grid-template-rows: repeat(2, 3rem);
+      }
+      .char-box {
+        display: grid;
+        grid-template-columns: 1rem 2.75rem;
+        grid-template-rows: 1rem 2rem;
+        grid-template-areas:
+          "rollIcon characName"
+          "characScore characScore";
+        align-items: baseline;
+        .roll-icon {
+          color: var(--main-sheet-front-color);
+          grid-area: rollIcon;
+          line-height: 1.4rem;
+        }
+        .charac-name {
+          color: var(--main-sheet-front-color);
+          grid-area: characName;
+          line-height: 1.4rem;
+        }
+        .charac-score {
+          grid-area: characScore;
+          margin-top: 0.25rem;
+          margin-right: 0.5rem;
+          border-radius: 0.25rem;
+          color: var(--main-sheet-back-color);
+          background: @whiteBackground;
+          display: grid;
+          grid-template-columns: 2.375rem 0.875rem;
+          grid-template-rows: 0.875rem 0.875rem;
+          grid-template-areas:
+            "mainScore halfScore"
+            "mainScore fithScore";
+          .main-score {
+            grid-area: mainScore;
+            justify-self: center;
+            align-self: center;
+          }
+          .half-score {
+            grid-area: halfScore;
+            font-size: 0.6rem;
+            justify-self: center;
+            align-self: center;
+          }
+          .fith-score {
+            grid-area: fithScore;
+            font-size: 0.6rem;
+            justify-self: center;
+            align-self: center;
+          }
+          input {
+            background: transparent;
+            border: 0;
+            font-weight: bold;
+          }
+        }
+      }
+      input {
+        text-align: center;
+        color: var(--main-sheet-back-color);
+        font-size: 1.3rem;
+        &:hover,
+        &:focus {
+          background: transparent;
+        }
+        &:read-only {
+          border: 1px solid transparent;
+          box-shadow: none;
+          cursor: default;
+        }
+      }
+    }
+    .skills {
+      grid-area: skills;
+      flex: 1;
+      flex-wrap: wrap;
+      width: auto;
+      flex-direction: column;
+      max-height: 125px;
+      .item-list {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        width: auto;
+        height: 100%;
+        flex-direction: column;
+        flex-wrap: wrap;
+        .itemV2 {
+          max-height: 1.25rem;
+          width: 125px;
+          margin-right: 0.5rem;
+          display: grid;
+          font-size: 0.75rem;
+          grid-template-columns: 1rem auto 1.5rem 0.7rem;
+          border-bottom: 1px solid;
+
+          &.specialization {
+            margin-left: 0.5rem;
+            width: var(--skill-specialization-length);
+            border-left: 1px solid;
+          }
+
+          .item-image {
+            height: 0.875rem;
+            background-size: contain;
+            margin: 1px 0 0 0;
+          }
+
+          .item-name {
+            // .cursive();
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            padding-left: 3px;
+            line-height: 1rem;
+
+            input {
+              height: 1rem;
+              padding: 0;
+              overflow: visible;
+              background-color: @greyBackground;
+              color: var(--main-sheet-front-color);
+            }
+          }
+
+          .item-score {
+            // .cursive();
+            color: var(--main-sheet-back-color);
+            text-align: end;
+            margin-right: 2px;
+            line-height: 1rem;
+
+            input {
+              height: 1rem;
+              padding: 0;
+              margin-right: 2px;
+              background-color: @greyBackground;
+              color: var(--main-sheet-back-color);
+              text-align: end;
+            }
+          }
+
+          .item-controls {
+            // font-family: system-ui;
+            font-size: 0.625rem;
+            line-height: 1rem;
+            flex: 0 0 1.25rem;
+            display: block;
+            text-align: end;
+            width: max-content;
+            a:hover {
+              text-shadow: none;
+              color: var(--main-sheet-back-color);
+            }
+
+            .item-control {
+              &.active {
+                color: goldenrod;
+              }
+            }
+          }
+        }
+      }
+    }
+    .other {
+      grid-area: other;
+      padding: 0 0 0 10px;
+      height: 100%;
+      overflow-y: auto;
+      ol {
+        margin: 0;
+        margin-bottom: 25px;
+        padding: 0;
+      }
+      .cash-row {
+        input {
+          border: 0;
+        }
+        span {
+          line-height: 1.4rem;
+        }
+      }
+      .item-list {
+        .itemV2 {
+          margin-right: 3px !important;
+          width: 10rem !important;
+        }
+        display: flex !important;
+        flex-direction: row !important;
+        flex-wrap: wrap !important;
+      }
+      .weapon-row {
+        max-height: 1.25rem;
+        font-size: 0.75rem;
+        display: grid;
+        border-bottom: 1px solid;
+        grid-template-columns: 1rem 5.5rem 2.5rem 2rem;
+        grid-template-rows: 1rem;
+        grid-template-areas: "image name damage weaponControl";
+        .weapon-damage {
+          grid-area: damage;
+          color: var(--main-sheet-back-color);
+          text-align: end;
+          margin-right: 2px;
+          line-height: 1rem;
+          text-align: center;
+        }
+        .weapon-image {
+          height: 0.875rem;
+          grid-area: image;
+          background-size: contain;
+          margin: 1px 0 0 0;
+        }
+        .weapon-name {
+          grid-area: name;
+          height: 1rem;
+          line-height: 1rem;
+          padding-left: 3px;
+          font-size: 0.75rem;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        .alternativ-skill {
+          flex: 0 0 24px;
+        }
+        .weapon-control {
+          text-align: center;
+          line-height: 1rem;
+          grid-area: weaponControl;
+        }
+        .weapon-controls {
+          line-height: 1rem;
+          text-align: center;
+          display: grid;
+          grid-template-columns: 1rem 1rem;
+          grid-template-rows: 1rem;
+          grid-area: weaponControl;
+        }
+      }
+    }
+  }
+}

--- a/styles/system/index.less
+++ b/styles/system/index.less
@@ -28,3 +28,4 @@
 @import '../sheets/vehicle.less';
 @import 'variables.less';
 @import 'default-override.less';
+@import '../sheets/summary.less';

--- a/templates/actors/character/index.html
+++ b/templates/actors/character/index.html
@@ -1,0 +1,5 @@
+{{#if summarized}}
+  {{> "systems/CoC7/templates/actors/character/summary.html"}}
+{{else}}
+  {{> "systems/CoC7/templates/actors/character-sheet-v2.html"}}
+{{/if}}

--- a/templates/actors/character/summary.html
+++ b/templates/actors/character/summary.html
@@ -1,0 +1,203 @@
+<form class="summarized" autocomplete="off" data-actor-id="{{actor.id}}" {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}}>
+  <div class="container">
+    <div class="header flexrow">
+      <div class="flexrow" data-attrib="lck">
+        <label class="attribute-label rollable">{{localize 'CoC7.Luck'}}</label>
+        <div class="current-value">
+          <input class="attribute-value" type="text" name="data.attribs.lck.value" value="{{data.attribs.lck.value}}" data-dtype="Number"/>
+        </div>
+        <div class="separator">/</div>
+        <div class="max-value">
+            {{#if data.attribs.lck.auto}}
+                <input type="text" name="data.attribs.lck.max" value="{{data.attribs.lck.max}}" data-dtype="Number" readonly/>
+            {{else}}
+                <input type="text" name="data.attribs.lck.max" value="{{data.attribs.lck.max}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}/>
+            {{/if}}
+        </div>
+      </div>
+      <div class="flexrow" data-attrib="hp">
+        <label class="attribute-label">{{localize 'CoC7.HitPoints'}}</label>
+        <div class="current-value">
+          <input class="attribute-value" type="text" name="data.attribs.hp.value" value="{{data.attribs.hp.value}}"  data-dtype="Number"/>
+        </div>
+        <div class="separator">/</div>
+        <div class="max-value">
+            {{#if data.attribs.hp.auto}}
+                <input type="text" name="data.attribs.hp.max" value="{{data.attribs.hp.max}}" data-dtype="Number" readonly/>
+            {{else}}
+                <input type="text" name="data.attribs.hp.max" value="{{data.attribs.hp.max}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}/>
+            {{/if}}
+        </div>
+        <div class="status">
+          <a class="status-monitor {{#if data.status.prone.value}}status-on{{/if}}" title="{{localize 'CoC7.Prone'}}" data-status="prone"><i class="game-icon game-icon-falling"></i></a>
+          <a class="status-monitor {{#if data.status.unconscious.value}}status-on{{/if}}" title="{{localize 'CoC7.Unconsious'}}" data-status="unconscious"><i class="game-icon game-icon-knocked-out-stars"></i></a>
+          <a class="status-monitor {{#if data.status.criticalWounds.value}}status-on{{/if}}" title="{{localize 'CoC7.CriticalWounds'}}" data-status="criticalWounds"><i class="game-icon game-icon-arm-sling"></i></a>
+          <a class="status-monitor {{#if data.status.dying.value}}status-on{{/if}} is-dead" title="{{localize 'CoC7.Dying'}}" data-status="dying"><i class="game-icon game-icon-heart-beats"></i></a>
+          {{#if data.status.dead.value}}
+          <a class="status-monitor status-on" title="{{localize 'CoC7.Dead'}}" data-status="dead"><i class="game-icon game-icon-tombstone"></i></a>
+          {{else}}
+          <a class="{{#if data.status.dying.value}}status-monitor dying-check{{else}}inative-status{{/if}}" title="{{#if data.status.dying.value}}{{localize 'CoC7.DyingCheck'}}{{/if}}"><i class="game-icon game-icon-d10"></i></a>
+          {{/if}}
+        </div>
+      </div>
+      <div class="flexrow" data-attrib="san">
+        <label class="attribute-label rollable">{{localize 'CoC7.Sanity'}}</label>
+        <div class="current-value">
+          <input class="attribute-value" type="text" name="data.attribs.san.value" value="{{data.attribs.san.value}}"  data-dtype="Number"/>
+          </div>
+          <div class="separator">/</div>
+          <div class="max-value">
+              {{#if data.attribs.san.auto}}
+                  <input type="text" name="data.attribs.san.max" value="{{data.attribs.san.max}}" data-dtype="Number" readonly/>
+              {{else}}
+                  <input type="text" name="data.attribs.san.max" value="{{data.attribs.san.max}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}/>
+              {{/if}}
+          </div>
+          <div class="status">
+            <div class="invisible">
+                <input class="locked" type="text" name="data.indefiniteInsanityLevel.value" value="{{data.indefiniteInsanityLevel.value}}" data-dtype="Number" readonly/>
+                <input class="locked" type="text" name="data.indefiniteInsanityLevel.max" value="{{data.indefiniteInsanityLevel.max}}" data-dtype="Number" readonly/>
+            </div>
+            <a class="status-monitor {{#if isInABoutOfMadness}}status-on{{/if}}" title="{{sanity.boutOfMadness.hint}}" data-effect="boutOfMadness"><i class="game-icon game-icon-hanging-spider"></i></a>
+            <a class="status-monitor {{#if isInsane}}status-on{{/if}}" title="{{localize 'CoC7.UnderlyingInsanity'}}: {{sanity.underlying.hint}}" data-effect="insanity"><i class="game-icon game-icon-tentacles-skull"></i></a>
+            </div>
+            <div class="control">
+                <a class="reset-counter" title="{{localize 'CoC7.DailySanIconOver'}}" data-counter="data.attribs.san.dailyLoss"><i class="fas fa-undo"></i></a>
+            </div>
+      </div>
+      <div class="flexrow" data-attrib="mp">
+        <label class="attribute-label">{{localize 'CoC7.MagicPoints'}}</label>
+        <div class="current-value">
+            <input class="attribute-value" type="text" name="data.attribs.mp.value" value="{{data.attribs.mp.value}}"  data-dtype="Number"/>
+        </div>
+        <div class="separator">/</div>
+        <div class="max-value">
+          {{#if data.attribs.mp.auto}}
+            <input type="text" name="data.attribs.mp.max" value="{{data.attribs.mp.max}}" data-dtype="Number" readonly/>
+          {{else}}
+            <input type="text" name="data.attribs.mp.max" value="{{data.attribs.mp.max}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}/>
+          {{/if}}
+        </div>
+      </div>
+    </div>
+    <div class="characteristics">
+      <div class="char-boxes">
+        {{#each actor.characteristics as |characteristic key|}}
+          <div class="char-box"  data-characteristic="{{key}}" draggable="true">
+            <div class="roll-icon"><i class="game-icon game-icon-d10"></i></div>
+            <div class="charac-name characteristic-label rollable"  draggable="true">{{characteristic.shortName}}</div>
+            <div class="charac-score">
+              <div class="main-score">
+                <input class="characteristic-score" type="text" name="data.characteristics.{{key}}.value" value="{{characteristic.value}}" data-dtype="Number"/>
+              </div>
+              <div class="half-score">{{characteristic.hard}}</div>
+              <div class="fith-score">{{characteristic.extreme}}</div>
+            </div>
+          </div>
+        {{/each}}
+      </div>
+      <div class="footer">
+        {{#if data.flags.locked}}
+          <div class="attribute">
+            <div class="attribute-label"><h2>{{localize 'CoC7.Mov'}}:</h2></div>
+            <div class="attribute-value">{{data.attribs.mov.value}}</div>
+          </div>
+          <div class="attribute">
+            <div class="attribute-label"><h2>{{localize 'CoC7.Build'}}:</h2></div>
+            <div class="attribute-value">{{data.attribs.build.value}}</div>
+          </div>
+          <div class="attribute" data-attrib="db" data-roll-formula="{{data.attribs.db.value}}">
+            <div class="attribute-label rollable"><h2>{{localize 'CoC7.DB'}}:</h2></div>
+            <div class="attribute-value">{{data.attribs.db.value}}</div>
+          </div>
+          <div class="attribute">
+            <div class="attribute-label"><h2>{{localize 'CoC7.Armor'}}:</h2></div>
+            <div class="attribute-value">{{data.attribs.armor.value}}</div>
+          </div>
+        {{/if}}
+      </div>
+    </div>
+    <div class="skills">
+      <ol class="item-list">
+        {{#each topSkills as |skill|}}
+          <li class="item itemV2" data-skill-id="{{skill._id}}" data-item-id="{{skill._id}}">
+            <div class="item-image" style="background-image: url('{{skill.img}}')"></div>
+            <div class="item-name skill-name rollable"  title="{{skill.name}}">{{skill.name}}</div>
+            <div class="item-score">{{skill.data.value}}</div>
+            <div class="item-controls">
+              {{#unless skill.data.properties.noxpgain}}
+                {{#if skill.data.flags.developement}}
+                  <a class="item-control development-flag active" title="{{localize 'CoC7.SkillUnflagForDevelopement'}}"><i class="fas fa-certificate"></i></a>
+                {{else}}
+                  <a class="item-control development-flag" title="{{localize 'CoC7.SkillFlagForDevelopement'}}"><i class="fas fa-certificate"></i></a>
+                {{/if}}
+              {{/unless}}
+            </div>
+          </li>
+        {{/each}}
+      </ol>
+    </div>
+    <div class="other">
+      <ol>
+        {{#each topWeapons as |weapon|}}
+        {{#if weapon.data.properties.melee}}
+          <li class="weapon-row item weapon {{#unless weapon.skillSet}}error{{/unless}}" data-item-id="{{weapon._id}}" title="{{#unless weapon.skillSet}}{{localize 'CoC7.NoSkill'}}{{/unless}}">
+            <div class="weapon-image" style="background-image: url('{{weapon.img}}')"></div>
+            <div class="flexrow">
+                <div class="weapon-name combat {{#if weapon.skillSet}}rollable{{else}}item-edit{{/if}}">{{weapon.name}}</div>
+                {{#if weapon.data.properties.thrown}}
+                    <a class="weapon-name combat alternativ-skill {{#if weapon.skillSet}}rollable{{else}}item-edit{{/if}}" title="Throw"><i class="game-icon game-icon-thrown-knife"></i></a>
+                {{/if}}
+            </div>
+            <div class="weapon-damage">
+              {{weapon.data.range.normal.damage}}
+            </div>
+            <div class="weapon-control">
+                {{#if weapon.data.properties.addb}}<span class="tag" title="Add DB">{{localize 'CoC7.WeaponAddb'}}</span>{{/if}}
+                {{#if weapon.data.properties.ahdb}}<span class="tag" title="Add DB">{{localize 'CoC7.WeaponAhdb'}}</span>{{/if}}
+            </div>
+          </li>
+        {{else}}
+          <li class="weapon-row item weapon {{#unless weapon.skillSet}}error{{/unless}}" data-item-id="{{weapon._id}}" title="{{#unless weapon.skillSet}}{{localize 'CoC7.NoSkill'}}{{/unless}}">
+            <div class="weapon-image" style="background-image: url('{{weapon.img}}')"></div>
+            <div class="flexrow">
+                <div class="weapon-name combat {{#if weapon.skillSet}}rollable{{else}}item-edit{{/if}}">{{weapon.name}}</div>
+                {{#if weapon.usesAlternateSkill}}
+                    <a class="weapon-name combat alternativ-skill {{#if weapon.skillSet}}rollable{{else}}item-edit{{/if}}" title="{{localize 'CoC7.AutomaticFire'}}"><i class="game-icon game-icon-machine-gun-magazine"></i></a>
+                {{/if}}
+            </div>
+            <div class="weapon-damage">
+              {{weapon.data.range.normal.damage}}
+            </div>
+            <div class="weapon-controls">
+                <div class="ammo">
+                    <span class="tag">{{weapon.data.ammo}}</span>
+                </div>
+                <div class="control">
+                    <a class="reload-weapon" title="{{localize 'CoC7.Reload'}}"><i class="game-icon game-icon-chaingun"></i></a>
+                </div>
+            </div>
+          </li>
+        {{/if}}
+       {{/each}}
+      </ol>
+      <div class="flexrow cash-row">
+        <label>{{localize 'CoC7.MonetarySpendingLevel'}}</label>
+        {{#if data.flags.manualCredit}}
+            <input type="text" name="data.credit.spendingLevel" value="{{data.credit.spendingLevel}}">
+        {{else}}
+            <span>{{credit.spendingLevel}}</span>
+        {{/if}}
+      </div>
+      <div class="flexrow cash-row">
+          <label>{{localize 'CoC7.MonetaryCash'}}</label>
+          {{#if data.flags.manualCredit}}
+              <input type="text" name="data.credit.cash" value="{{data.credit.cash}}">
+          {{else}}
+              <span>{{credit.cash}}</span>
+          {{/if}}
+          <label>{{localize 'CoC7.MonetarySpent'}}</label><input type="text" name="data.credit.spent" value="{{data.credit.spent}}">
+      </div>
+    </div>
+  </div>
+</form>

--- a/templates/actors/character/summary.html
+++ b/templates/actors/character/summary.html
@@ -61,9 +61,6 @@
             <a class="status-monitor {{#if isInABoutOfMadness}}status-on{{/if}}" title="{{sanity.boutOfMadness.hint}}" data-effect="boutOfMadness"><i class="game-icon game-icon-hanging-spider"></i></a>
             <a class="status-monitor {{#if isInsane}}status-on{{/if}}" title="{{localize 'CoC7.UnderlyingInsanity'}}: {{sanity.underlying.hint}}" data-effect="insanity"><i class="game-icon game-icon-tentacles-skull"></i></a>
             </div>
-            <div class="control">
-                <a class="reset-counter" title="{{localize 'CoC7.DailySanIconOver'}}" data-counter="data.attribs.san.dailyLoss"><i class="fas fa-undo"></i></a>
-            </div>
       </div>
       <div class="flexrow" data-attrib="mp">
         <label class="attribute-label">{{localize 'CoC7.MagicPoints'}}</label>


### PR DESCRIPTION
## Description.

Add  option for summarize the character sheet, which is just a smaller version of the original one, keeping only the essential stuff. The sheet will always be started as maximized, the user always needs to click on "Summarize" to see this version. There is also an algorithm to filter the most important skills, and show them in descending order. Same for weapons.

## Motivation and Context.

Beginning players often feel lost when navigating the original sheet.

## Screenshots.

![image](https://user-images.githubusercontent.com/80350000/132898606-35456480-19cc-4166-9610-c61e52b99d24.png)

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
