### PR TITLE
Fix CSS for tabs display

### DIFF
--- a/styles/sheets/sheets.less
+++ b/styles/sheets/sheets.less
@@ -2,6 +2,45 @@ html {
   font-size: 16px;
 }
 
+.tabs {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+.tabs > * {
+  flex: 1;
+}
+.tabs > .flex0 {
+  display: block;
+  flex: 0;
+}
+.tabs > .flex1 {
+  flex: 1;
+}
+.tabs > .flex2 {
+  flex: 2;
+}
+.tabs > .flex3 {
+  flex: 3;
+}
+.tabs .item {
+  text-align: center;
+}
+.tabs .item.active {
+  text-shadow: 0 0 10px red;
+}
+.tab[data-tab] {
+  display: none;
+}
+.tab[data-tab].active {
+  display: block;
+}
+.tab[data-tab].active.flexrow,
+.tab[data-tab].active.flexcol {
+  display: flex;
+}
+
 a.keeper-only-tab {
   flex: 0 0 30px;
   color: @colorGreen;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

Fix the display of tabs.

<!--- Describe your changes in details. -->

Apply tab style, keeper tab has now the correct size and tabs are properly displayed.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->

## Screenshots.

7.2:
![7.2](https://user-images.githubusercontent.com/65915923/147469970-43192d62-a1cb-41ce-843f-51a04cb23d80.png)
7.3:
![7.3](https://user-images.githubusercontent.com/65915923/147469996-e08fd5ba-a647-4894-a41c-9937ad7b81ef.png)
Fix:
![Fix](https://user-images.githubusercontent.com/65915923/147470020-b530507e-a334-4119-8142-bbc80eb15718.png)


## Types of Changes.


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
