### PR TITLE
Add option to force DSN

### DIFF
--- a/module/chat/cards/san-check.js
+++ b/module/chat/cards/san-check.js
@@ -290,7 +290,7 @@ export class SanCheckCard extends ChatCardActor {
     this.sanCheck.difficulty =
       this.options.sanDifficulty || CoC7Check.difficultyLevel.regular
     this.sanCheck.diceModifier = this.options.sanModifier || 0
-    await this.sanCheck._perform()
+    await this.sanCheck._perform( {forceDSN: true})
     this.state.sanRolled = true
     this.state.involuntaryActionPerformed = this.sanCheck.passed
     this.state.sanLossRolled = true
@@ -305,7 +305,7 @@ export class SanCheckCard extends ChatCardActor {
     this.sanCheck.difficulty =
       this.options.sanDifficulty || CoC7Check.difficultyLevel.regular
     this.sanCheck.diceModifier = this.options.sanModifier || 0
-    await this.sanCheck._perform()
+    await this.sanCheck._perform( {forceDSN: true})
     this.state.sanRolled = true
     this.state.involuntaryActionPerformed = this.sanCheck.passed
     if (!this.isActorLoosingSan) {
@@ -429,7 +429,7 @@ export class SanCheckCard extends ChatCardActor {
     this.intCheck.difficulty =
       this.options.intDifficulty || CoC7Check.difficultyLevel.regular
     this.intCheck.diceModifier = this.options.intModifier || 0
-    await this.intCheck._perform()
+    await this.intCheck._perform( {forceDSN: true})
     this.state.intRolled = true
     if (this.intCheck.passed || this.state.alreadyInsane) {
       this.state.insanity = true

--- a/module/check.js
+++ b/module/check.js
@@ -718,6 +718,10 @@ export class CoC7Check {
       (await CoC7Dice.roll(this.diceModifier, this.rollMode, this.isBlind))
     if (!options.silent) AudioHelper.play({ src: CONFIG.sounds.dice })
 
+    if( options.forceDSN){
+      await CoC7Dice.showRollDice3d( this.dice.roll)
+    }
+
     this.dices = {
       tens: [],
       unit: {


### PR DESCRIPTION
Add dice rolls to SAN workflow

## Description.

Option added to CoC7Check._perform() : forceDSN will force displaying the dice
SAN workflow chat cards modified to show the roll for SAN and INT check

## Motivation and Context.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->

## Screenshots.

<!-- If appropriate. -->

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
