### PR TITLE
Remove comment from handlebar JS template

### DIFF
--- a/templates/actors/parts/actor-background.html
+++ b/templates/actors/parts/actor-background.html
@@ -22,7 +22,6 @@
     </div>
     {{/if}}
     <textarea class='bio-section-value' style='height: max-content;resize: none;font-family: customSheetFont, "Palatino Linotype", serif;font-size: 0.75rem;' rows="4" >{{section.value}}</textarea>
-    <!-- {{editor content=section.value target="section.value" button=true editable=editable}} -->
 </div>
 {{/each}}
 </div>


### PR DESCRIPTION
## Description.
If different text boxes have <3> and </3> the comment is being rendered incorrect, remove comment as there is not space for multiple tiny TinyMCE editors.

Resolves #913

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
