### PR TITLE
Updates to Spells in Books

### DIFF
--- a/module/items/spell/data.js
+++ b/module/items/spell/data.js
@@ -123,16 +123,15 @@ export class CoC7Spell extends CoC7Item {
         }
       }
       if (this.context.parent === null) {
-        item.update({
+        await item.update({
           'data.spells': book.data.spells
         })
+        this.sheet.object = new CoC7Spell(book.data.spells.find(spell => spell._id === this.id), this.context)
       } else {
-        this.context.parent.updateEmbeddedDocuments('Item', [book])
+        await this.context.parent.updateEmbeddedDocuments('Item', [book])
+        this.sheet.object = new CoC7Spell(book.data.spells.find(spell => spell._id === this.id), this.context)
       }
-      // const parent = book.actor ? book.actor : null
-      // const spell = new CoC7Spell(spellData, { parent, bookId: book.id })
-      // await this.sheet.close(true)
-      // await spell.sheet.render(true)
+      this.sheet.render(true)
     } else {
       super.update(data, context)
     }

--- a/module/updater.js
+++ b/module/updater.js
@@ -404,7 +404,7 @@ export class Updater {
         updateData['data.mythosRating'] = Number(item.data.mythosRating) || 0
         /** Renamed/moved fields */
         updateData['data.content'] = item.data.description.unidentified
-        updateData['data.keeperNotes'] = item.data.description.notes
+        updateData['data.description.keeper'] = item.data.description.notes
         /** New fields set default values */
         updateData['data.difficultyLevel'] = 'regular'
         updateData['data.fullStudies'] = 0
@@ -437,7 +437,7 @@ export class Updater {
   }
 
   static _migrateItemKeeperNotesMerge (item, updateData) {
-    if (item.type === 'spell') {
+    if (item.type === 'spell' || item.type === 'book') {
       if (typeof item.data.notes !== 'undefined') {
         if (typeof item.data.description.keeper !== 'undefined') {
           updateData['data.description.keeper'] =
@@ -446,6 +446,14 @@ export class Updater {
           updateData['data.description.keeper'] = item.data.notes
         }
         updateData['data.-=notes'] = null
+      }
+      if (typeof item.data.keeperNotes !== 'undefined') {
+        if (typeof updateData['data.description.keeper'] !== 'undefined') {
+          updateData['data.description.keeper'] = item.data.keeperNotes + updateData['data.description.keeper']
+        } else {
+          updateData['data.description.keeper'] = item.data.keeperNotes
+        }
+        updateData['data.-=keeperNotes'] = null
       }
     }
   }

--- a/template.json
+++ b/template.json
@@ -552,10 +552,10 @@
       },
       "description": {
         "chat": "",
-        "value": ""
+        "value": "",
+        "keeper": ""
       },
       "effects": [],
-      "keeperNotes": "",
       "source": "",
       "type": {
         "bind": false,
@@ -575,7 +575,8 @@
       "date": "",
       "description": {
         "chat": "",
-        "value": ""
+        "value": "",
+        "keeper": ""
       },
       "difficultyLevel": "",
       "fullStudies": 0,
@@ -588,7 +589,6 @@
         "others": []
       },
       "initialReading": false,
-      "keeperNotes": "",
       "language": "",
       "mythosRating": 0,
       "sanityLoss": 0,

--- a/templates/items/book/main.html
+++ b/templates/items/book/main.html
@@ -183,10 +183,9 @@
       </div>
       <div class="tab" data-group="primary" data-tab="notes">
         {{editor
-          content=data.notes
-          target="data.notes"
-          button=true
-          owner=owner
+          content=data.description.keeper
+          target="data.description.keeper"
+          button=true owner=owner
           editable=editable
         }}
       </div>

--- a/templates/items/spell/main.html
+++ b/templates/items/spell/main.html
@@ -69,8 +69,7 @@
         {{editor
           content=data.description.keeper
           target="data.description.keeper"
-          button=true
-          owner=owner
+          button=true owner=owner
           editable=editable
         }}
       </div>


### PR DESCRIPTION
Move keeperNotes into description.keeper for books and spells.

Generate a new Spell item then rerender when updating.

Resolves #905
Resolves #906

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
