### PR TITLE
Further async and item.base fixes

### DIFF
--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -918,7 +918,7 @@ export class CoC7ActorSheet extends ActorSheet {
       //  await effect.sheet.render(true);
       //  // effect.delete();
       // }
-      // this.actor.effects.forEach( e => e.delete());
+      // for (const e of this.actor.effects) { e.delete() }
       // await setProperty( this.actor, 'data.data.encounteredCreatures', []);
 
       // await this.actor.update( {['data.encounteredCreatures'] : []});
@@ -967,11 +967,11 @@ export class CoC7ActorSheet extends ActorSheet {
       content: content,
       callback: html => {
         const formData = new FormData(html[0].querySelector('#selectform'))
-        formData.forEach(function (value, name) {
+        for (const [name, value] of formData) {
           if (name === 'user') {
             message.actorTo = value
           }
-        })
+        }
       }
     })
     await game.CoC7socket.executeAsGM('gmtradeitemto', message)
@@ -1160,11 +1160,11 @@ export class CoC7ActorSheet extends ActorSheet {
       const div = $('<div class="item-summary"></div>')
 
       const labels = $('<div class="item-labels"></div>')
-      chatData.labels.forEach(p =>
+      for (const p of chatData.labels) {
         labels.append(
           `<div class="item-label"><span class="label-name">${p.name} :</span><span class="label-value">${p.value}</span></div>`
         )
-      )
+      }
       div.append(labels)
 
       div.append(
@@ -1179,11 +1179,11 @@ export class CoC7ActorSheet extends ActorSheet {
       }
 
       const props = $('<div class="item-properties"></div>')
-      chatData.properties.forEach(p =>
+      for (const p of chatData.properties) {
         props.append(
           `<div class="tag item-property">${game.i18n.localize(p)}</div>`
         )
-      )
+      }
       div.append(props)
 
       li.append(div.hide())

--- a/module/actors/sheets/container.js
+++ b/module/actors/sheets/container.js
@@ -161,11 +161,11 @@ export class CoC7ContainerSheet extends ActorSheet {
       content: content,
       callback: html => {
         const formData = new FormData(html[0].querySelector('#selectform'))
-        formData.forEach(function (value, name) {
+        for (const [name, value] of formData) {
           if (name === 'user') {
             message.actorTo = value
           }
-        })
+        }
       }
     })
     await game.CoC7socket.executeAsGM('gmtradeitemto', message)
@@ -185,11 +185,11 @@ export class CoC7ContainerSheet extends ActorSheet {
       const div = $('<div class="item-summary"></div>')
 
       const labels = $('<div class="item-labels"></div>')
-      chatData.labels.forEach(p =>
+      for (const p of chatData.labels) {
         labels.append(
           `<div class="item-label"><span class="label-name">${p.name} :</span><span class="label-value">${p.value}</span></div>`
         )
-      )
+      }
       div.append(labels)
 
       div.append(
@@ -204,11 +204,11 @@ export class CoC7ContainerSheet extends ActorSheet {
       }
 
       const props = $('<div class="item-properties"></div>')
-      chatData.properties.forEach(p =>
+      for (const p of chatData.properties) {
         props.append(
           `<div class="tag item-property">${game.i18n.localize(p)}</div>`
         )
-      )
+      }
       div.append(props)
 
       li.append(div.hide())

--- a/module/apps/actor-importer.js
+++ b/module/apps/actor-importer.js
@@ -163,9 +163,9 @@ export class CoC7ActorImporter {
     const results = []
     if (spells !== null) {
       const spellsArr = spells.replace(/(\n|\r)/g, ' ').split(',')
-      spellsArr.forEach(s => {
+      for (const s of spellsArr) {
         results.push(this.cleanString(s))
-      })
+      }
     }
     if (CONFIG.debug.CoC7Importer) {
       console.debug('spells', results)
@@ -210,7 +210,7 @@ export class CoC7ActorImporter {
       if (CONFIG.debug.CoC7Importer) {
         console.debug('skillsArr', skillsArr)
       }
-      skillsArr.forEach(skill => {
+      for (const skill of skillsArr) {
         const parsedSkill = this.RE.skillRegExp.exec(skill)
         if (CONFIG.debug.CoC7Importer) {
           console.debug('parsedSkill', parsedSkill)
@@ -222,7 +222,7 @@ export class CoC7ActorImporter {
             value: Number(parsedSkill.groups.percentage)
           })
         }
-      })
+      }
     }
     if (CONFIG.debug.CoC7Importer) {
       console.debug('skills', results)
@@ -332,18 +332,18 @@ export class CoC7ActorImporter {
 
   async updateActorData (pc, npc) {
     let updateData = {}
-    ;['str', 'con', 'siz', 'dex', 'app', 'int', 'pow', 'edu'].forEach(key => {
+    for (const key of ['str', 'con', 'siz', 'dex', 'app', 'int', 'pow', 'edu']) {
       updateData[`data.characteristics.${key}.value`] = Number(pc[key])
-    })
+    }
     await npc.update(updateData)
     await npc.setLuck(Number(pc.lck))
     await npc.setHp(Number(pc.hp))
     await npc.setMp(Number(pc.mp))
 
     updateData = {}
-    ;['san', 'mov', 'db', 'build', 'armor'].forEach(key => {
+    for (const key of ['san', 'mov', 'db', 'build', 'armor']) {
       updateData[`data.attribs.${key}.value`] = Number(pc[key])
-    })
+    }
     if (pc.age !== null) {
       updateData['data.infos.age'] = pc.age
     }
@@ -549,11 +549,11 @@ export class CoC7ActorImporter {
    */
   needsConversion (npc) {
     let needsConversionResult = true
-    ;['str', 'con', 'siz', 'dex', 'app', 'int', 'pow', 'edu'].forEach(key => {
+    for (const key of ['str', 'con', 'siz', 'dex', 'app', 'int', 'pow', 'edu']) {
       if (npc[key] > 30) {
         needsConversionResult = false
       }
-    })
+    }
     if (CONFIG.debug.CoC7Importer) {
       console.debug('needsConversion:', needsConversionResult)
     }
@@ -597,9 +597,9 @@ export class CoC7ActorImporter {
     if (CONFIG.debug.CoC7Importer) {
       console.debug('Converting creature', creature)
     }
-    ;['str', 'con', 'siz', 'dex', 'app', 'int', 'pow'].forEach(key => {
+    for (const key of ['str', 'con', 'siz', 'dex', 'app', 'int', 'pow']) {
       creature[key] *= 5
-    })
+    }
     if (creature.edu <= 18) {
       creature.edu *= 5
     } else if (creature.edu <= 26) {

--- a/module/apps/canvas.js
+++ b/module/apps/canvas.js
@@ -43,7 +43,7 @@ export class CoC7Canvas {
               const whisperTargets = game.users.players.filter(
                 u => !!u.character
               ) // User with at least a character
-              whisperTargets.forEach(u => {
+              for (const u of whisperTargets) {
                 option.whisper = [u]
                 chatHelper.createMessage(
                   null,
@@ -53,9 +53,9 @@ export class CoC7Canvas {
                   }),
                   option
                 )
-              })
+              }
             } else {
-              dropTargetTokens.forEach(t => {
+              for (const t of dropTargetTokens) {
                 if (t.actor.hasPlayerOwner) {
                   option.whisper = t.actor.owners
                   chatHelper.createMessage(
@@ -67,7 +67,7 @@ export class CoC7Canvas {
                     option
                   )
                 }
-              })
+              }
             }
           }
           break

--- a/module/apps/link-creation-dialog.js
+++ b/module/apps/link-creation-dialog.js
@@ -258,7 +258,7 @@ export class CoC7LinkCreationDialog extends FormApplication {
           option.speaker = {
             alias: game.user.name
           }
-          canvas.tokens.controlled.forEach(t => {
+          for (const t of canvas.tokens.controlled) {
             if (t.actor.hasPlayerOwner) {
               option.whisper = t.actor.owners
               chatHelper.createMessage(
@@ -270,7 +270,7 @@ export class CoC7LinkCreationDialog extends FormApplication {
                 option
               )
             }
-          })
+          }
         }
         break
 

--- a/module/apps/parser.js
+++ b/module/apps/parser.js
@@ -410,7 +410,7 @@ export class CoC7Parser {
         return
       }
       if (canvas.tokens.controlled.length) {
-        canvas.tokens.controlled.forEach(token => {
+        for (const token of canvas.tokens.controlled) {
           switch (options.check) {
             case 'check':
               if (
@@ -463,7 +463,7 @@ export class CoC7Parser {
 
             default:
           }
-        })
+        }
       } else {
         if (game.user.data.document.character?.data) {
           await Promise.all(

--- a/module/apps/point-selection-dialog.js
+++ b/module/apps/point-selection-dialog.js
@@ -13,11 +13,11 @@ export class PointSelectDialog extends Dialog {
   async _onSelectCharacteristic (event) {
     const li = event.currentTarget.closest('.item')
     const itemList = li.closest('.item-list')
-    itemList.querySelectorAll('.selectable').forEach(item => {
+    for (const item of itemList.querySelectorAll('.selectable')) {
       item.classList.remove('selected')
       this.data.data.characteristics[item.dataset.key].selected = false
       this.data.data.characteristics[item.dataset.key].optional = false
-    })
+    }
     $(li).toggleClass('selected')
     this.data.data.characteristics[li.dataset.key].selected = true
     const totalPoints = li

--- a/module/chat.js
+++ b/module/chat.js
@@ -374,17 +374,17 @@ export class CoC7Chat {
   static _onTargetSelect (event) {
     const index = parseInt(event.currentTarget.dataset.key)
     const targetsSelector = event.currentTarget.closest('.targets-selector')
-    targetsSelector.querySelectorAll('img').forEach(i => {
+    for (const i of targetsSelector.querySelectorAll('img')) {
       i.style.border = 'none'
-    })
+    }
     targetsSelector
       .querySelector(`[data-key="${index}"]`)
       .querySelector('img').style.border = '1px solid #000'
     const targets = event.currentTarget.closest('.targets')
-    targets.querySelectorAll('.target').forEach(t => {
+    for (const t of targets.querySelectorAll('.target')) {
       t.style.display = 'none'
       t.dataset.active = 'false'
-    })
+    }
     const targetToDisplay = targets.querySelector(
       `[data-target-key="${index}"]`
     )
@@ -407,9 +407,9 @@ export class CoC7Chat {
     const dropDownBoxes = event.currentTarget
       .closest('.response-selection')
       .querySelectorAll('.toggle-switch')
-    ;[].forEach.call(dropDownBoxes, dpdnBox =>
+    for (const dpdnBox of dropDownBoxes) {
       dpdnBox.classList.remove('switched-on')
-    )
+    }
     event.currentTarget.closest('.toggle-switch').classList.add('switched-on')
 
     // close dropdown
@@ -490,9 +490,9 @@ export class CoC7Chat {
     const dropDownBoxes = event.currentTarget
       .closest('.response-selection')
       .querySelectorAll('.toggle-switch')
-    ;[].forEach.call(dropDownBoxes, dpdnBox =>
+    for (const dpdnBox of dropDownBoxes) {
       dpdnBox.classList.remove('switched-on')
-    )
+    }
     event.currentTarget.classList.add('switched-on') // Need to test if it's really a dodge !!!
 
     // Save action for the roll
@@ -940,7 +940,7 @@ export class CoC7Chat {
         // if( originMessage.dataset.messageId) damageCard.messageId = originMessage.dataset.messageId;
         // damageCard.rollDamage();
         // if( originMessage.dataset.messageId) {
-        //  card.querySelectorAll('.card-buttons').forEach( b => b.remove());
+        //  for (const b of card.querySelectorAll('.card-buttons')) { b.remove() }
         //  await CoC7Chat.updateChatCard( card);
         // }
         break

--- a/module/chat/cards/combined-roll.js
+++ b/module/chat/cards/combined-roll.js
@@ -40,9 +40,9 @@ export class CombinedCheckCard extends RollCard {
   get successCount () {
     if (this.rolled) {
       let count = 0
-      this.rolls.forEach(r => {
+      for (const r of this.rolls) {
         if (r.passed) count += 1
-      })
+      }
       return count
     }
     return undefined

--- a/module/chat/cards/opposed-roll.js
+++ b/module/chat/cards/opposed-roll.js
@@ -126,9 +126,9 @@ export class OpposedCheckCard extends RollCard {
 
   get winnerCount () {
     let count = 0
-    this.rolls.forEach(r => {
+    for (const r of this.rolls) {
       if (r.winner) count += 1
-    })
+    }
     return count
   }
 
@@ -340,10 +340,10 @@ export class OpposedCheckCard extends RollCard {
       // Combat roll includes only 2 persons, remove the rest.
       if (this.rolls.length > 1) {
         this.rolls = [this.rolls[0], this.rolls[1]]
-        this.rolls.forEach(r => {
+        for (const r of this.rolls) {
           delete r.winner
           delete r.tie
-        })
+        }
       }
 
       // First person added is the attacker.

--- a/module/chat/cards/roll-card.js
+++ b/module/chat/cards/roll-card.js
@@ -59,7 +59,9 @@ export class RollCard {
       card.toggleFlag(flag)
     } else {
       const buttons = toggle.querySelectorAll('.toggle-switch')
-      buttons.forEach(b => card.unsetFlag(b.dataset.flag))
+      for (const b of buttons) {
+        card.unsetFlag(b.dataset.flag)
+      }
       card.setFlag(flag)
     }
     card.updateChatCard()

--- a/module/chat/cards/san-check.js
+++ b/module/chat/cards/san-check.js
@@ -519,7 +519,7 @@ export class SanCheckCard extends ChatCardActor {
   static checkTargets (creatureKey, fastForward = false) {
     const targets = [...game.user.targets]
     if (targets.length) {
-      targets.forEach(t => {
+      for (const t of targets) {
         // TODO : ? Make async call to create ?
         if (t.actor.isToken) {
           SanCheckCard.create(
@@ -534,7 +534,7 @@ export class SanCheckCard extends ChatCardActor {
             { fastForward: fastForward }
           )
         }
-      })
+      }
     }
   }
 

--- a/module/chat/combat/melee-target.js
+++ b/module/chat/combat/melee-target.js
@@ -172,7 +172,7 @@ export class CoC7MeleeTarget extends ChatCardActor {
           content =
             '<p>' + game.i18n.localize('CoC7.MessageSelectSingleUserForTarget')
           content = content + '<form id="selectform"><select name="user">'
-          owners.forEach(function (k) {
+          for (const k of owners) {
             content =
               content +
               '<option value="' +
@@ -180,7 +180,7 @@ export class CoC7MeleeTarget extends ChatCardActor {
               '">' +
               game.users.get(k).name +
               '</option>'
-          })
+          }
           content = content + '</select></form></p>'
           await Dialog.prompt({
             title: game.i18n.localize(
@@ -191,11 +191,11 @@ export class CoC7MeleeTarget extends ChatCardActor {
               const formData = new FormData(
                 html[0].querySelector('#selectform')
               )
-              formData.forEach(function (value, name) {
+              for (const [name, value] of formData) {
                 if (name === 'user') {
                   user = game.users.get(value)
                 }
-              })
+              }
             }
           })
       }

--- a/module/chat/helper.js
+++ b/module/chat/helper.js
@@ -143,7 +143,7 @@ export class chatHelper {
   }
 
   static attachObjectToElement (object, element, objectName = '') {
-    Object.keys(object).forEach(prop => {
+    for (const prop of Object.keys(object)) {
       if (!prop.startsWith('_')) {
         if (typeof object[prop] === 'object') {
           chatHelper.attachObjectToElement(
@@ -155,7 +155,7 @@ export class chatHelper {
           element.dataset[`${objectName}${prop}`] = object[prop]
         }
       }
-    })
+    }
   }
 
   static getObjectFromElement (object, element) {
@@ -175,10 +175,10 @@ export class chatHelper {
     }
 
     if (!element || !object) return
-    Object.keys(element.dataset).forEach(prop => {
+    for (const prop of Object.keys(element.dataset)) {
       if (prop === 'template') return
       deserialize(object, prop, element.dataset[prop])
-    })
+    }
   }
 
   static getTokenFromKey (key) {
@@ -345,9 +345,9 @@ export class CoC7Roll {
   showDiceRoll () {
     if (game.modules.get('dice-so-nice')?.active) {
       const diceResults = []
-      this.dices.tens.forEach(dieResult => {
+      for (const dieResult of this.dices.tens) {
         diceResults.push(dieResult.value === 100 ? 0 : dieResult.value / 10)
-      })
+      }
       diceResults.push(this.dices.unit.value)
 
       const diceData = {
@@ -380,7 +380,7 @@ export class CoC7Roll {
         : game.i18n.format('CoC7.DiceModifierBonus')
     const tenDice = element.querySelector('.ten-dice')
     if (tenDice) {
-      tenDice.querySelectorAll('li').forEach(d => {
+      for (const d of tenDice.querySelectorAll('li')) {
         const die = {
           selected: false,
           isMax: false,
@@ -389,7 +389,7 @@ export class CoC7Roll {
         }
         chatHelper.getObjectFromElement(die, d)
         roll.dices.tens.push(die)
-      })
+      }
     }
     const unitDie = element.querySelector('.unit-die')
       ? element.querySelector('.unit-die').querySelector('li')
@@ -399,11 +399,11 @@ export class CoC7Roll {
     roll.increaseSuccess = []
     const increaseSuccess = element.querySelector('.increase-success')
     if (increaseSuccess && increaseSuccess.querySelectorAll('button')) {
-      increaseSuccess.querySelectorAll('button').forEach(isl => {
+      for (const isl of increaseSuccess.querySelectorAll('button')) {
         const newSuccesLevel = {}
         chatHelper.getObjectFromElement(newSuccesLevel, isl)
         roll.increaseSuccess.push(newSuccesLevel)
-      })
+      }
     }
 
     if (roll.luckNeeded) {
@@ -475,11 +475,11 @@ export class CoC7Damage {
     chatHelper.getObjectFromElement(damage, element)
     const rolls = element.querySelector('.dice-rolls').querySelectorAll('li')
     damage.rolls = []
-    rolls.forEach(r => {
+    for (const r of rolls) {
       const roll = {}
       chatHelper.getObjectFromElement(roll, r)
       damage.rolls.push(roll)
-    })
+    }
 
     if (!object) return damage
   }

--- a/module/chat/interactive-chat-card.js
+++ b/module/chat/interactive-chat-card.js
@@ -273,7 +273,9 @@ export class InteractiveChatCard {
       this.toggleFlag(flag)
     } else {
       const buttons = toggle.querySelectorAll('.ic-radio-switch')
-      buttons.forEach(b => this.unsetFlag(b.dataset.flag))
+      for (const b of buttons) {
+        this.unsetFlag(b.dataset.flag)
+      }
       this.setFlag(flag)
     }
     const card = target.closest('.interactive-card')

--- a/module/chat/rangecombat.js
+++ b/module/chat/rangecombat.js
@@ -27,11 +27,11 @@ export class CoC7RangeInitiator {
     this.aimed = false
     this.totalBulletsFired = 0
     this._targets = []
-    ;[...game.user.targets].forEach(t => {
+    for (const t of [...game.user.targets]) {
       const target = new CoC7RangeTarget(`${t.scene.id}.${t.id}`) //
       target.token = t
       this._targets.push(target)
-    })
+    }
     if (this._targets.length) this._targets[0].active = true
     else {
       const target = new CoC7RangeTarget()
@@ -51,7 +51,7 @@ export class CoC7RangeInitiator {
       }
     }
     if (this.tokenKey) {
-      this._targets.forEach(t => {
+      for (const t of this._targets) {
         if (t.token && this.token) {
           t.distance = chatHelper.getDistance(t.token, this.token)
           t.roundedDistance = Math.round(t.distance.value * 100) / 100
@@ -111,7 +111,7 @@ export class CoC7RangeInitiator {
           }
           // }
         } else t.baseRange = true
-      })
+      }
     }
   }
 
@@ -201,9 +201,9 @@ export class CoC7RangeInitiator {
 
   get didAnyShotHit () {
     let anyHit = false
-    this.rolls.forEach(r => {
+    for (const r of this.rolls) {
       anyHit = anyHit || r.isSuccess
-    })
+    }
     return anyHit
   }
 
@@ -294,9 +294,9 @@ export class CoC7RangeInitiator {
   }
 
   calcTargetsDifficulty () {
-    this.targets.forEach(t => {
+    for (const t of this.targets) {
       t.shotDifficulty = this.shotDifficulty(t)
-    })
+    }
   }
 
   shotDifficulty (t = null) {
@@ -662,18 +662,18 @@ export class CoC7RangeInitiator {
 
     chatHelper.getObjectFromElement(rangeInitiator, card)
     const cardTargets = card.querySelectorAll('.target')
-    cardTargets.forEach(t => {
+    for (const t of cardTargets) {
       const target = CoC7RangeTarget.getFromElement(t)
       rangeInitiator.targets.push(target)
-    })
+    }
 
     const cardShots = card.querySelectorAll('.shot')
     if (cardShots) {
-      cardShots.forEach(s => {
+      for (const s of cardShots) {
         const shot = {}
         chatHelper.getObjectFromElement(shot, s)
         rangeInitiator.shots.push(shot)
-      })
+      }
     }
     // else {
     //  const shot = {
@@ -685,17 +685,17 @@ export class CoC7RangeInitiator {
 
     rangeInitiator.rolls = []
     const rolls = card.querySelectorAll('.roll-result')
-    rolls.forEach(r => {
+    for (const r of rolls) {
       const roll = CoC7Roll.getFromElement(r)
       rangeInitiator.rolls.push(roll)
-    })
+    }
 
     rangeInitiator.damage = []
     const damageRolls = card.querySelectorAll('.damage-results')
-    damageRolls.forEach(dr => {
+    for (const dr of damageRolls) {
       const damageRoll = CoC7Damage.getFromElement(dr)
       rangeInitiator.damage.push(damageRoll)
-    })
+    }
 
     return rangeInitiator
   }

--- a/module/chat/sancheck.js
+++ b/module/chat/sancheck.js
@@ -102,7 +102,7 @@ export class CoC7SanCheck {
   static checkTargets (sanMin, sanMax, fastForward = false, tokenKey = null) {
     const targets = [...game.user.targets]
     if (targets.length) {
-      targets.forEach(t => {
+      for (const t of targets) {
         let check
         if (t.actor.isToken) {
           check = new CoC7SanCheck(t.actor.tokenKey, sanMin, sanMax)
@@ -110,7 +110,7 @@ export class CoC7SanCheck {
           check = new CoC7SanCheck(t.actor.id, sanMin, sanMax)
         }
         check.toMessage(fastForward)
-      })
+      }
     } else {
       if (tokenKey) {
         const speaker = chatHelper.getSpeakerFromKey(tokenKey)

--- a/module/check.js
+++ b/module/check.js
@@ -1001,9 +1001,9 @@ export class CoC7Check {
   showDiceRoll () {
     if (game.modules.get('dice-so-nice')?.active) {
       const diceResults = []
-      this.dices.tens.forEach(dieResult => {
+      for (const dieResult of this.dices.tens) {
         diceResults.push(dieResult.value === 100 ? 0 : dieResult.value / 10)
-      })
+      }
       diceResults.push(this.dices.unit.value)
 
       const diceData = {
@@ -1088,9 +1088,9 @@ export class CoC7Check {
     for (let index = 0; index < upgradeindex + 1; index++) {
       this.increaseSuccess.shift()
     }
-    this.increaseSuccess.forEach(s => {
+    for (const s of this.increaseSuccess) {
       s.luckToSpend = s.luckToSpend - luckAmount
-    })
+    }
     this.luckSpent = true
     this.computeCheck()
     if (update) return await this.updateChatCard()
@@ -1108,9 +1108,9 @@ export class CoC7Check {
     if (luckAmount) {
       this.actor.spendLuck(luckAmount)
       this.successLevel = this.difficulty
-      this.increaseSuccess.forEach(s => {
+      for (const s of this.increaseSuccess) {
         s.luckToSpend = s.luckToSpend - luckAmount
-      })
+      }
       this.luckSpent = true
       this.isSuccess = true
       this.totalLuckSpent = !parseInt(this.totalLuckSpent)

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -256,9 +256,9 @@ Hooks.on('ready', async () => {
   // }
 
   const tableChoice = { none: 'SETTINGS.LetKeeperDecide' }
-  game.tables.forEach(t => {
+  for (const t of game.tables) {
     tableChoice[t.data._id] = t.data.name
-  })
+  }
 
   game.settings.register('CoC7', 'boutOfMadnessSummaryTable', {
     name: 'SETTINGS.BoutOfMadnessSummaryTable',

--- a/module/dice.js
+++ b/module/dice.js
@@ -31,14 +31,14 @@ export class CoC7Dice {
     }
     if (rollMode) result.rollMode = rollMode
     if (hideDice) result.hideDice = hideDice
-    roll.dice.forEach(d => {
+    for (const d of roll.dice) {
       if (d instanceof CONFIG.Dice.terms.t) {
         result.tens.results.push(d.total)
       } else {
         result.unit.total = d.total === 10 ? 0 : d.total
         result.unit.results.push(result.unit.total)
       }
-    })
+    }
     if (modif < 0) {
       result.tens.total =
         result.unit.total === 0 && result.tens.results.includes(0)

--- a/module/items/book/data.js
+++ b/module/items/book/data.js
@@ -37,9 +37,9 @@ export class CoC7Book extends CoC7Item {
     const collection = this.data.data.spells
       ? duplicate(this.data.data.spells)
       : []
-    spells.forEach(spell => {
+    for (const spell of spells) {
       collection.push(spell)
-    })
+    }
     return await this.update({ 'data.spells': collection })
   }
 

--- a/module/items/item.js
+++ b/module/items/item.js
@@ -544,6 +544,30 @@ export class CoC7Item extends Item {
     return skillProperties
   }
 
+  static async calculateBase (actor, data) {
+    if (data.type !== 'skill') return null
+    if (String(data.data.base).includes('@')) {
+      const parsed = {}
+      for (const [key, value] of Object.entries(COC7.formula.actorsheet)) {
+        if (key.startsWith('@') && value.startsWith('this.actor.')) {
+          parsed[key.substring(1)] = getProperty(actor, value.substring(11))
+        }
+      }
+      let value
+      try {
+        value = Math.floor(
+          new Roll(data.data.base, parsed).evaluate({
+            maximize: true
+          }).total
+        )
+      } catch (err) {
+        value = 0
+      }
+      return value
+    }
+    return (!isNaN(parseInt(data.data.base)) ? parseInt(data.data.base) : null)
+  }
+
   get _base () {
     if (this.type !== 'skill') return [null, false]
     if (typeof this.data.data.base !== 'string') {

--- a/module/items/sheets/archetype.js
+++ b/module/items/sheets/archetype.js
@@ -67,7 +67,7 @@ export class CoC7ArchetypeSheet extends ItemSheet {
     } else {
       const div = $(`<div class="item-summary">${chatData.value}</div>`)
       const props = $('<div class="item-properties"></div>')
-      // chatData.properties.forEach(p => props.append(`<span class="tag">${p}</span>`));
+      // for (const p of chatData.properties) { props.append(`<span class="tag">${p}</span>`) }
       div.append(props)
       li.append(div.hide())
       div.slideDown(200)
@@ -147,7 +147,7 @@ export class CoC7ArchetypeSheet extends ItemSheet {
     }
 
     data.skillListEmpty = data.data.skills.length === 0
-    data.data.skills.forEach(skill => {
+    for (const skill of data.data.skills) {
       // For each skill if it's a spec and spac name not included in the name add it
       if (
         skill.data.specialization &&
@@ -155,7 +155,7 @@ export class CoC7ArchetypeSheet extends ItemSheet {
       ) {
         skill.displayName = `${skill.data.specialization} (${skill.name})`
       } else skill.displayName = skill.name
-    })
+    }
 
     data.data.skills.sort((a, b) => {
       return a.displayName.localeCompare(b.displayName)

--- a/module/items/sheets/chase.js
+++ b/module/items/sheets/chase.js
@@ -56,9 +56,9 @@ export class CoC7ChaseSheet extends ItemSheet {
     /*****************/
 
     data.participants = []
-    this.participants.forEach(p => {
+    for (const p of this.participants) {
       data.participants.push(new _participant(p))
-    })
+    }
     data.preys =
       data.participants
         .filter(p => !p.isChaser && p.isValid)
@@ -690,18 +690,18 @@ export class _participant {
     }
     if (this.hasActor) {
       check.options = []
-      ;['con'].forEach(c => {
+      for (const c of ['con']) {
         const characterisitc = this.actor.getCharacteristic(c)
         if (characterisitc?.value) check.options.push(characterisitc.label)
-      })
+      }
 
-      this.actor.driveSkills.forEach(s => {
+      for (const s of this.actor.driveSkills) {
         check.options.push(s.name)
-      })
+      }
 
-      this.actor.pilotSkills.forEach(s => {
+      for (const s of this.actor.pilotSkills) {
         check.options.push(s.name)
-      })
+      }
       check.hasOptions = !!check.options.length
 
       if (this.data.speedCheck?.id) {

--- a/module/items/sheets/occupation.js
+++ b/module/items/sheets/occupation.js
@@ -133,7 +133,7 @@ export class CoC7OccupationSheet extends ItemSheet {
     } else {
       const div = $(`<div class="item-summary">${chatData.value}</div>`)
       const props = $('<div class="item-properties"></div>')
-      // chatData.properties.forEach(p => props.append(`<span class="tag">${p}</span>`));
+      // for (const p of chatData.properties) { props.append(`<span class="tag">${p}</span>`) }
       div.append(props)
       li.append(div.hide())
       div.slideDown(200)
@@ -231,7 +231,7 @@ export class CoC7OccupationSheet extends ItemSheet {
     }
 
     data.skillListEmpty = data.data.skills.length === 0
-    data.data.skills.forEach(skill => {
+    for (const skill of data.data.skills) {
       // For each skill if it's a spec and spac name not included in the name add it
       if (
         skill.data.specialization &&
@@ -239,7 +239,7 @@ export class CoC7OccupationSheet extends ItemSheet {
       ) {
         skill.displayName = `${skill.data.specialization} (${skill.name})`
       } else skill.displayName = skill.name
-    })
+    }
 
     data.data.skills.sort((a, b) => {
       return a.displayName.localeCompare(b.displayName)
@@ -248,7 +248,7 @@ export class CoC7OccupationSheet extends ItemSheet {
     for (let index = 0; index < data.data.groups.length; index++) {
       data.data.groups[index].isEmpty =
         data.data.groups[index].skills.length === 0
-      data.data.groups[index].skills.forEach(skill => {
+      for (const skill of data.data.groups[index].skills) {
         // For each skill of each sub group if it's a spec and spac name not included in the name add it
         if (
           skill.data.specialization &&
@@ -256,7 +256,7 @@ export class CoC7OccupationSheet extends ItemSheet {
         ) {
           skill.displayName = `${skill.data.specialization} (${skill.name})`
         } else skill.displayName = skill.name
-      })
+      }
 
       data.data.groups[index].skills.sort((a, b) => {
         return a.displayName.localeCompare(b.displayName)

--- a/module/items/sheets/setup.js
+++ b/module/items/sheets/setup.js
@@ -95,7 +95,7 @@ export class CoC7SetupSheet extends ItemSheet {
     } else {
       const div = $(`<div class="item-summary">${chatData.value}</div>`)
       const props = $('<div class="item-properties"></div>')
-      // chatData.properties.forEach(p => props.append(`<span class="tag">${p}</span>`));
+      // for (const p of chatData.properties) { props.append(`<span class="tag">${p}</span>`) }
       div.append(props)
       li.append(div.hide())
       div.slideDown(200)
@@ -177,14 +177,14 @@ export class CoC7SetupSheet extends ItemSheet {
     data.otherItems = data.data.items.filter(it => it.type !== 'skill')
 
     data.skillListEmpty = data.skills.length === 0
-    data.skills.forEach(skill => {
+    for (const skill of data.skills) {
       if (
         skill.data.specialization &&
         !skill.name.includes(skill.data.specialization)
       ) {
         skill.displayName = `${skill.data.specialization} (${skill.name})`
       } else skill.displayName = skill.name
-    })
+    }
 
     data.skills.sort((a, b) => {
       return a.displayName.localeCompare(b.displayName)

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -56,16 +56,16 @@ export class CoC7Utilities {
       const thresholdStr = escaped.match(/[^(]+(?=\))/)
       if (thresholdStr && thresholdStr.length) {
         threshold = Number(thresholdStr[0])
-        thresholdStr.forEach(match => {
+        for (const match of thresholdStr) {
           escaped = escaped.replace(`(${match})`, '')
-        })
+        }
       }
       const difficultyStr = escaped.match(/[^[]+(?=\])/)
       if (difficultyStr && difficultyStr.length) {
         difficulty = CoC7Utilities.convertDifficulty(difficultyStr[0])
-        difficultyStr.forEach(match => {
+        for (const match of difficultyStr) {
           escaped = escaped.replace(`[${match}]`, '')
-        })
+        }
       }
       if (escaped.includes('?')) {
         ask = true
@@ -433,84 +433,86 @@ export class CoC7Utilities {
   static async startRest () {
     const actors = game.actors.filter(actor => actor.hasPlayerOwner)
     let chatContent = `<i>${game.i18n.localize('CoC7.dreaming')}...</i><br>`
-    actors.forEach(actor => {
-      let quickHealer = false
-      actor.data.items.forEach(item => {
-        if (item.type === 'talent') {
-          if (item.name === `${game.i18n.localize('CoC7.quickHealer')}`) {
-            quickHealer = true
+    for (const actor of actors) {
+      if (['character', 'npc', 'creature'].includes(actor.type)) {
+        let quickHealer = false
+        for (const item of actor.data.items) {
+          if (item.type === 'talent') {
+            if (item.name === `${game.i18n.localize('CoC7.quickHealer')}`) {
+              quickHealer = true
+            }
           }
         }
-      })
-      const isCriticalWounds = actor.data.data.status.criticalWounds.value
-      const dailySanityLoss = actor.data.data.attribs.san.dailyLoss
-      const hpValue = actor.data.data.attribs.hp.value
-      const hpMax = actor.data.data.attribs.hp.max
-      const oneFifthSanity =
-        ' / ' + Math.floor(actor.data.data.attribs.san.value / 5)
-      const mpValue = actor.data.data.attribs.mp.value
-      const mpMax = actor.data.data.attribs.mp.max
-      chatContent = chatContent + `<br><b>${actor.name}. </b>`
-      if (isCriticalWounds === false && hpValue < hpMax) {
-        if (game.settings.get('CoC7', 'pulpRules') && quickHealer === true) {
+        const isCriticalWounds = actor.data.data.status.criticalWounds.value
+        const dailySanityLoss = actor.data.data.attribs.san.dailyLoss
+        const hpValue = actor.data.data.attribs.hp.value
+        const hpMax = actor.data.data.attribs.hp.max
+        const oneFifthSanity =
+          ' / ' + Math.floor(actor.data.data.attribs.san.value / 5)
+        const mpValue = actor.data.data.attribs.mp.value
+        const mpMax = actor.data.data.attribs.mp.max
+        chatContent = chatContent + `<br><b>${actor.name}. </b>`
+        if (isCriticalWounds === false && hpValue < hpMax) {
+          if (game.settings.get('CoC7', 'pulpRules') && quickHealer === true) {
+            chatContent =
+              chatContent +
+              `<b style="color:darkolivegreen">${game.i18n.format(
+                'CoC7.pulpHealthRecovered',
+                { number: 3 }
+              )}. </b>`
+            actor.update({
+              'data.attribs.hp.value': actor.data.data.attribs.hp.value + 3
+            })
+          } else if (game.settings.get('CoC7', 'pulpRules')) {
+            chatContent =
+              chatContent +
+              `<b style="color:darkolivegreen">${game.i18n.format(
+                'CoC7.pulpHealthRecovered',
+                { number: 2 }
+              )}. </b>`
+            actor.update({
+              'data.attribs.hp.value': actor.data.data.attribs.hp.value + 2
+            })
+          } else {
+            chatContent =
+              chatContent +
+              `<b style="color:darkolivegreen">${game.i18n.localize(
+                'CoC7.healthRecovered'
+              )}. </b>`
+            actor.update({
+              'data.attribs.hp.value': actor.data.data.attribs.hp.value + 1
+            })
+          }
+        } else if (isCriticalWounds === true && hpValue < hpMax) {
           chatContent =
             chatContent +
-            `<b style="color:darkolivegreen">${game.i18n.format(
-              'CoC7.pulpHealthRecovered',
-              { number: 3 }
+            `<b style="color:darkred">${game.i18n.localize(
+              'CoC7.hasCriticalWounds'
             )}. </b>`
-          actor.update({
-            'data.attribs.hp.value': actor.data.data.attribs.hp.value + 3
-          })
-        } else if (game.settings.get('CoC7', 'pulpRules')) {
-          chatContent =
-            chatContent +
-            `<b style="color:darkolivegreen">${game.i18n.format(
-              'CoC7.pulpHealthRecovered',
-              { number: 2 }
-            )}. </b>`
-          actor.update({
-            'data.attribs.hp.value': actor.data.data.attribs.hp.value + 2
-          })
-        } else {
+        }
+        if (dailySanityLoss > 0) {
           chatContent =
             chatContent +
             `<b style="color:darkolivegreen">${game.i18n.localize(
-              'CoC7.healthRecovered'
-            )}. </b>`
+              'CoC7.dailySanLossRestarted'
+            )}.</b>`
           actor.update({
-            'data.attribs.hp.value': actor.data.data.attribs.hp.value + 1
+            'data.attribs.san.dailyLoss': 0,
+            'data.attribs.san.oneFifthSanity': oneFifthSanity
           })
         }
-      } else if (isCriticalWounds === true && hpValue < hpMax) {
-        chatContent =
-          chatContent +
-          `<b style="color:darkred">${game.i18n.localize(
-            'CoC7.hasCriticalWounds'
-          )}. </b>`
+        if (mpValue < mpMax) {
+          chatContent =
+            chatContent +
+            `<b style="color:darkolivegreen">${game.i18n.format(
+              'CoC7.magicPointsRecovered'
+            )}: 7.</b>`
+          actor.update({
+            'data.attribs.mp.value': actor.data.data.attribs.mp.value + 7
+          })
+        }
       }
-      if (dailySanityLoss > 0) {
-        chatContent =
-          chatContent +
-          `<b style="color:darkolivegreen">${game.i18n.localize(
-            'CoC7.dailySanLossRestarted'
-          )}.</b>`
-        actor.update({
-          'data.attribs.san.dailyLoss': 0,
-          'data.attribs.san.oneFifthSanity': oneFifthSanity
-        })
-      }
-      if (mpValue < mpMax) {
-        chatContent =
-          chatContent +
-          `<b style="color:darkolivegreen">${game.i18n.format(
-            'CoC7.magicPointsRecovered'
-          )}: 7.</b>`
-        actor.update({
-          'data.attribs.mp.value': actor.data.data.attribs.mp.value + 7
-        })
-      }
-    })
+    }
     const chatData = {
       user: game.user.id,
       speaker: ChatMessage.getSpeaker(),
@@ -560,9 +562,9 @@ export class CoC7Utilities {
     const actors = []
 
     if (game.user.isGM && canvas.tokens.controlled.length) {
-      canvas.tokens.controlled.forEach(token => {
+      for (const token of canvas.tokens.controlled) {
         actors.push(token.actor.tokenKey)
-      })
+      }
     } else if (game.user.character) {
       actors.push(game.user.character.tokenKey)
     }
@@ -593,19 +595,19 @@ export class CoC7Utilities {
 
   static updateCharSheets () {
     if (game.user.isGM) {
-      game.actors.contents.forEach(a => {
+      for (const a of game.actors.contents) {
         if (a?.data?.type === 'character' && a?.sheet && a?.sheet?.rendered) {
           a.update({ 'data.flags.locked': true })
           a.render(false)
         }
-      })
+      }
     } else {
-      game.actors.contents.forEach(a => {
+      for (const a of game.actors.contents) {
         if (a.isOwner) {
           a.update({ 'data.flags.locked': true })
           a.render(false)
         }
-      })
+      }
     }
   }
 


### PR DESCRIPTION
When dragging a setup and then an occupation onto a character skills added directly after a skill with a base equation can not have the occupation flag set.

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to change).
