### PR TITLE
Replace status/effect/ActiveEffect toggles with conditions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.{html,svg}]
+insert_final_newline = false

--- a/lang/en.json
+++ b/lang/en.json
@@ -740,6 +740,11 @@
   "CoC7.Migrate.ButtonSkip": "Skip",
   "CoC7.Migrate.ButtonOkay": "Okay",
 
+  "CoC7.Migrate.TriggerButton": "Trigger Data Migration",
+  "CoC7.Migrate.TriggerTitle": "Trigger Data Migration",
+  "CoC7.Migrate.TriggerContents": "<p>Turn on data migration and restart</p>",
+  "CoC7.Migrate.TriggerRestart": "Save and restart",
+
   "CoC7.Maximize": "Maximize",
   "CoC7.Summarize": "Summarize",
 

--- a/module/chat/cards/san-check.js
+++ b/module/chat/cards/san-check.js
@@ -1,5 +1,6 @@
 /* global $, game, renderTemplate, Roll, ui */
 
+import { COC7 } from '../../config.js'
 import { CoC7Check } from '../../check.js'
 import { CoC7Dice } from '../../dice.js'
 import { CoC7Utilities } from '../../utilities.js'
@@ -152,7 +153,7 @@ export class SanCheckCard extends ChatCardActor {
 
   get isActorLoosingSan () {
     // No san loss during bout of mad.
-    if (this.actor.isInABoutOfMadness) {
+    if (this.actor.hasTempoInsane) {
       return false
     }
 
@@ -187,17 +188,6 @@ export class SanCheckCard extends ChatCardActor {
       if (this.boutSummary) return `${this.boutDuration} hours`
     }
     return null
-  }
-
-  get alreadyInsaneText () {
-    if (this.actor.sanity.underlying.indefintie) {
-      return game.i18n.localize('CoC7.AlreadyUnderlyingInsanity')
-    } else {
-      return (
-        game.i18n.localize('CoC7.AlreadyUnderlyingInsanity') +
-        ` (${this.actor.sanity.underlying.durationText})`
-      )
-    }
   }
 
   get youGainCthulhuMythosString () {
@@ -250,7 +240,7 @@ export class SanCheckCard extends ChatCardActor {
         break
       }
       case 'boutOfMadnessOver': {
-        await this.actor.exitBoutOfMadness()
+        await this.actor.unsetCondition(COC7.status.tempoInsane)
         await this.triggerInsanity()
         break
       }
@@ -310,7 +300,7 @@ export class SanCheckCard extends ChatCardActor {
     this.state.involuntaryActionPerformed = this.sanCheck.passed
     if (!this.isActorLoosingSan) {
       this.state.finish = true
-      if (this.actor.isInABoutOfMadness) {
+      if (this.actor.hasTempoInsane) {
         this.state.immuneAlreadyInBout = true
         if (!this.sanCheck.passed) this.state.finish = false
       }
@@ -392,7 +382,7 @@ export class SanCheckCard extends ChatCardActor {
 
     if (this.sanLoss < 5) {
       this.state.intRolled = true
-      if (this.actor.isInsane) {
+      if (this.actor.isIndefInsane) {
         this.state.insanity = true
         this.state.shaken = true
         this.state.insanityTableRolled = false
@@ -447,23 +437,7 @@ export class SanCheckCard extends ChatCardActor {
 
   async triggerInsanity () {
     this.state.boutOfMadnessOver = true
-    if (this.state.indefinitelyInsane) await this.actor.enterInsanity(true)
-    if (this.state.temporaryInsane) {
-      if (
-        this.actor.sanity.underlying.active &&
-        this.actor.sanity.underlying.indefintie
-      ) {
-        // Already indefinite insanity
-        this.state.finish = true
-        return
-      }
-      this.insanityDurationRoll = await new Roll('1D10').roll({ async: true })
-      this.insanityDuration = this.insanityDurationRoll.total
-      if (this.actor.sanity.underlying.duration) {
-        this.insanityDuration += this.actor.sanity.underlying.duration
-      }
-      await this.actor.enterInsanity(false, this.insanityDuration)
-    }
+    if (this.state.indefinitelyInsane) await this.actor.setCondition(COC7.status.indefInsane)
     this.state.finish = true
   }
 
@@ -541,7 +515,7 @@ export class SanCheckCard extends ChatCardActor {
   static async create (...args) {
     const chatCard = new SanCheckCard(...args)
 
-    if (chatCard.actor.isInsane) {
+    if (chatCard.actor.isIndefInsane) {
       chatCard.state.alreadyInsane = true
     }
 

--- a/module/chat/concheck.js
+++ b/module/chat/concheck.js
@@ -1,5 +1,6 @@
 /* global $, ChatMessage, game, renderTemplate, ui */
 
+import { COC7 } from '../config.js'
 import { CoC7Check } from '../check.js'
 import { chatHelper, CoC7Roll } from './helper.js'
 
@@ -132,9 +133,12 @@ export class CoC7ConCheck {
   async rollCon () {
     this.check.hideDiceResult = true
     await this.check._perform()
-    if (!this.isSuccess && !this.isBlind) {
-      if (this.stayAlive) await this.actor.fallDead()
-      else await this.actor.fallUnconscious()
+    if (!this.isBlind && !this.isRolled && !this.isSuccess) {
+      if (this.stayAlive) {
+        await this.actor.setCondition(COC7.status.dead)
+      } else {
+        await this.actor.setCondition(COC7.status.unconscious)
+      }
     }
     this.applied = true
   }
@@ -149,8 +153,11 @@ export class CoC7ConCheck {
     check.replaceWith(await this.getCheckElement())
 
     if (!this.isBlind && this.isRolled && !this.isSuccess) {
-      if (this.stayAlive) await this.actor.fallDead()
-      else await this.actor.fallUnconscious()
+      if (this.stayAlive) {
+        await this.actor.setCondition(COC7.status.dead)
+      } else {
+        await this.actor.setCondition(COC7.status.unconscious)
+      }
     }
 
     if (!this.messageId) return

--- a/module/settings-directory.js
+++ b/module/settings-directory.js
@@ -1,0 +1,33 @@
+/* global Dialog, game, Settings */
+
+export class CoC7SettingsDirectory extends Settings {
+  activateListeners (html) {
+    super.activateListeners(html)
+    html.find('#settings-game').append('<button class="trigger-data-migration"><i class="fas fa-wrench"></i> ' + game.i18n.localize('CoC7.Migrate.TriggerButton') + '</button>')
+    html.find('.trigger-data-migration').click(() => {
+      new Dialog(
+        {
+          title: game.i18n.localize('CoC7.Migrate.TriggerTitle'),
+          content: game.i18n.localize('CoC7.Migrate.TriggerContents'),
+          buttons: {
+            migrate: {
+              icon: '<i class="fas fa-check"></i>',
+              label: game.i18n.localize('CoC7.Migrate.TriggerRestart'),
+              callback: async () => {
+                await game.settings.set('CoC7', 'systemUpdateVersion', 0)
+                window.location.reload()
+              }
+            },
+            close: {
+              icon: '<i class="fas fa-ban"></i>',
+              label: game.i18n.localize('Cancel'),
+              callback: () => {}
+            }
+          },
+          default: 'close'
+        },
+        {}
+      ).render(true)
+    })
+  }
+}

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -1,5 +1,6 @@
 /* global canvas, ChatMessage, CONST, Dialog, game, getDocumentClass, Hooks, Macro, Roll, ui */
 
+import { COC7 } from './config.js'
 import { CoC7Check } from './check.js'
 import { CoC7Item } from './items/item.js'
 import { RollDialog } from './apps/roll-dialog.js'
@@ -14,7 +15,7 @@ export class CoC7Utilities {
   //   if (speaker.token) actor = game.actors.tokens[speaker.token];
   //   if (!actor) actor = game.actors.get(speaker.actor);
 
-  //  actor.inflictMajorWound();
+  //  actor.setCondition(COC7.status.criticalWounds);
   // }
 
   static isFormula (x) {
@@ -479,7 +480,7 @@ export class CoC7Utilities {
             }
           }
         }
-        const isCriticalWounds = actor.data.data.status.criticalWounds.value
+        const isCriticalWounds = actor.hasCondition(COC7.status.criticalWounds)
         const dailySanityLoss = actor.data.data.attribs.san.dailyLoss
         const hpValue = actor.data.data.attribs.hp.value
         const hpMax = actor.data.data.attribs.hp.max

--- a/styles/sheets/summary.less
+++ b/styles/sheets/summary.less
@@ -31,14 +31,14 @@
       label {
         line-height: 1;
       }
-      .status-monitor {
+      .condition-monitor {
         color: darkgrey;
         text-align: center;
       }
-      .status-monitor.invert {
+      .condition-monitor.invert {
         transform: rotateZ(180deg);
       }
-      .status-monitor.status-on {
+      .condition-monitor.status-on {
         color: darkred;
       }
       .status {

--- a/styles/system/main.less
+++ b/styles/system/main.less
@@ -334,19 +334,19 @@
     flex: 0 0 auto;
     height: 16px;
   }
-  .status-monitors {
+  .condition-monitors {
     font-size: 1rem;
   }
-  .status-monitor {
+  .condition-monitor {
     flex: 0 0 25px;
     color: darkgrey;
     padding: 1px 6px;
     text-align: center;
   }
-  .status-monitor.invert {
+  .condition-monitor.invert {
     transform: rotateZ(180deg);
   }
-  .status-monitor.status-on {
+  .condition-monitor.status-on {
     color: darkred;
   }
   .sheet-body {

--- a/template.json
+++ b/template.json
@@ -122,33 +122,26 @@
         }
       },
       "status": {
-        "status": {
+        "conditions": {
           "criticalWounds": {
-            "type": "Boolean",
             "value": false
           },
           "unconscious": {
-            "type": "Boolean",
             "value": false
           },
           "dying": {
-            "type": "Boolean",
             "value": false
           },
           "dead": {
-            "type": "Boolean",
             "value": false
           },
           "prone": {
-            "type": "Boolean",
             "value": false
           },
           "tempoInsane": {
-            "type": "boolean",
             "value": false
           },
           "indefInsane": {
-            "type": "boolean",
             "value": false
           }
         }

--- a/templates/actors/character-sheet-v2.html
+++ b/templates/actors/character-sheet-v2.html
@@ -200,7 +200,10 @@
 
           {{#if isGM}}
             <div class="tab coc7 sheet actor temp-retro-compat restore-list-styles" data-group="primary" data-tab="keeper">
-              {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+              <div style="height: calc(100% - 20px);">
+                {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+              </div>
+              <div><a class="clear_conditions">Clear All Conditions</a></div>
             </div>
           {{/if}}
 				</div>

--- a/templates/actors/character-sheet.html
+++ b/templates/actors/character-sheet.html
@@ -145,7 +145,7 @@
         <input class="attribute-value {{#if data.flags.locked}}read-only{{/if}}" type="text" name="data.attribs.armor.value" value="{{data.attribs.armor.value}}" data-dtype="Number" {{#if data.flags.locked}}readonly{{/if}}>
       </div>
     </div>
-    <div class="status-monitors flexrow" style="line-height: 22px;">
+    <div class="condition-monitors flexrow" style="line-height: 22px;">
       <div style="display: none;">
         <input class="locked" type="text" name="data.indefiniteInsanityLevel.value" value="{{data.indefiniteInsanityLevel.value}}" data-dtype="Number" readonly/>
         <input class="locked" type="text" name="data.indefiniteInsanityLevel.max" value="{{data.indefiniteInsanityLevel.max}}" data-dtype="Number" readonly/>
@@ -154,21 +154,21 @@
         <span style="max-width: 20px;font-size: 14px;height: 22px;padding: 1px 3px;border: 1px solid transparent;">{{data.attribs.san.dailyLoss}}</span>
         <a class="reset-counter" style="flex: 0 0 25px;color: darkgrey;padding: 1px 6px;text-align: center;" data-counter="data.attribs.san.dailyLoss" title="{{localize 'CoC7.DailySanIconOver'}}"><i class="fas fa-undo"></i></a>
         <div style="flex: 0 0 20px;"></div>
-        <a class="status-monitor {{#if data.status.prone.value}}status-on{{/if}}" title="{{localize 'CoC7.Prone'}}" data-status='prone'> <i class="game-icon game-icon-falling"></i></a>
-        <a class="status-monitor {{#if data.status.unconscious.value}}status-on{{/if}}" title="{{localize 'CoC7.Unconsious'}}" data-status="unconscious"> <i class="game-icon game-icon-knocked-out-stars"></i></a>
-        <a class="status-monitor {{#if data.status.criticalWounds.value}}status-on{{/if}}" title="{{localize 'CoC7.CriticalWounds'}}" data-status="criticalWounds"> <i class="game-icon game-icon-arm-sling"></i></a>
-        <a class="status-monitor {{#if data.status.dying.value}}status-on{{/if}}" title="{{localize 'CoC7.Dying'}}" data-status="dying"> <i class="game-icon game-icon-heart-beats"></i></a>
-        <a class='status-monitor {{#if data.status.dead.value}}status-on{{/if}} is-dead' title="{{localize 'CoC7.Dead'}}" data-status="dead"><i class="game-icon game-icon-tombstone"></i></a>
+        <a class="condition-monitor {{#if data.conditions.prone.value}}status-on{{/if}}" title="{{localize 'CoC7.Prone'}}" data-condition='prone'> <i class="game-icon game-icon-falling"></i></a>
+        <a class="condition-monitor {{#if data.conditions.unconscious.value}}status-on{{/if}}" title="{{localize 'CoC7.Unconsious'}}" data-condition="unconscious"> <i class="game-icon game-icon-knocked-out-stars"></i></a>
+        <a class="condition-monitor {{#if data.conditions.criticalWounds.value}}status-on{{/if}}" title="{{localize 'CoC7.CriticalWounds'}}" data-condition="criticalWounds"> <i class="game-icon game-icon-arm-sling"></i></a>
+        <a class="condition-monitor {{#if data.conditions.dying.value}}status-on{{/if}}" title="{{localize 'CoC7.Dying'}}" data-condition="dying"> <i class="game-icon game-icon-heart-beats"></i></a>
+        <a class="condition-monitor {{#if data.conditions.dead.value}}status-on{{/if}}" title="{{localize 'CoC7.Dead'}}" data-condition="dead"><i class="game-icon game-icon-tombstone"></i></a>
 
         <div style="flex: 0 0 25px;"></div>
         {{#if isDying}}
-          <a class='status-monitor dying-check' title="Check if you'll die immediately"><i class="fas fa-dice-d20"></i></a>
+          <a class='condition-monitor dying-check' title="Check if you'll die immediately"><i class="fas fa-dice-d20"></i></a>
         {{else}}
           <div style="flex: 0 0 25px;"></div>
         {{/if}}
         <div style="flex: 0 0 40px;"></div>
-        <a class="status-monitor {{#if isInABoutOfMadness}}status-on{{/if}}" title="{{localize 'CoC7.TemporaryInsanity'}}" data-effect="boutOfMadness"> <i class="game-icon game-icon-hanging-spider"></i></a>
-        <a class="status-monitor {{#if isInsane}}status-on{{/if}}" title="{{localize 'CoC7.IndefiniteInsanity'}}" data-effect="insanity"> <i class="game-icon game-icon-tentacles-skull"></i></a>
+        <a class="condition-monitor {{#if data.conditions.tempoInsane.value}}status-on{{/if}}" title="{{localize 'CoC7.BoutOfMadness'}}{{#if actor.getTempoInsaneDurationText}}: {{actor.getTempoInsaneDurationText}}{{/if}}" data-condition="tempoInsane"><i class="game-icon game-icon-hanging-spider"></i></a>
+        <a class="condition-monitor {{#if data.conditions.indefInsane.value}}status-on{{/if}}" title="{{#if data.conditions.indefInsane.value}}{{localize 'CoC7.UnderlyingInsanity'}}{{else}}{{localize 'CoC7.IndefiniteInsanity'}}{{/if}}" data-condition="indefInsane"><i class="game-icon game-icon-tentacles-skull"></i></a>
 
         <div class="flex1"></div>
         {{#if data.flags.locked}}

--- a/templates/actors/character/summary.html
+++ b/templates/actors/character/summary.html
@@ -29,14 +29,14 @@
             {{/if}}
         </div>
         <div class="status">
-          <a class="status-monitor {{#if data.status.prone.value}}status-on{{/if}}" title="{{localize 'CoC7.Prone'}}" data-status="prone"><i class="game-icon game-icon-falling"></i></a>
-          <a class="status-monitor {{#if data.status.unconscious.value}}status-on{{/if}}" title="{{localize 'CoC7.Unconsious'}}" data-status="unconscious"><i class="game-icon game-icon-knocked-out-stars"></i></a>
-          <a class="status-monitor {{#if data.status.criticalWounds.value}}status-on{{/if}}" title="{{localize 'CoC7.CriticalWounds'}}" data-status="criticalWounds"><i class="game-icon game-icon-arm-sling"></i></a>
-          <a class="status-monitor {{#if data.status.dying.value}}status-on{{/if}} is-dead" title="{{localize 'CoC7.Dying'}}" data-status="dying"><i class="game-icon game-icon-heart-beats"></i></a>
+          <a class="condition-monitor {{#if data.status.prone.value}}status-on{{/if}}" title="{{localize 'CoC7.Prone'}}" data-condition="prone"><i class="game-icon game-icon-falling"></i></a>
+          <a class="condition-monitor {{#if data.status.unconscious.value}}status-on{{/if}}" title="{{localize 'CoC7.Unconsious'}}" data-condition="unconscious"><i class="game-icon game-icon-knocked-out-stars"></i></a>
+          <a class="condition-monitor {{#if data.status.criticalWounds.value}}status-on{{/if}}" title="{{localize 'CoC7.CriticalWounds'}}" data-condition="criticalWounds"><i class="game-icon game-icon-arm-sling"></i></a>
+          <a class="condition-monitor {{#if data.status.dying.value}}status-on{{/if}}" title="{{localize 'CoC7.Dying'}}" data-condition="dying"><i class="game-icon game-icon-heart-beats"></i></a>
           {{#if data.status.dead.value}}
-          <a class="status-monitor status-on" title="{{localize 'CoC7.Dead'}}" data-status="dead"><i class="game-icon game-icon-tombstone"></i></a>
+          <a class="condition-monitor status-on" title="{{localize 'CoC7.Dead'}}" data-condition="dead"><i class="game-icon game-icon-tombstone"></i></a>
           {{else}}
-          <a class="{{#if data.status.dying.value}}status-monitor dying-check{{else}}inative-status{{/if}}" title="{{#if data.status.dying.value}}{{localize 'CoC7.DyingCheck'}}{{/if}}"><i class="game-icon game-icon-d10"></i></a>
+          <a class="{{#if data.status.dying.value}}condition-monitor dying-check{{else}}inative-status{{/if}}" title="{{#if data.status.dying.value}}{{localize 'CoC7.DyingCheck'}}{{/if}}"><i class="game-icon game-icon-d10"></i></a>
           {{/if}}
         </div>
       </div>
@@ -58,8 +58,8 @@
                 <input class="locked" type="text" name="data.indefiniteInsanityLevel.value" value="{{data.indefiniteInsanityLevel.value}}" data-dtype="Number" readonly/>
                 <input class="locked" type="text" name="data.indefiniteInsanityLevel.max" value="{{data.indefiniteInsanityLevel.max}}" data-dtype="Number" readonly/>
             </div>
-            <a class="status-monitor {{#if isInABoutOfMadness}}status-on{{/if}}" title="{{sanity.boutOfMadness.hint}}" data-effect="boutOfMadness"><i class="game-icon game-icon-hanging-spider"></i></a>
-            <a class="status-monitor {{#if isInsane}}status-on{{/if}}" title="{{localize 'CoC7.UnderlyingInsanity'}}: {{sanity.underlying.hint}}" data-effect="insanity"><i class="game-icon game-icon-tentacles-skull"></i></a>
+            <a class="condition-monitor {{#if data.conditions.tempoInsane.value}}status-on{{/if}}" title="{{localize 'CoC7.BoutOfMadness'}}{{#if actor.getTempoInsaneDurationText}}: {{actor.getTempoInsaneDurationText}}{{/if}}" data-condition="tempoInsane"><i class="game-icon game-icon-hanging-spider"></i></a>
+            <a class="condition-monitor {{#if data.conditions.indefInsane.value}}status-on{{/if}}" title="{{#if data.conditions.indefInsane.value}}{{localize 'CoC7.UnderlyingInsanity'}}{{else}}{{localize 'CoC7.IndefiniteInsanity'}}{{/if}}" data-condition="indefInsane"><i class="game-icon game-icon-tentacles-skull"></i></a>
             </div>
       </div>
       <div class="flexrow" data-attrib="mp">

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -224,17 +224,17 @@
           </div>
         </div>
 
-        <div class="status-monitors flexrow">
+        <div class="condition-monitors flexrow">
         {{#if isDying}}
           <a class='dying-check' style="text-align: center;font-size: 20px;" title="Check if you'll die immediately"><i class="fas fa-dice-d20"></i></a>
         {{else}}
-          <a class="status-monitor {{#if data.status.prone.value}}status-on{{/if}}" title="{{localize 'CoC7.Prone'}}" data-status='prone'> <i class="game-icon game-icon-falling"></i></a>
-          <a class="status-monitor {{#if data.status.unconscious.value}}status-on{{/if}}" title="{{localize 'CoC7.Unconsious'}}" data-status="unconscious"> <i class="game-icon game-icon-knocked-out-stars"></i></a>
-          <a class="status-monitor {{#if data.status.criticalWounds.value}}status-on{{/if}}" title="{{localize 'CoC7.CriticalWounds'}}" data-status="criticalWounds"> <i class="fas fa-user-injured"></i></a>
-          <a class="status-monitor {{#if data.status.dying.value}}status-on{{/if}}" title="{{localize 'CoC7.Dying'}}" data-status="dying"> <i class="fas fa-heartbeat"></i></a>
+          <a class="condition-monitor {{#if data.conditions.prone.value}}status-on{{/if}}" title="{{localize 'CoC7.Prone'}}" data-condition='prone'> <i class="game-icon game-icon-falling"></i></a>
+          <a class="condition-monitor {{#if data.conditions.unconscious.value}}status-on{{/if}}" title="{{localize 'CoC7.Unconsious'}}" data-condition="unconscious"> <i class="game-icon game-icon-knocked-out-stars"></i></a>
+          <a class="condition-monitor {{#if data.conditions.criticalWounds.value}}status-on{{/if}}" title="{{localize 'CoC7.CriticalWounds'}}" data-condition="criticalWounds"> <i class="fas fa-user-injured"></i></a>
+          <a class="condition-monitor {{#if data.conditions.dying.value}}status-on{{/if}}" title="{{localize 'CoC7.Dying'}}" data-condition="dying"> <i class="fas fa-heartbeat"></i></a>
 
-          <a class="status-monitor {{#if data.status.tempoInsane.value}}status-on{{/if}}" title="{{localize 'CoC7.TemporaryInsanity'}}" data-status="tempoInsane"> <i class="game-icon game-icon-hanging-spider"></i></a>
-          <a class="status-monitor {{#if data.status.indefInsane.value}}status-on{{/if}}" title="{{localize 'CoC7.IndefiniteInsanity'}}" data-status="indefInsane"> <i class="game-icon game-icon-tentacles-skull"></i></a>
+          <a class="condition-monitor {{#if data.conditions.tempoInsane.value}}status-on{{/if}}" title="{{localize 'CoC7.BoutOfMadness'}}{{#if actor.getTempoInsaneDurationText}}: {{actor.getTempoInsaneDurationText}}{{/if}}" data-condition="tempoInsane"><i class="game-icon game-icon-hanging-spider"></i></a>
+          <a class="condition-monitor {{#if data.conditions.indefInsane.value}}status-on{{/if}}" title="{{#if data.conditions.indefInsane.value}}{{localize 'CoC7.UnderlyingInsanity'}}{{else}}{{localize 'CoC7.IndefiniteInsanity'}}{{/if}}" data-condition="indefInsane"><i class="game-icon game-icon-tentacles-skull"></i></a>
           <div class="flex1"></div>
 
           <div class="san-check flexrow flex3" draggable="true">
@@ -284,12 +284,12 @@
       </div>
     {{/unless}}
     {{#if isDead}}
-    <div class='is-dead status-monitor {{#if data.status.dead.value}}status-on{{/if}}' data-status="dead" style="flex: 0 0 100px;margin: 6px;">
+    <div class="condition-monitor {{#if data.status.dead.value}}status-on{{/if}}" data-condition="dead" style="flex: 0 0 100px;margin: 6px;">
       <i style="font-size: 100px;color: darkred;line-height: 100px;" class="game-icon game-icon-tombstone"></i>
     </div>
     {{else}}
       {{#if isDying}}
-        <div class='is-dying status-monitor {{#if data.status.dying.value}}status-on{{/if}}' data-status="dying" style="flex: 0 0 100px;margin: 6px;">
+        <div class="condition-monitor {{#if data.status.dying.value}}status-on{{/if}}" data-condition="dying" style="flex: 0 0 100px;margin: 6px;">
           <i style="font-size: 100px;color: darkred;line-height: 100px;" class="fas fa-heartbeat"></i>
         </div>
       {{else}}
@@ -369,6 +369,7 @@
           </div>
           <div class="keeper pannel expanded resizededitor">
             {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+            <div><a class="clear_conditions">Clear All Conditions</a></div>
           </div>
         </section>
       {{/if}}

--- a/templates/actors/parts/vitals.html
+++ b/templates/actors/parts/vitals.html
@@ -21,17 +21,17 @@
             </div>
         </div>
         <div class="status">
-            <a class="status-monitor {{#if data.status.prone.value}}status-on{{/if}}" title="{{localize 'CoC7.Prone'}}" data-status="prone"><i class="game-icon game-icon-falling"></i></a>
-            <a class="status-monitor {{#if data.status.unconscious.value}}status-on{{/if}}" title="{{localize 'CoC7.Unconsious'}}" data-status="unconscious"><i class="game-icon game-icon-knocked-out-stars"></i></a>
-            <a class="status-monitor {{#if data.status.criticalWounds.value}}status-on{{/if}}" title="{{localize 'CoC7.CriticalWounds'}}" data-status="criticalWounds"><i class="game-icon game-icon-arm-sling"></i></a>
-            <a class="status-monitor {{#if data.status.dying.value}}status-on{{/if}} is-dead" title="{{localize 'CoC7.Dying'}}" data-status="dying"><i class="game-icon game-icon-heart-beats"></i></a>
+            <a class="condition-monitor {{#if data.conditions.prone.value}}status-on{{/if}}" title="{{localize 'CoC7.Prone'}}" data-condition="prone"><i class="game-icon game-icon-falling"></i></a>
+            <a class="condition-monitor {{#if data.conditions.unconscious.value}}status-on{{/if}}" title="{{localize 'CoC7.Unconsious'}}" data-condition="unconscious"><i class="game-icon game-icon-knocked-out-stars"></i></a>
+            <a class="condition-monitor {{#if data.conditions.criticalWounds.value}}status-on{{/if}}" title="{{localize 'CoC7.CriticalWounds'}}" data-condition="criticalWounds"><i class="game-icon game-icon-arm-sling"></i></a>
+            <a class="condition-monitor {{#if data.conditions.dying.value}}status-on{{/if}}" title="{{localize 'CoC7.Dying'}}" data-condition="dying"><i class="game-icon game-icon-heart-beats"></i></a>
         </div>
-        
+
         <div class="status">
-            {{#if data.status.dead.value}}
-                <a class="status-monitor status-on" title="{{localize 'CoC7.Dead'}}" data-status="dead"><i class="game-icon game-icon-tombstone"></i></a>
+            {{#if data.conditions.dead.value}}
+                <a class="condition-monitor status-on" title="{{localize 'CoC7.Dead'}}" data-condition="dead"><i class="game-icon game-icon-tombstone"></i></a>
             {{else}}
-                <a class="{{#if data.status.dying.value}}status-monitor dying-check{{else}}inative-status{{/if}}" title="{{#if data.status.dying.value}}{{localize 'CoC7.DyingCheck'}}{{/if}}"><i class="game-icon game-icon-d10"></i></a>
+                <a class="{{#if data.conditions.dying.value}}condition-monitor dying-check{{else}}inative-status{{/if}}" title="{{#if data.conditions.dying.value}}{{localize 'CoC7.DyingCheck'}}{{/if}}"><i class="game-icon game-icon-d10"></i></a>
             {{/if}}
         </div>
     </div>
@@ -61,8 +61,8 @@
                 <input class="locked" type="text" name="data.indefiniteInsanityLevel.value" value="{{data.indefiniteInsanityLevel.value}}" data-dtype="Number" readonly/>
                 <input class="locked" type="text" name="data.indefiniteInsanityLevel.max" value="{{data.indefiniteInsanityLevel.max}}" data-dtype="Number" readonly/>
             </div>
-            <a class="status-monitor {{#if isInABoutOfMadness}}status-on{{/if}}" title="{{sanity.boutOfMadness.hint}}" data-effect="boutOfMadness"><i class="game-icon game-icon-hanging-spider"></i></a>
-            <a class="status-monitor {{#if isInsane}}status-on{{/if}}" title="{{localize 'CoC7.UnderlyingInsanity'}}: {{sanity.underlying.hint}}" data-effect="insanity"><i class="game-icon game-icon-tentacles-skull"></i></a>
+            <a class="condition-monitor {{#if data.conditions.tempoInsane.value}}status-on{{/if}}" title="{{localize 'CoC7.BoutOfMadness'}}{{#if actor.getTempoInsaneDurationText}}: {{actor.getTempoInsaneDurationText}}{{/if}}" data-condition="tempoInsane"><i class="game-icon game-icon-hanging-spider"></i></a>
+            <a class="condition-monitor {{#if data.conditions.indefInsane.value}}status-on{{/if}}" title="{{#if data.conditions.indefInsane.value}}{{localize 'CoC7.UnderlyingInsanity'}}{{else}}{{localize 'CoC7.IndefiniteInsanity'}}{{/if}}" data-condition="indefInsane"><i class="game-icon game-icon-tentacles-skull"></i></a>
         </div>
         <div class="control">
             <a class="reset-counter" title="{{localize 'CoC7.DailySanIconOver'}}" data-counter="data.attribs.san.dailyLoss"><i class="fas fa-undo"></i></a>

--- a/templates/chat/cards/san-check.html
+++ b/templates/chat/cards/san-check.html
@@ -15,250 +15,250 @@
     </header>
   {{/unless}}
 
-	<div class="infos">
-		<div class="loss-min"></div>
-		<div class="loss-max"></div>
-		<div class="max-loss"></div>
-	</div>
+  <div class="infos">
+    <div class="loss-min"></div>
+    <div class="loss-max"></div>
+    <div class="max-loss"></div>
+  </div>
 
-	<div class="status-list">
-		<div class="status">{{localize 'CoC7.DailyLoss'}}: {{actor.dailySanLoss}}</div>
-		<div class="status">{{localize 'CoC7.Sanity'}}: {{actor.san}}/{{actor.sanMax}}</div>
-		{{#if creature}}
-			{{#if creatureEncountered}}<div class="status">Creature encountered</div>{{/if}}
-			{{#if creatureSpecieEncountered}}<div class="status">Specie encountered</div>{{/if}}
-			<div class="status">Already lost: {{sanLostToThisCreature}}</div>
-			<div class="status">Creature max loss: {{creature.sanLossMax}}</div>
-			<div class="status">Max loss to this creature: {{maxSanLossToThisCreature}}</div>
-		{{else}}
-			<div class="status">Max loss: {{maxSanLoss}}</div>
-		{{/if}}
-		{{#if state.sanRolled}}
-			{{#if sanCheck.failed}}
-				<div class="status">Check failed</div>
-				<div class="status {{#unless state.involuntaryActionPerformed}}pending{{/unless}}">{{localize 'CoC7.InvoluntaryAction'}} {{#if state.involuntaryActionPerformed}}<i class="fas fa-check"></i>{{/if}}</div>
-			{{else}}
-				<div class="status">Check passed</div>
-			{{/if}}
-			{{#if state.sanLossRolled}}
-				<div class="status {{#unless state.sanLossApplied}}pending{{/unless}}">{{ localize 'CoC7.SANLoss' }}: {{sanLoss}} {{#if state.sanLossApplied}}<i class="fas fa-check"></i>{{/if}}</div>
-			{{/if}}
-		{{/if}}
-		{{#if state.insanity}}
-			<div class="status">Insanity</div>
-		{{/if}}
-		{{#if state.sane}}
-			<div class="status">Sane</div>
-		{{/if}}
-		{{#if state.memoryRepressed}}
-			<div class="status">Memory repressed</div>
-		{{/if}}
-		{{#if state.inSanity}}
-			<div class="status">Insanity</div>
-		{{/if}}
-		{{#if state.temporaryInsane}}
-			<div class="status">Temporary insannity</div>
-		{{/if}}
-		{{#if state.indefinitelyInsane}}
-			<div class="status">Indefinitely insane</div>
-		{{/if}}
-		{{#if state.definitelyInsane}}
-			<div class="status">Good for the asylum</div>
-		{{/if}}
+  <div class="status-list">
+    <div class="status">{{localize 'CoC7.DailyLoss'}}: {{actor.dailySanLoss}}</div>
+    <div class="status">{{localize 'CoC7.Sanity'}}: {{actor.san}}/{{actor.sanMax}}</div>
+    {{#if creature}}
+      {{#if creatureEncountered}}<div class="status">Creature encountered</div>{{/if}}
+      {{#if creatureSpecieEncountered}}<div class="status">Specie encountered</div>{{/if}}
+      <div class="status">Already lost: {{sanLostToThisCreature}}</div>
+      <div class="status">Creature max loss: {{creature.sanLossMax}}</div>
+      <div class="status">Max loss to this creature: {{maxSanLossToThisCreature}}</div>
+    {{else}}
+      <div class="status">Max loss: {{maxSanLoss}}</div>
+    {{/if}}
+    {{#if state.sanRolled}}
+      {{#if sanCheck.failed}}
+        <div class="status">Check failed</div>
+        <div class="status {{#unless state.involuntaryActionPerformed}}pending{{/unless}}">{{localize 'CoC7.InvoluntaryAction'}} {{#if state.involuntaryActionPerformed}}<i class="fas fa-check"></i>{{/if}}</div>
+      {{else}}
+        <div class="status">Check passed</div>
+      {{/if}}
+      {{#if state.sanLossRolled}}
+        <div class="status {{#unless state.sanLossApplied}}pending{{/unless}}">{{ localize 'CoC7.SANLoss' }}: {{sanLoss}} {{#if state.sanLossApplied}}<i class="fas fa-check"></i>{{/if}}</div>
+      {{/if}}
+    {{/if}}
+    {{#if state.insanity}}
+      <div class="status">Insanity</div>
+    {{/if}}
+    {{#if state.sane}}
+      <div class="status">Sane</div>
+    {{/if}}
+    {{#if state.memoryRepressed}}
+      <div class="status">Memory repressed</div>
+    {{/if}}
+    {{#if state.inSanity}}
+      <div class="status">Insanity</div>
+    {{/if}}
+    {{#if state.temporaryInsane}}
+      <div class="status">Temporary insannity</div>
+    {{/if}}
+    {{#if state.indefinitelyInsane}}
+      <div class="status">Indefinitely insane</div>
+    {{/if}}
+    {{#if state.definitelyInsane}}
+      <div class="status">Good for the asylum</div>
+    {{/if}}
 
-		{{#if state.finish}}
-			<div class="status">--F-I-N-I-S-H--</div>
-		{{/if}}
+    {{#if state.finish}}
+      <div class="status">--F-I-N-I-S-H--</div>
+    {{/if}}
 
-	</div>
+  </div>
 
-	<div class='player-actions'>
-		{{#if state.sanRolled}}
-			<div class='info'>{{ localize 'CoC7.SanityCheckPerformed' }} {{#unless isBypassed}} {{{__inlineSanCheck}}} {{/unless}}</div>
-			{{#if state.involuntaryActionPerformed}}
-				{{#unless sanCheck.passed}}
-					<div class='info'>{{ localize 'CoC7.InvoluntaryActionPerformed' }}</div>
-				{{/unless}}
-				{{#if state.sanLossRolled}}
-					{{#if state.sanLossApplied}}
-						{{#if state.actorLostSan}}
-							<div class='info'>{{ localize 'CoC7.SanityLost' }}: {{#if __inlineSanLossRoll}}{{{__inlineSanLossRoll}}}{{else}}{{sanLoss}}{{/if}}</div>
-							{{#if state.limitedLossToCreature}}
-								<div class='info'>{{ localize 'CoC7.GrowingAccustomedToAwfulness' }}: {{sanLoss}}</div>
-							{{/if}}
-						{{else}}
-							{{#if state.immuneAlreadyInBout}}
-								<div class='info'>{{ localize 'CoC7.AlreadyInABout' }}</div>
-							{{/if}}
-							{{#if state.immuneToCreature}}
-								<div class='info'>{{ localize 'CoC7.ImmuneToAwfulness' }}</div>
-							{{/if}}
-						{{/if}}
-						{{#if state.intRolled}}
-							{{#if state.memoryRepressed}}
-								<div class='info'>{{{__inlineIntCheck}}} {{ localize 'CoC7.MemoryRepressed' }}</div>
-							{{/if}}
-							{{#if state.temporaryInsane}}
-								<div class='info'>{{{__inlineIntCheck}}} {{ localize 'CoC7.RememberEverything' }}</div>
-							{{/if}}
-							{{#if state.insanity}}
-								{{#unless state.boutOfMadnessOver}}
-									<div class='info'>{{ localize 'CoC7.EnteringBoutOfMadness' }} {{#if state.boutOfMadnessResolved}}({{actor.sanity.boutOfMadness.durationText}}){{/if}}</div>
-								{{/unless}}
-								{{#if state.permanentlyInsane}}
-									<div class='info'>{{ localize 'CoC7.GoodForAsylum' }}</div>
-								{{/if}}
-								{{#if state.boutOfMadnessResolved}}
-									{{#if boutResult.phobia}}
-										<div class='info'>{{ localize 'CoC7.PhobiaGained' }}: {{boutResult.name}}</div>
-									{{/if}}
+  <div class='player-actions'>
+    {{#if state.sanRolled}}
+      <div class='info'>{{ localize 'CoC7.SanityCheckPerformed' }} {{#unless isBypassed}} {{{__inlineSanCheck}}} {{/unless}}</div>
+      {{#if state.involuntaryActionPerformed}}
+        {{#unless sanCheck.passed}}
+          <div class='info'>{{ localize 'CoC7.InvoluntaryActionPerformed' }}</div>
+        {{/unless}}
+        {{#if state.sanLossRolled}}
+          {{#if state.sanLossApplied}}
+            {{#if state.actorLostSan}}
+              <div class='info'>{{ localize 'CoC7.SanityLost' }}: {{#if __inlineSanLossRoll}}{{{__inlineSanLossRoll}}}{{else}}{{sanLoss}}{{/if}}</div>
+              {{#if state.limitedLossToCreature}}
+                <div class='info'>{{ localize 'CoC7.GrowingAccustomedToAwfulness' }}: {{sanLoss}}</div>
+              {{/if}}
+            {{else}}
+              {{#if state.immuneAlreadyInBout}}
+                <div class='info'>{{ localize 'CoC7.AlreadyInABout' }}</div>
+              {{/if}}
+              {{#if state.immuneToCreature}}
+                <div class='info'>{{ localize 'CoC7.ImmuneToAwfulness' }}</div>
+              {{/if}}
+            {{/if}}
+            {{#if state.intRolled}}
+              {{#if state.memoryRepressed}}
+                <div class='info'>{{{__inlineIntCheck}}} {{ localize 'CoC7.MemoryRepressed' }}</div>
+              {{/if}}
+              {{#if state.temporaryInsane}}
+                <div class='info'>{{{__inlineIntCheck}}} {{ localize 'CoC7.RememberEverything' }}</div>
+              {{/if}}
+              {{#if state.insanity}}
+                {{#unless state.boutOfMadnessOver}}
+                  <div class='info'>{{ localize 'CoC7.EnteringBoutOfMadness' }}{{#if (and state.boutOfMadnessResolved actor.getTempoInsaneDurationText)}} ({{actor.getTempoInsaneDurationText}}){{/if}}</div>
+                {{/unless}}
+                {{#if state.permanentlyInsane}}
+                  <div class='info'>{{ localize 'CoC7.GoodForAsylum' }}</div>
+                {{/if}}
+                {{#if state.boutOfMadnessResolved}}
+                  {{#if boutResult.phobia}}
+                    <div class='info'>{{ localize 'CoC7.PhobiaGained' }}: {{boutResult.name}}</div>
+                  {{/if}}
 
-									{{#if boutResult.mania}}
-										<div class='info'>{{ localize 'CoC7.ManiaGained' }}: {{boutResult.name}}</div>
-									{{/if}}
+                  {{#if boutResult.mania}}
+                    <div class='info'>{{ localize 'CoC7.ManiaGained' }}: {{boutResult.name}}</div>
+                  {{/if}}
 
-									{{#if state.boutOfMadnessOver}}
-										<div class='info'>{{ localize 'CoC7.BoutOfMadnesslasted' }} {{boutDuration}} {{#if boutRealTime}}{{ localize 'CoC7.rounds'}}{{/if}}{{#if boutSummary}}{{ localize 'CoC7.hours'}}{{/if}}</div>
+                  {{#if state.boutOfMadnessOver}}
+                    <div class='info'>{{ localize 'CoC7.BoutOfMadnesslasted' }} {{boutDuration}} {{#if boutRealTime}}{{ localize 'CoC7.rounds'}}{{/if}}{{#if boutSummary}}{{ localize 'CoC7.hours'}}{{/if}}</div>
 
-										{{#if state.indefinitelyInsane}}
-											<div class='info'>{{ localize 'CoC7.IndefinitelyInsane' }}</div>
-										{{/if}}
-										{{#if state.temporaryInsane}}
-											<div class='info'>{{ localize 'CoC7.TemporaryInsane' }} ({{actor.sanity.underlying.durationText}})</div>
-										{{/if}}
-									{{/if}}
-								{{/if}}
-							{{else}}
-								<div class='flow-ended'></div>
-							{{/if}}
-						{{else}}
-							<div class='card-buttons'>
-								<button data-action="roll-int-check">{{ localize 'CoC7.IntCheck' }}: ({{actor.int.value}}%)</button>
-							</div>
-						{{/if}}
-					{{/if}}
-				{{else}}
-					<div class='card-buttons'>
-						<button data-action="roll-san-loss">Roll {{ localize 'CoC7.SANLoss' }}: {{sanLossFormula}}</button>
-					</div>
-				{{/if}}
-			{{/if}}
-		{{else}}
-			{{#if state.permanentlyInsane}}
-				<div class='info important'>{{ localize 'CoC7.PlayerPermanentlyInsane' }}</div>
-			{{else}}
-				<div class='card-buttons'>
-					<button data-action="roll-san-check">{{ localize 'CoC7.SanityCheck' }}: ({{actor.san}}%)</button>
-				</div>
-			{{/if}}
-		{{/if}}
+                    {{#if state.indefinitelyInsane}}
+                      <div class='info'>{{ localize 'CoC7.IndefinitelyInsane' }}</div>
+                    {{/if}}
+                    {{#if state.temporaryInsane}}
+                      <div class='info'>{{ localize 'CoC7.TemporaryInsane' }}</div>
+                    {{/if}}
+                  {{/if}}
+                {{/if}}
+              {{else}}
+                <div class='flow-ended'></div>
+              {{/if}}
+            {{else}}
+              <div class='card-buttons'>
+                <button data-action="roll-int-check">{{ localize 'CoC7.IntCheck' }}: ({{actor.int.value}}%)</button>
+              </div>
+            {{/if}}
+          {{/if}}
+        {{else}}
+          <div class='card-buttons'>
+            <button data-action="roll-san-loss">Roll {{ localize 'CoC7.SANLoss' }}: {{sanLossFormula}}</button>
+          </div>
+        {{/if}}
+      {{/if}}
+    {{else}}
+      {{#if state.permanentlyInsane}}
+        <div class='info important'>{{ localize 'CoC7.PlayerPermanentlyInsane' }}</div>
+      {{else}}
+        <div class='card-buttons'>
+          <button data-action="roll-san-check">{{ localize 'CoC7.SanityCheck' }}: ({{actor.san}}%)</button>
+        </div>
+      {{/if}}
+    {{/if}}
 
-		{{#if state.cthulhuMythosAwarded}}
-			<div class='info'> {{youGainCthulhuMythosString}}</div>
-		{{/if}}
-	</div>
+    {{#if state.cthulhuMythosAwarded}}
+      <div class='info'> {{youGainCthulhuMythosString}}</div>
+    {{/if}}
+  </div>
 
-	<div class='gm-actions gm-visible-only'>
-		{{#if state.alreadyInsane}}
-			<div class='info'>{{alreadyInsaneText}}</div>
-		{{/if}}
-		{{#if state.boutOfMadnessResolved}}
-			{{#if boutResult.phobia}}
-				<div class='info'>{{ localize 'CoC7.InvestigatorPhobiaGained'}}</div>
-			{{/if}}
-			{{#if boutResult.mania}}
-				<div class='card-buttons'>
-					<div class='info'>{{ localize 'CoC7.InvestigatorManiaGained'}}</div>
-				</div>
-			{{/if}}
-			<div class="bout-info">{{{boutResult.description}}}</div>
-			{{#unless state.boutOfMadnessOver}}
-				<div class='card-buttons'>
-					<button data-action="advance-state" data-state="boutOfMadnessOver">{{ localize 'CoC7.EndBoutOfMadness' }}</button>
-				</div>
-			{{/unless}}
-		{{/if}}
-		{{#if state.insanity}}
-				{{#if state.permanentlyInsane}}
-					<div class="status important">
-						{{ localize 'CoC7.PlayerPermanentlyInsane'}}
-					</div>
-				{{else}}
-					{{#unless state.boutOfMadnessResolved}}
-						<div class='card-buttons'>
-							<button data-action="advance-state" data-state="enterBoutOfMadnessRealTime">{{ localize 'CoC7.BoutRealTime' }}</button>
-							<button data-action="advance-state" data-state="enterBoutOfMadnessSummary">{{ localize 'CoC7.BoutSummary' }}</button>
-						</div>
-					{{/unless}}
-				{{/if}}
-		{{/if}}
-		{{#if sanCheck.failed}}
-			{{#unless state.involuntaryActionPerformed}}
-				<div class='card-buttons'>
-					<button data-action="advance-state" data-state="involuntaryActionPerformed">{{ localize 'CoC7.InvoluntaryActionPerfomed' }}</button>
-				</div>
-			{{/unless}}
-		{{/if}}
+  <div class='gm-actions gm-visible-only'>
+    {{#if state.alreadyInsane}}
+      <div class='info'>{{ localize 'CoC7.AlreadyUnderlyingInsanity'}}</div>
+    {{/if}}
+    {{#if state.boutOfMadnessResolved}}
+      {{#if boutResult.phobia}}
+        <div class='info'>{{ localize 'CoC7.InvestigatorPhobiaGained'}}</div>
+      {{/if}}
+      {{#if boutResult.mania}}
+        <div class='card-buttons'>
+          <div class='info'>{{ localize 'CoC7.InvestigatorManiaGained'}}</div>
+        </div>
+      {{/if}}
+      <div class="bout-info">{{{boutResult.description}}}</div>
+      {{#unless state.boutOfMadnessOver}}
+        <div class='card-buttons'>
+          <button data-action="advance-state" data-state="boutOfMadnessOver">{{ localize 'CoC7.EndBoutOfMadness' }}</button>
+        </div>
+      {{/unless}}
+    {{/if}}
+    {{#if state.insanity}}
+        {{#if state.permanentlyInsane}}
+          <div class="status important">
+            {{ localize 'CoC7.PlayerPermanentlyInsane'}}
+          </div>
+        {{else}}
+          {{#unless state.boutOfMadnessResolved}}
+            <div class='card-buttons'>
+              <button data-action="advance-state" data-state="enterBoutOfMadnessRealTime">{{ localize 'CoC7.BoutRealTime' }}</button>
+              <button data-action="advance-state" data-state="enterBoutOfMadnessSummary">{{ localize 'CoC7.BoutSummary' }}</button>
+            </div>
+          {{/unless}}
+        {{/if}}
+    {{/if}}
+    {{#if sanCheck.failed}}
+      {{#unless state.involuntaryActionPerformed}}
+        <div class='card-buttons'>
+          <button data-action="advance-state" data-state="involuntaryActionPerformed">{{ localize 'CoC7.InvoluntaryActionPerfomed' }}</button>
+        </div>
+      {{/unless}}
+    {{/if}}
 
-		{{#if state.sanLossRolled}}
-			{{#unless state.sanLossApplied}}
-				<div class='card-buttons'>
-					<button data-action="advance-state" data-state="sanLossApplied">{{ localize 'CoC7.Apply' }} : {{sanLoss}}</button>
-				</div>
-			{{/unless}}
-		{{/if}}
+    {{#if state.sanLossRolled}}
+      {{#unless state.sanLossApplied}}
+        <div class='card-buttons'>
+          <button data-action="advance-state" data-state="sanLossApplied">{{ localize 'CoC7.Apply' }} : {{sanLoss}}</button>
+        </div>
+      {{/unless}}
+    {{/if}}
 
-		{{#if actor.isInABoutOfMadness}}
-			<div class="status">{{ localize 'CoC7.BoutActive'}}</div>
-		{{/if}}
+    {{#if actor.hasTempoInsane}}
+      <div class="status">{{ localize 'CoC7.BoutActive'}}</div>
+    {{/if}}
 
-		{{#if creature}}
-			{{#if state.insanity}}
-				{{#if sanLoss}}
-					{{#unless state.cthulhuMythosAwarded}}
-					<div class='card-buttons'>
-						{{#if firstEncounter}}
-							<button data-action="advance-state" data-state="cthulhuMythosAwarded">{{ localize 'CoC7.MythosFirstEncounter' }}</button>
-						{{else}}
-							<button data-action="advance-state" data-state="cthulhuMythosAwarded">{{ localize 'CoC7.MythosAlreadyEncountered' }}</button>
-						{{/if}}
-						<button data-action="advance-state" data-state="noMythosGained">{{ localize 'CoC7.DisregardMythosGain' }}</button>
-					</div>
-					{{/unless}}
-				{{/if}}
-			{{/if}}
+    {{#if creature}}
+      {{#if state.insanity}}
+        {{#if sanLoss}}
+          {{#unless state.cthulhuMythosAwarded}}
+          <div class='card-buttons'>
+            {{#if firstEncounter}}
+              <button data-action="advance-state" data-state="cthulhuMythosAwarded">{{ localize 'CoC7.MythosFirstEncounter' }}</button>
+            {{else}}
+              <button data-action="advance-state" data-state="cthulhuMythosAwarded">{{ localize 'CoC7.MythosAlreadyEncountered' }}</button>
+            {{/if}}
+            <button data-action="advance-state" data-state="noMythosGained">{{ localize 'CoC7.DisregardMythosGain' }}</button>
+          </div>
+          {{/unless}}
+        {{/if}}
+      {{/if}}
 
-			{{#if creatureEncountered}}<div class="status">Creature encountered</div>{{/if}}
-			{{#if creatureHasSpecie}}{{#if creatureSpecieEncountered}}<div class="status">Specie encountered</div>{{/if}}{{/if}}
-			<div class="status">{{ localize 'CoC7.AlreadyLost'}}: {{sanLostToThisCreature}}</div>
-			<div class="status">{{ localize 'CoC7.CreatureMaxLoss'}}: {{creature.sanLossMax}}</div>
-			<div class="status">{{ localize 'CoC7.MaxLossToCreature'}}: {{maxSanLossToThisCreature}}</div>
+      {{#if creatureEncountered}}<div class="status">Creature encountered</div>{{/if}}
+      {{#if creatureHasSpecie}}{{#if creatureSpecieEncountered}}<div class="status">Specie encountered</div>{{/if}}{{/if}}
+      <div class="status">{{ localize 'CoC7.AlreadyLost'}}: {{sanLostToThisCreature}}</div>
+      <div class="status">{{ localize 'CoC7.CreatureMaxLoss'}}: {{creature.sanLossMax}}</div>
+      <div class="status">{{ localize 'CoC7.MaxLossToCreature'}}: {{maxSanLossToThisCreature}}</div>
 
-			{{#unless state.keepCreatureSanData}}
-				<div class='card-buttons'>
+      {{#unless state.keepCreatureSanData}}
+        <div class='card-buttons'>
 
-				{{#if creatureEncountered}}
-					<button data-action="reset-creature-san-data">{{ localize 'CoC7.ResetCreatureSan' }}</button>
-				{{/if}}
-				{{#if creatureHasSpecie}}
-					{{#if creatureSpecieEncountered}}
-						<button data-action="reset-specie-san-data">{{ localize 'CoC7.ResetSpecieSan' }}</button>
-					{{/if}}
-				{{/if}}
-					<button data-action="advance-state" data-state="keepCreatureSanData">{{ localize 'CoC7.KeepData' }}</button>
-				</div>
-			{{/unless}}
+        {{#if creatureEncountered}}
+          <button data-action="reset-creature-san-data">{{ localize 'CoC7.ResetCreatureSan' }}</button>
+        {{/if}}
+        {{#if creatureHasSpecie}}
+          {{#if creatureSpecieEncountered}}
+            <button data-action="reset-specie-san-data">{{ localize 'CoC7.ResetSpecieSan' }}</button>
+          {{/if}}
+        {{/if}}
+          <button data-action="advance-state" data-state="keepCreatureSanData">{{ localize 'CoC7.KeepData' }}</button>
+        </div>
+      {{/unless}}
 
-		{{else}}
-			<div class="status">{{localize 'CoC7.MaxSanloss'}}: {{maxSanLoss}}</div>
-		{{/if}}
+    {{else}}
+      <div class="status">{{localize 'CoC7.MaxSanloss'}}: {{maxSanLoss}}</div>
+    {{/if}}
 
-		{{#if mythosGain}}
-			<div class="status important">{{localize 'CoC7.MythosGain'}}: {{mythosGain}}%</div>
-		{{/if}}
+    {{#if mythosGain}}
+      <div class="status important">{{localize 'CoC7.MythosGain'}}: {{mythosGain}}%</div>
+    {{/if}}
 
-		{{#if state.finish}}
-			<div class="status">{{localize 'CoC7.CardResolved'}}</div>
-		{{/if}}
-	</div>
+    {{#if state.finish}}
+      <div class="status">{{localize 'CoC7.CardResolved'}}</div>
+    {{/if}}
+  </div>
 </div>


### PR DESCRIPTION
## Description.
* If ActiveEffect icons are enabled when adding or removing a condition create/remove the ActiveEffect instead
* If ActiveEffect icons are disabled or when adding/removing an ActiveEffect apply/remove the condition

* Correctly allow adding conditions from the FoundryVTT effects menu or marking as dead from the combat tracker
* Prevent UI toggle/on/off for statuses being called twice
* Add Clear All Conditions button after Keeper Notes for NPC/Creature and Characters sheets
###
Actor.setCondition and Actor.unsetCondition control all adding or removing of conditions and any additional condition triggers
* Calling setCondition for COC7.status.dead will remove COC7.status.criticalWounds, COC7.status.dying, and COC7.status.unconscious if set.
* Calling setCondition for COC7.status.criticalWounds will also set COC7.status.prone then if the actor is not COC7.status.unconscious and not COC7.status.dead create a CoC7ConCheck message

## Motivation and Context.
* In FoundryVTT v9 adding or removing ActiveEffects shows scrolling status text even if the icon is null
* Adding status via the Combat Tracker or effects menu doesn't update the character sheet
* Some users Actors statuses and ActiveEffects get out of sync or duplicated

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to change).
