### PR TITLE
Merged any spell keeper notes accidentally stored in data.notes

### DIFF
--- a/module/updater.js
+++ b/module/updater.js
@@ -239,6 +239,7 @@ export class Updater {
     Updater._migrateItemBookAutomated(item, updateData)
     Updater._migrateItemKeeperNotes(item, updateData)
     Updater._migrateItemSpellAutomated(item, updateData)
+    Updater._migrateItemKeeperNotesMerge(item, updateData)
 
     return updateData
   }
@@ -433,6 +434,19 @@ export class Updater {
       }
     }
     return updateData
+  }
+
+  static _migrateItemKeeperNotesMerge (item, updateData) {
+    if (item.type === 'spell') {
+      if (typeof item.data.notes !== 'undefined') {
+        if (typeof item.data.description.keeper !== 'undefined') {
+          updateData['data.description.keeper'] = item.data.description.keeper + item.data.notes
+        } else {
+          updateData['data.description.keeper'] = item.data.notes
+        }
+        updateData['data.-=notes'] = null
+      }
+    }
   }
 
   static _migrateActorArtwork (actor, updateData) {


### PR DESCRIPTION
## Description.
Typo in spell sheet that stored keeper notes in data.notes.
If there is existing keeper notes and data.notes merge them, otherwise replace empty keeper notes with data.notes

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
