### PR TITLE
Character sheet tooltips

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -732,6 +732,16 @@
   "CoC7.MessageSelectUserToGiveTo": "Which character would you like to give this item to?",
   "CoC7.MessageDistanceCalculationFailure": "Unable to calculate distance between tokens, please use the token character sheet.",
 
+  "CoC7.ToolTipSkill": "<label>{skill} {regular}% ({hard}/{extreme})</label><ol><li><strong>Left click</strong> roll check with options</li><li><strong>Shift + Left click</strong> Immediate regular difficult check roll</li></ol><label>Opposed checks</label><ol><li><strong>Right click</strong> Opposed check with options</li><li><strong>Shift + Right click</strong> Immediate opposed check</li></ol><label>Combined checks</label><ol><li><strong>Alt/Option + Right click</strong> Opposed check with options</li></ol>",
+  "CoC7.ToolTipKeeperSkill": "<label>Keeper checks</label><ol><li><strong>CTRL + Left click</strong> Create roll link</li>{other}</ol>",
+  "CoC7.ToolTipKeeperStandbySkill": "<li><strong>Left click</strong> Request a roll from {name}</li>",
+  "CoC7.ToolTipDB": "<label>Damage Bonus</label><ol><li><strong>Left click</strong> Immediate regular difficult check roll</li></ol>",
+  "CoC7.ToolTipKeeperSanity": "<li><strong>CTRL + Alt/Option</strong> Create sanity check roll link</li>",
+  "CoC7.ToolTipAutoToggle": "<label>Automatic calculation toggle</label><ol><li><strong>Left click</strong> Toggle automatic calculation / manual entry</li>",
+  "CoC7.ToolTipSkillFlagToggle": "<label>{status}</label><ol><li><strong>Double Click</strong> Toggle flag status</li>",
+  "CoC7.ToolTipSkillFlagged": "Flagged for development",
+  "CoC7.ToolTipSkillUnflagged": "Not flagged for development",
+
   "SETTINGS.TitleRules": "Rules",
   "SETTINGS.TitleInitiative": "Initiative Settings",
   "SETTINGS.TitleRoll": "Roll Settings",
@@ -838,5 +848,6 @@
   "SETTINGS.ShowExperimentalFeaturesHint": "Your world may become unusable in a future release if you use these features. For testing only DO NOT use these in your game worlds",
   "CoC7.ExperimentalFeaturesWarning": "This feature is a work in progress and is not recommended for use in your game world.",
   "SETTINGS.CheckElevation": "Include elevation in distance",
-  "SETTINGS.CheckElevationHint": "Use elevation in range combat distance calculations"
+  "SETTINGS.CheckElevationHint": "Use elevation in range combat distance calculations",
+  "CoC7.toolTipDelay": "Millisecond delay before tooltip should show, 0 for never"
 }

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -922,6 +922,125 @@ export class CoC7ActorSheet extends ActorSheet {
       if (event.shiftKey) ui.notifications.info('Shift cliecked')
       // SanCheckCard.create( this.actor.actorKey, {min:'1D10',max:'1D12'}, {fastForward:event.shiftKey});
     })
