### PR TITLE
Spell learning from book

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -540,6 +540,8 @@
   "CoC7.GateSpell": "Reise- und Transportzauber",
   "CoC7.CombatSpell": "Kampfzauber",
   "CoC7.SpellType": "Zaubertyp",
+  "CoC7.SpellSuccessfullyLearned": "Zauber wurde erfolgreich gelernt!",
+  "CoC7.SpellAlreadyLearned": "Zauber mit diesem Namen wurde bereits gelernt.",
 
   "CoC7.BookHasNothingMoreToTeach": "{book} kann nichts mehr lehren. Cthulhu Mythos Fertigkeit von {actor} ist größer als der Mythoswert.",
   "CoC7.BookType": "Buch Typ",

--- a/lang/de.json
+++ b/lang/de.json
@@ -540,8 +540,8 @@
   "CoC7.GateSpell": "Reise- und Transportzauber",
   "CoC7.CombatSpell": "Kampfzauber",
   "CoC7.SpellType": "Zaubertyp",
-  "CoC7.SpellSuccessfullyLearned": "Zauber wurde erfolgreich gelernt!",
-  "CoC7.SpellAlreadyLearned": "Zauber mit diesem Namen wurde bereits gelernt.",
+  "CoC7.SpellSuccessfullyLearned": "Zauber '{spell}' wurde erfolgreich gelernt!",
+  "CoC7.SpellAlreadyLearned": "Zauber mit dem Namen '{spell}' wurde bereits gelernt.",
 
   "CoC7.BookHasNothingMoreToTeach": "{book} kann nichts mehr lehren. Cthulhu Mythos Fertigkeit von {actor} ist größer als der Mythoswert.",
   "CoC7.BookType": "Buch Typ",

--- a/lang/en.json
+++ b/lang/en.json
@@ -541,8 +541,8 @@
   "CoC7.GateSpell": "Gate",
   "CoC7.CombatSpell": "Combat",
   "CoC7.SpellType": "Spell Type",
-  "CoC7.SpellSuccessfullyLearned": "Spell was learned successfully!",
-  "CoC7.SpellAlreadyLearned": "Spell of that name was already learned.",
+  "CoC7.SpellSuccessfullyLearned": "Spell '{spell}' was learned successfully!",
+  "CoC7.SpellAlreadyLearned": "Spell named ('{spell}') was already learned.",
 
   "CoC7.BookHasNothingMoreToTeach": "{book} has nothing more to teach. Cthulhu Mythos skill of {actor} is greater than this Mythos Rating.",
   "CoC7.BookType": "Book Type",

--- a/lang/en.json
+++ b/lang/en.json
@@ -541,6 +541,8 @@
   "CoC7.GateSpell": "Gate",
   "CoC7.CombatSpell": "Combat",
   "CoC7.SpellType": "Spell Type",
+  "CoC7.SpellSuccessfullyLearned": "Spell was learned successfully!",
+  "CoC7.SpellAlreadyLearned": "Spell of that name was already learned.",
 
   "CoC7.BookHasNothingMoreToTeach": "{book} has nothing more to teach. Cthulhu Mythos skill of {actor} is greater than this Mythos Rating.",
   "CoC7.BookType": "Book Type",

--- a/module/items/book/data.js
+++ b/module/items/book/data.js
@@ -287,7 +287,11 @@ export class CoC7Book extends CoC7Item {
           spelllearned.data.learned = true
         }
         else {
-          ui.notifications.warn(game.i18n.localize('CoC7.SpellAlreadyLearned'))
+          ui.notifications.warn(
+            game.i18n.format('CoC7.SpellAlreadyLearned', {
+              spell: spelllearned.name,
+              book: this.name
+            })            )
         }
         break
       }
