### PR TITLE
Added German entry for "Okkult". As this entry is used to find the ab…

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -559,7 +559,7 @@
   "CoC7.Mythos": "Mythos",
   "CoC7.MythosRating": "Mythoswert",
   "CoC7.NotOwned": "Der Gegenstand muss sich im Besitz eines Spielers befinden, damit diese Aktion ausgeführt werden kann.",
-  "CoC7.Occult": "Okkult",
+  "CoC7.Occult": "Okkultismus",
   "CoC7.Points": "Punkt(e)",
   "CoC7.Progress": "Fortschritt",
   "CoC7.RedoFullStudy": "Eingehendes Studium wiederholen",


### PR DESCRIPTION
Changed an entry of the German language file.

## Motivation and Context.

The language entry "CoC7.Occult" is used to find the ability to raise after reading an occult book successfully. But the German translation of this ability in the Core Rules is not "Okkult" but "Okkultismus". So I changed that in order to fix occult book reading in the German version.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