+    html.find('.skill-name.rollable').mouseenter(this.toolTipSkillEnter.bind(this)).mouseleave(game.CoC7Tooltips.toolTipLeave.bind(this))
+    html.find('.characteristic-label').mouseenter(this.toolTipCharacteristicEnter.bind(this)).mouseleave(game.CoC7Tooltips.toolTipLeave.bind(this))
+    html.find('.attribute-label.rollable').mouseenter(this.toolTipAttributeEnter.bind(this)).mouseleave(game.CoC7Tooltips.toolTipLeave.bind(this))
+    html.find('.auto-toggle').mouseenter(this.toolTipAutoEnter.bind(this)).mouseleave(game.CoC7Tooltips.toolTipLeave.bind(this))
+    html.find('.item-control.development-flag').mouseenter(this.toolTipFlagForDevelopment.bind(this)).mouseleave(game.CoC7Tooltips.toolTipLeave.bind(this))
+  }
+
+  toolTipSkillEnter (event) {
+    const delay = parseInt(game.settings.get('CoC7', 'toolTipDelay'))
+    if (delay > 0) {
+      const sheet = this
+      game.CoC7Tooltips.ToolTipHover = event.currentTarget
+      game.CoC7Tooltips.toolTipTimer = setTimeout(function () {
+        if (typeof game.CoC7Tooltips.ToolTipHover !== 'undefined') {
+          const item = game.CoC7Tooltips.ToolTipHover.closest('.item')
+          if (typeof item !== 'undefined') {
+            const skillId = item.dataset.skillId
+            const skill = sheet.actor.items.get(skillId)
+            let toolTip = game.i18n.format('CoC7.ToolTipSkill', { skill: skill.sName, regular: skill.value, hard: Math.floor(skill.value / 2), extreme: Math.floor(skill.value / 5) })
+            if (game.user.isGM) {
+              toolTip = toolTip + game.i18n.format('CoC7.ToolTipKeeperSkill', { other: (game.settings.get('CoC7', 'stanbyGMRolls') && sheet.actor.hasPlayerOwner ? game.i18n.format('CoC7.ToolTipKeeperStandbySkill', { name: sheet.actor.name }) : '') })
+            }
+            game.CoC7Tooltips.displayToolTip(toolTip)
+          }
+        }
+      }, delay)
+    }
+  }
+
+  toolTipCharacteristicEnter (event) {
+    const delay = parseInt(game.settings.get('CoC7', 'toolTipDelay'))
+    if (delay > 0) {
+      const sheet = this
+      game.CoC7Tooltips.ToolTipHover = event.currentTarget
+      game.CoC7Tooltips.toolTipTimer = setTimeout(function () {
+        if (typeof game.CoC7Tooltips.ToolTipHover !== 'undefined') {
+          const char = game.CoC7Tooltips.ToolTipHover.closest('.char-box')
+          if (typeof char !== 'undefined') {
+            const charId = char.dataset.characteristic
+            const characteristic = sheet.actor.characteristics[charId]
+            let toolTip = game.i18n.format('CoC7.ToolTipSkill', { skill: characteristic.label, regular: characteristic.value, hard: characteristic.hard, extreme: characteristic.extreme })
+            if (game.user.isGM) {
+              toolTip = toolTip + game.i18n.format('CoC7.ToolTipKeeperSkill', { other: (game.settings.get('CoC7', 'stanbyGMRolls') && sheet.actor.hasPlayerOwner ? game.i18n.format('CoC7.ToolTipKeeperStandbySkill', { name: sheet.actor.name }) : '') })
+            }
+            game.CoC7Tooltips.displayToolTip(toolTip)
+          }
+        }
+      }, delay)
+    }
+  }
+
+  toolTipAttributeEnter (event) {
+    const delay = parseInt(game.settings.get('CoC7', 'toolTipDelay'))
+    if (delay > 0) {
+      const sheet = this
+      game.CoC7Tooltips.ToolTipHover = event.currentTarget
+      game.CoC7Tooltips.toolTipTimer = setTimeout(function () {
+        if (typeof game.CoC7Tooltips.ToolTipHover !== 'undefined') {
+          const attrib = game.CoC7Tooltips.ToolTipHover.closest('.attribute')
+          if (typeof attrib !== 'undefined') {
+            const attributeId = attrib.dataset.attrib
+            let toolTip = ''
+            const attributes = sheet.actor.data.data.attribs[attributeId]
+            switch (attributeId) {
+              case 'lck':
+                toolTip = game.i18n.format('CoC7.ToolTipSkill', { skill: attributes.label, regular: attributes.value, hard: Math.floor(attributes.value / 2), extreme: Math.floor(attributes.value / 5) })
+                if (game.user.isGM) {
+                  toolTip = toolTip + game.i18n.format('CoC7.ToolTipKeeperSkill', { other: (game.settings.get('CoC7', 'stanbyGMRolls') && sheet.actor.hasPlayerOwner ? game.i18n.format('CoC7.ToolTipKeeperStandbySkill', { name: sheet.actor.name }) : '') })
+                }
+                game.CoC7Tooltips.displayToolTip(toolTip)
+                break
+              case 'db':
+                toolTip = game.i18n.localize('CoC7.ToolTipDB')
+                game.CoC7Tooltips.displayToolTip(toolTip)
+                break
+              case 'san':
+                toolTip = game.i18n.format('CoC7.ToolTipSkill', { skill: 'Sanity', regular: attributes.value, hard: Math.floor(attributes.value / 2), extreme: Math.floor(attributes.value / 5) })
+                if (game.user.isGM) {
+                  toolTip = toolTip + game.i18n.format('CoC7.ToolTipKeeperSkill', { other: game.i18n.localize('CoC7.ToolTipKeeperSanity') + (game.settings.get('CoC7', 'stanbyGMRolls') && sheet.actor.hasPlayerOwner ? game.i18n.format('CoC7.ToolTipKeeperStandbySkill', { name: sheet.actor.name }) : '') })
+                }
+                game.CoC7Tooltips.displayToolTip(toolTip)
+                break
+            }
+          }
+        }
+      }, delay)
+    }
+  }
+
+  toolTipAutoEnter (event) {
+    const delay = parseInt(game.settings.get('CoC7', 'toolTipDelay'))
+    if (delay > 0) {
+      game.CoC7Tooltips.ToolTipHover = event.currentTarget
+      game.CoC7Tooltips.toolTipTimer = setTimeout(function () {
+        if (typeof game.CoC7Tooltips.ToolTipHover !== 'undefined') {
+          const toolTip = game.i18n.localize('CoC7.ToolTipAutoToggle')
+          game.CoC7Tooltips.displayToolTip(toolTip)
+        }
+      }, delay)
+    }
+  }
+
+  toolTipFlagForDevelopment (event) {
+    const delay = parseInt(game.settings.get('CoC7', 'toolTipDelay'))
+    if (delay > 0) {
+      const sheet = this
+      game.CoC7Tooltips.ToolTipHover = event.currentTarget
+      game.CoC7Tooltips.toolTipTimer = setTimeout(function () {
+        if (typeof game.CoC7Tooltips.ToolTipHover !== 'undefined') {
+          const item = game.CoC7Tooltips.ToolTipHover.closest('.item')
+          if (typeof item !== 'undefined') {
+            const skillId = item.dataset.skillId
+            const skill = sheet.actor.items.get(skillId)
+            const toolTip = game.i18n.format('CoC7.ToolTipSkillFlagToggle', { status: game.i18n.localize((skill.data.data.flags.developement ? 'CoC7.ToolTipSkillFlagged' : 'CoC7.ToolTipSkillUnflagged')) })
+            game.CoC7Tooltips.displayToolTip(toolTip)
+          }
+        }
+      }, delay)
+    }
   }
 
   _onRenderItemSheet (event) {

--- a/module/apps/tooltips.js
+++ b/module/apps/tooltips.js
@@ -1,0 +1,42 @@
+/* global game */
+export class CoC7Tooltips {
+  constructor () {
+    this.ToolTipHover = null
+    this.toolTipTimer = null
+  }
+
+  displayToolTip (toolTip) {
+    if (typeof this.ToolTipHover !== 'undefined') {
+      const bounds = this.ToolTipHover.getBoundingClientRect()
+      if (!isNaN(bounds.left || '') && !isNaN(bounds.top || '')) {
+        let left = bounds.left
+        let top = bounds.top
+        const heightText = $(this.ToolTipHover).outerHeight()
+        $('body').append('<div id="help-tooltip">' + toolTip + '</div>')
+        const tip = $('#help-tooltip')
+        const heightTip = tip.outerHeight()
+        const widthTip = tip.outerWidth()
+        if (window.innerHeight < (heightText * 1.5 + heightTip + top)) {
+          top = top - heightTip
+        } else {
+          top = top + heightText * 1.5
+        }
+        if (window.innerWidth < (widthTip + left)) {
+          left = window.innerWidth - widthTip
+        }
+        tip.css({
+          left: left + 'px',
+          top: top + 'px'
+        })
+      }
+    }
+  }
+
+  toolTipLeave (event) {
+    if (game.CoC7Tooltips.ToolTipHover === event.currentTarget) {
+      clearTimeout(game.CoC7Tooltips.toolTipTimer)
+      game.CoC7Tooltips.ToolTipHover = null
+      $('#help-tooltip').remove()
+    }
+  }
+}

--- a/module/hooks/ready.js
+++ b/module/hooks/ready.js
@@ -1,4 +1,5 @@
 /* global game, Hooks */
+import { CoC7Tooltips } from '../apps/tooltips.js'
 
 // import { CoC7WelcomeMessage } from '../apps/welcome-message.js'
 
@@ -9,5 +10,6 @@ export function listen () {
       /** This will prompt the welcome message when it is  finished */
       // await CoC7WelcomeMessage.create()
     }
+    game.CoC7Tooltips = new CoC7Tooltips()
   })
 }

