### PR TITLE
Copy the importer example text to Clipboard 

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -874,6 +874,6 @@
   "CoC7.toolTipDelay": "Millisecond delay before tooltip should show, 0 for never",
 
   "CoC7.getTheExample": "Copy Example",
-  "CoC7.Copied": "Copied the Example Text"
+  "CoC7.Copied": "Copied the Example Text to Clipboard"
 
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -871,5 +871,9 @@
   "CoC7.ExperimentalFeaturesWarning": "This feature is a work in progress and is not recommended for use in your game world.",
   "SETTINGS.CheckElevation": "Include elevation in distance",
   "SETTINGS.CheckElevationHint": "Use elevation in range combat distance calculations",
-  "CoC7.toolTipDelay": "Millisecond delay before tooltip should show, 0 for never"
+  "CoC7.toolTipDelay": "Millisecond delay before tooltip should show, 0 for never",
+
+  "CoC7.getTheExample": "Copy Example",
+  "CoC7.Copied": "Copied the Example Text"
+
 }

--- a/lang/zh-TW.json
+++ b/lang/zh-TW.json
@@ -824,5 +824,7 @@
   "SETTINGS.ArtPauseTextHint": "留空為默認",
   "SETTINGS.CheckElevation": "在距離中包括高度",
   "SETTINGS.CheckElevationHint": "在範圍戰鬥距離計算中使用高度",
-  "CoC7.toolTipDelay": "顯示提示前的毫秒延遲，0表示從不顯示"
+  "CoC7.toolTipDelay": "顯示提示前的毫秒延遲，0表示從不顯示",
+  "CoC7.getTheExample": "複製示範文字",
+  "CoC7.Copied": "已複製示範文字"
 }

--- a/lang/zh-TW.json
+++ b/lang/zh-TW.json
@@ -826,7 +826,7 @@
   "SETTINGS.CheckElevationHint": "在範圍戰鬥距離計算中使用高度",
   "CoC7.toolTipDelay": "顯示提示前的毫秒延遲，0表示從不顯示",
   "CoC7.getTheExample": "複製示範文字",
-  "CoC7.Copied": "已複製示範文字",
+  "CoC7.Copied": "已複製示範文字到剪貼簿",
   "CoC7.NotEnoughMagicPoints": "{spell}需要消耗{originalMagicPoints}點MP，但你只有{actorMagicPoints}點。你希望轉換你{convertedHitPoints}點的HP嗎？這樣的話，你將會受到{convertedHitPoints}點的HP傷害。",
   "CoC7.German": "德文"
 }

--- a/module/apps/actor-importer-dialog.js
+++ b/module/apps/actor-importer-dialog.js
@@ -100,7 +100,7 @@ export class CoC7ActorImporterDialog extends Dialog {
 
   submit (button) {
     if(button.cssClass=="getExampleNow"){
-      var content = CoC7ActorImporterRegExp.getExampleText(game.i18n.lang);
+      var content = CoC7ActorImporterRegExp.getExampleText($("#coc-entity-lang :selected").val());
       navigator.clipboard.writeText(content)
           .then(() => {
             return ui.notifications.warn(

--- a/module/apps/actor-importer-dialog.js
+++ b/module/apps/actor-importer-dialog.js
@@ -99,9 +99,9 @@ export class CoC7ActorImporterDialog extends Dialog {
   }
 
   submit (button) {
-    if(button.cssClass=="getExampleNow"){
+    if(button.cssClass === "getExampleNow"){
       var content = CoC7ActorImporterRegExp.getExampleText($("#coc-entity-lang :selected").val());
-      navigator.clipboard.writeText(content)
+      CoC7Utilities.copyToClipboard(content)
           .then(() => {
             return ui.notifications.warn(
               game.i18n.localize('CoC7.Copied')

--- a/module/apps/actor-importer-dialog.js
+++ b/module/apps/actor-importer-dialog.js
@@ -99,6 +99,19 @@ export class CoC7ActorImporterDialog extends Dialog {
   }
 
   submit (button) {
+    if(button.cssClass=="getExampleNow"){
+      var content = CoC7ActorImporterRegExp.getExampleText(game.i18n.lang);
+      navigator.clipboard.writeText(content)
+          .then(() => {
+            return ui.notifications.warn(
+              game.i18n.localize('CoC7.Copied')
+            )
+      })
+          .catch(err => {
+          console.log('Something went wrong', err);
+      })
+      return
+    }
     if (
       $('#coc-pasted-character-data')
         .val()
@@ -135,6 +148,10 @@ export class CoC7ActorImporterDialog extends Dialog {
             no: {
               icon: '<i class="fas fa-times"></i>',
               label: game.i18n.localize('CoC7.Cancel')
+            },
+            getExampleNow: {
+              icon: '<i class="fas fa-info-circle"></i>',
+              label: game.i18n.localize('CoC7.getTheExample')
             }
           }
         },


### PR DESCRIPTION
## Description.

Add a button to copy the importer example text to Clipboard with a notifications.

## Motivation and Context.
Importer is a quick way to create a npc
But the text format is not necessarily the same as in some book
Or sometimes I want to add a self-created character
Then if you use the text of the example as a basis, you can quickly add new NPCs

## Screenshots.
![image](https://user-images.githubusercontent.com/23254376/141955249-6e20f5ce-7792-457d-b546-27d0ff27b303.png)

## Types of Changes.

- [x] New feature (non-breaking change which adds functionality).

