### PR TITLE
Fix wrong repository url on CONTRIBUTING.md file

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Follow the installation steps and then make sure everything went right with:
 
 On the directory where you would like to pull your changes open the terminal or shell of your choice, run:
 
-`git clone https://github.com/HavlockV/CoC7-FoundryVTT.git`
+`git clone https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT.git`
 
 This will create a local clone of the project repository.
 


### PR DESCRIPTION
## Description.

Changed the repository url on CONTRIBUTING.md file.

## Motivation and Context.

The contribution guide was misleading because it mentioned that you need to clone the repository but it used the old url of the repository.

## Types of Changes.

- [x] Bug fix (non-breaking change which fixes an issue).