--- a/module/scripts/register-settings.js
+++ b/module/scripts/register-settings.js
@@ -196,6 +196,13 @@ export function registerSettings () {
     default: false,
     type: Boolean
   })
+  game.settings.register('CoC7', 'toolTipDelay', {
+    name: 'CoC7.toolTipDelay',
+    scope: 'world',
+    config: true,
+    default: 2000,
+    type: Number
+  })
   game.settings.register('CoC7', 'showIconsOnly', {
     name: 'SETTINGS.showIconsOnly',
     scope: 'world',

--- a/styles/system/index.less
+++ b/styles/system/index.less
@@ -28,3 +28,4 @@
 @import 'variables.less';
 @import 'default-override.less';
 @import '../sheets/summary.less';
+@import 'tooltips.less';

--- a/styles/system/tooltips.less
+++ b/styles/system/tooltips.less
@@ -1,0 +1,23 @@
+#help-tooltip {
+  z-index: 509;
+  position: absolute;
+  left: -999px;
+  top: -999px;
+  background-color: #fff;
+  padding: 0.5rem 0 0 0;
+  border: 2px solid #670b0b;
+  background: url(/ui/parchment.jpg) repeat;
+  label {
+    font-weight: bold;
+    font-size: 0.8rem;
+    margin: 0.5rem;
+  }
+  ol {
+    padding: 0;
+    margin: 0 0.5rem 0.5rem;
+    list-style: none;
+    li {
+      font-size: 0.75rem;
+    }
+  }
+}

--- a/templates/actors/parts/actor-skills-v2.html
+++ b/templates/actors/parts/actor-skills-v2.html
@@ -48,15 +48,15 @@
         <li class="item itemV2 {{#if skill.data.properties.special}}specialization{{/if}}" data-skill-id="{{skill._id}}" data-item-id="{{skill._id}}">
           <div class="item-image" style="background-image: url('{{skill.img}}')"></div>
           {{#if ../data.flags.locked}}
-            <div class="item-name skill-name rollable"  title="{{skill.name}}">{{skill.name}}</div>
+            <div class="item-name skill-name rollable">{{skill.name}}</div>
             <div class="item-score">{{skill.data.value}}</div>
             <div class="item-controls">
               {{#unless skill.data.properties.noxpgain}}
                 <!-- <a class="item-control inactive" title="{{localize 'CoC7.SkillCantGainXp'}}"><i class="fas fa-certificate"></i></a> -->
                 {{#if skill.data.flags.developement}}
-                  <a class="item-control development-flag active" title="{{localize 'CoC7.SkillUnflagForDevelopement'}}"><i class="fas fa-certificate"></i></a>
+                  <a class="item-control development-flag active"><i class="fas fa-certificate"></i></a>
                 {{else}}
-                  <a class="item-control development-flag" title="{{localize 'CoC7.SkillFlagForDevelopement'}}"><i class="fas fa-certificate"></i></a>
+                  <a class="item-control development-flag"><i class="fas fa-certificate"></i></a>
                 {{/if}}
               {{/unless}}
               <a class="item-control item-popup" title="{{localize 'CoC7.SkillDetail'}}"><i class="fas fa-info-circle"></i></a>


### PR DESCRIPTION
## Description.
Setting for tooltip delay, by default if you hover over a valid element for two seconds show the tooltip. Zero to turn off.

Tooltips for
* Skills
* Luck
* Sanity
* Damage bonus
* Automatic calculation toggle
* Characteristics
* Flag / unflag for development

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
