### PR TITLE
Select rest Target

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -662,6 +662,8 @@
   "CoC7.WarnFastTargetWithWrongMOV": "Fast selected on a target with less than 8 MOV. (MOV: {mov})",
   "CoC7.WarnTooManyTarget": "Too many target selected. Keeping only last selected target",
 
+  "CoC7.allActor": "All Actor",
+  "CoC7.whoGoToDream": "Rest Target: ",
   "CoC7.startRest": "Start Rest",
   "CoC7.dreaming": "The Investigators wait dreaming",
   "CoC7.healthRecovered": "Recovered one Hit Point",

--- a/lang/zh-TW.json
+++ b/lang/zh-TW.json
@@ -597,6 +597,9 @@
   "CoC7.toggleXP": "獲得 成長標記",
   "CoC7.XPGainEnabled": "角色現在可以獲得成長標記",
   "CoC7.XPGainDisabled": "角色現在無法獲得成長標記",
+
+  "CoC7.allActor": "所有角色",
+  "CoC7.whoGoToDream": "休息對象: ",
   "CoC7.startRest": "開始休息",
   "CoC7.dreaming": "調查員在夢境中等待",
   "CoC7.healthRecovered": "恢復 1 點生命值",

--- a/module/menu.js
+++ b/module/menu.js
@@ -85,7 +85,7 @@ export class CoC7Menu {
           icon: 'fas fa-moon',
           name: 'startrest',
           title: 'CoC7.startRest',
-          onClick: async () => await CoC7Utilities.startRest()
+          onClick: async () => await CoC7Utilities.getTarget()
         }
       ]
     })


### PR DESCRIPTION
## Description.
#945 
When press `start rest`  , pop out a dialog let kp select which actor rest.
It detect selected token on the map  and actor  which player selected.

## Motivation and Context.

Because KP may have a large number of characters in the world , or a world with several different games running.

## Screenshots.

![image](https://user-images.githubusercontent.com/23254376/143419291-d27945bb-90be-4dea-87c7-6f8bfc9293f4.png)


## Types of Changes.


- [x] New feature (non-breaking change which adds functionality).