@@ -296,7 +300,12 @@ export class CoC7Book extends CoC7Item {
     await this.update({ 'data.spells': this.data.data.spells })
     // Add learned spell to actor
     if (spelllearned.data.learned) {
-      ui.notifications.info(game.i18n.localize('CoC7.SpellSuccessfullyLearned'))
+      ui.notifications.info(
+        game.i18n.format('CoC7.SpellSuccessfullyLearned', {
+          spell: spelllearned.name,
+          book: this.name
+        })
+      )
       const actorSpell = await this.actor.createEmbeddedDocuments('Item', [
         duplicate(spelllearned)
       ])

--- a/module/items/book/data.js
+++ b/module/items/book/data.js
@@ -48,7 +48,9 @@ export class CoC7Book extends CoC7Item {
     const data = this.data.data.spells[index]
     const parent = this.actor ? this.actor : null
     const spell = new CoC7Spell(data, { parent, bookId: this.id })
-    return await spell.sheet.render(true)
+    if (spell.data.data.learned) {
+      return await spell.sheet.render(true)
+    }
   }
 
   /**
@@ -267,10 +269,39 @@ export class CoC7Book extends CoC7Item {
     return await this.update({ 'data.initialReading': true })
   }
 
-  async grantSpellLearning () {
-    return ui.notifications.warn(
-      'Automation of learning spells from books is not currently supported and will be added in future updates.'
-    )
+  /**
+   * 
+   * @param {Item} spelllearned The spell that was learned successfully from book
+   * @returns 
+   */
+  async grantSpellLearning (spelllearned) {
+    for (const spell of this.data.data.spells) {
+      if (spell._id === spelllearned._id) {
+        spell.data.learned = true;
+        // Does the actor already has a spell of that name? Then do not add the spell
+        const existingSpell = await this.actor.items.find(
+          item =>
+            item.data.type === 'spell' && item.data.name === spelllearned.name
+        )
+        if (!existingSpell) {
+          spelllearned.data.learned = true
+        }
+        else {
+          ui.notifications.warn(game.i18n.localize('CoC7.SpellAlreadyLearned'))
+        }
+        break
+      }
+    }
+    // Save spell list of book
+    await this.update({ 'data.spells': this.data.data.spells })
+    // Add learned spell to actor
+    if (spelllearned.data.learned) {
+      ui.notifications.info(game.i18n.localize('CoC7.SpellSuccessfullyLearned'))
+      const actorSpell = await this.actor.createEmbeddedDocuments('Item', [
+        duplicate(spelllearned)
+      ])
+    }
+    return;
   }
 
   /**
@@ -434,6 +465,7 @@ export class CoC7Book extends CoC7Item {
         spell: spell.name
       })
       check.context = 'SPELL_LEARNING'
+      check.spell = spell
       await check.rollCharacteristic('int')
       await check.toMessage()
     }
@@ -442,12 +474,13 @@ export class CoC7Book extends CoC7Item {
   /** Listen to changes on the check card */
   async updateRoll (roll) {
     const check = CoC7Check.fromRollString(roll)
+
     /** Will know if user push the roll or spend Luck */
     if (check.passed) {
       if (check.context === 'INITIAL_READING') {
         return await this.grantInitialReading()
       } else if (check.context === 'SPELL_LEARNING') {
-        return await this.grantSpellLearning()
+        return await this.grantSpellLearning(check.spell)
       }
     }
   }

--- a/template.json
+++ b/template.json
@@ -550,6 +550,7 @@
       },
       "effects": [],
       "source": "",
+      "learned": false,
       "type": {
         "bind": false,
         "call": false,

--- a/templates/items/book/main.html
+++ b/templates/items/book/main.html
@@ -170,12 +170,18 @@
                   </label>
                 </div>
                 <div class="edit">
+                  {{#if (or isKeeper spell.data.learned)}}
                   <i class="fas fa-edit edit-spell"></i>
+                  {{/if}}
+                  {{#if (isKeeper)}}
                   <i class="fas fa-trash delete-spell"></i>
+                  {{/if}}
                 </div>
+                {{#if (not spell.data.learned)}}
                 <div class="status">
                   <i class="fas fa-book-open teach-spell"></i>
                 </div>
+                {{/if}}
               </li>
             {{/each}}
           </ul>


### PR DESCRIPTION
This CR adds spell learning from books. Please have a closer look, as it seems, someone already started something on that issue.

But my system works very well in my tests! :)

## Description.

I did the following changes to the code:

General:
* Updated template.json: A new flag on item.type[spell]: learned. It will be used and saved in the books spell list.
* Added two notification translations to en.json and de.json. "learned" and "already learned"

Book sheet:
* Spells not learned yet won't open spell details (else actors could cast before learning the spell). It still will open the detail when used as keeper.
* Spells can't be deleted from books when not keeper.
* Learning success will update spell.learned = true
* Learning success will add that spell to the actors items. Before adding the spell there is a check (by name) whether this spell is already known by the actor. This might be too much, maybe let the player learn again (it might be another spell with same name?)

## Motivation and Context.

Well, there was no spell learn system implemented yet and I needed it for my next session. :)

## Types of Changes.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
