### PR TITLE
Missing Foundry VTT v9 css fix

### DIFF
--- a/styles/chat/damage.less
+++ b/styles/chat/damage.less
@@ -16,7 +16,7 @@
   .ic-switch {
     height: 16px;
     line-height: 16px;
-    flex: 0;
+    flex: none;
   }
   label {
     height: 16px;


### PR DESCRIPTION
## Description.
Critical and impale on damage chat card do flex incorrectly in Foundry VTT v9

Resolves #1033

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
