### PR TITLE
Optionally include elevation in range combat distances

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -717,6 +717,7 @@
 
   "CoC7.MessageTitleSelectUserToGiveTo": "Give item to another character",
   "CoC7.MessageSelectUserToGiveTo": "Which character would you like to give this item to?",
+  "CoC7.MessageDistanceCalculationFailure": "Unable to calculate distance between tokens, please use the token character sheet.",
 
   "SETTINGS.TitleRules": "Rules",
   "SETTINGS.TitleInitiative": "Initiative Settings",
@@ -822,5 +823,7 @@
   "SETTINGS.EnableStatusIconsHint": "Set if combat and sanity effects icons are shown in tokens.",
   "SETTINGS.ShowExperimentalFeatures": "Show Experimental Features",
   "SETTINGS.ShowExperimentalFeaturesHint": "Your world may become unusable in a future release if you use these features. For testing only DO NOT use these in your game worlds",
-  "CoC7.ExperimentalFeaturesWarning": "This feature is a work in progress and is not recommended for use in your game world."
+  "CoC7.ExperimentalFeaturesWarning": "This feature is a work in progress and is not recommended for use in your game world.",
+  "SETTINGS.CheckElevation": "Include elevation in distance",
+  "SETTINGS.CheckElevationHint": "Use elevation in range combat distance calculations"
 }

--- a/module/chat/helper.js
+++ b/module/chat/helper.js
@@ -1,4 +1,4 @@
-/* global canvas, ChatMessage, CONST, duplicate, game, Ray, Token */
+/* global canvas, ChatMessage, CONST, duplicate, game, Ray, Token, ui */
 
 import { CoC7Check } from '../check.js'
 
@@ -253,6 +253,17 @@ export class chatHelper {
   static getDistance (startToken, endToken) {
     // startToken.updateSource();
     // canvas.sight.initializeTokens();
+    if (typeof endToken.center === 'undefined' && typeof endToken.data.document?.id !== 'undefined') {
+      if (startToken.scene?.id || false) {
+        const scene = game.scenes.get(startToken.scene.id)
+        if (typeof scene?.tokens !== 'undefined') {
+          const tokens = scene?.tokens.filter(token => token.actor.id === endToken.data.document.id).map(token => token.object)
+          if (tokens.length === 1) {
+            endToken = tokens[0]
+          }
+        }
+      }
+    }
     let distance = {
       gridUnit: 0,
       value: 0,
@@ -274,6 +285,12 @@ export class chatHelper {
         })[0],
         unit: canvas.scene.data.gridUnits
       }
+      if (game.settings.get('CoC7', 'distanceElevation')) {
+        const elevation = Math.abs((startToken.data.elevation || 0) - (endToken.data.elevation || 0))
+        distance.value = Math.sqrt(distance.value * distance.value + elevation * elevation)
+      }
+    } else {
+      ui.notifications.warn(game.i18n.localize('CoC7.MessageDistanceCalculationFailure'))
     }
     return distance
   }

--- a/module/scripts/register-settings.js
+++ b/module/scripts/register-settings.js
@@ -177,6 +177,14 @@ export function registerSettings () {
     default: false,
     type: Boolean
   })
+  game.settings.register('CoC7', 'distanceElevation', {
+    name: 'SETTINGS.CheckElevation',
+    hint: 'SETTINGS.CheckElevationHint',
+    scope: 'world',
+    config: true,
+    default: true,
+    type: Boolean
+  })
 
   /**
    * Sheet settings


### PR DESCRIPTION
Show warning message if unable to calculate distance
Update ranged calculation from actor sheet to scene token, if there is only one copy of the actor's token in the scene use that token in the range calculation

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
