### PR TITLE
Update creature encounters based on tokens/actors to sanity loss events based on type/name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,5 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{html,svg}]
+[*.{hbs,html,svg}]
 insert_final_newline = false

--- a/lang/en.json
+++ b/lang/en.json
@@ -402,6 +402,7 @@
   "CoC7.DevSuccessDetails": "{item} upgraded by {augment}%",
   "CoC7.SanGained": "Gained 2d6 ({results} = <strong>{sanGained}</strong>) Sanity after mastering <strong>{skill}</strong> with a <strong>{skillValue}%</strong>",
   "CoC7.DevFailureDetails": "{item} NOT upgraded",
+  "CoC7.ReduceSanityLimits": "Reduced all sanity limits by one",
   "CoC7.DevSuccess": "{item} upgraded ({die}/{score}%) by {augment}%",
   "CoC7.DevFailure": "{item} NOT upgraded ({die}/{score}%)",
   "CoC7.LuckIncreased": "Luck recovered ({die}/{score}) by {augment} points",
@@ -479,6 +480,24 @@
   "CoC7.BackgroundDeleteSection": "Delete section",
   "CoC7.BackgroundSectionMoveUp": "Move Up",
   "CoC7.BackgroundSectionMoveDown": "Move Down",
+  "CoC7.BackgroundEncounters": "Losses from Strange Entities",
+  "CoC7.BackgroundFlags": "Flags",
+  "CoC7.BackgroundFlagsMythosExperienced": "5% Insanity Mythos Awarded",
+  "CoC7.BackgroundFlagsMythosHardened": "Mythos Hardened",
+
+  "CoC7.SanityLossEncounters": "Sanity Loss Encounters",
+  "CoC7.SanityLossImmunities": "Sanity Loss Immunities",
+  "CoC7.AddSanityLossEncounter": "Add Sanity Loss Encounter",
+  "CoC7.AddSanityLossImmunity": "Add Sanity Loss Immunity",
+  "CoC7.DeleteSanityLossEncounter": "Delete Sanity Loss Encounter",
+  "CoC7.DeleteSanityLossImmunity": "Delete Sanity Loss Immunity",
+
+  "CoC7.SanityLossTypeDialogTitle": "New sanity loss or immunity",
+  "CoC7.SanityLossTypeDialogBody": "Add a new Mythos Encounter, Sanity Loss, or Sanity Immunity to the character.",
+  "CoC7.SanityLossTypeReason": "Reason",
+  "CoC7.SanityLossTypeValue": "Sanity points lost",
+  "CoC7.SanityLossEncounter": "Sanity loss encounter",
+  "CoC7.SanityLossImmunity": "Sanity loss immunity",
 
   "CoC7.creatureFightingSkill": "Fighting",
 

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -244,7 +244,7 @@ export class CoCActor extends Actor {
       result.tableRoll = await boutOfMadnessTable.roll()
       if (typeof result.tableRoll.results[0] !== 'undefined') {
         if (
-          CONST.TABLE_RESULT_TYPES.ENTITY ===
+          CONST.TABLE_RESULT_TYPES.DOCUMENT ===
           result.tableRoll.results[0].data.type
         ) {
           const item = game.items.get(result.tableRoll.results[0].data.resultId)
@@ -1533,345 +1533,77 @@ export class CoCActor extends Actor {
     return parseInt(this.data.data.attribs.mp.max)
   }
 
-  encounteredCreaturesSanData (creature) {
-    const i = this.encounteredCreaturesSanDataIndex(creature)
-    if (i !== -1) return this.data.data.encounteredCreatures[i]
-    return null
+  getReasonSanLoss (sanReason) {
+    return (
+      this.data.data.sanityLossEvents.filter(
+        r => r.type.toLocaleLowerCase() === sanReason.toLocaleLowerCase()
+      )[0] ?? { type: '', totalLoss: 0, immunity: false }
+    )
   }
 
-  encounteredCreaturesSanDataIndex (creature) {
-    const sanData = CoC7Utilities.getCreatureSanData(creature)
-    return this.data.data.encounteredCreatures.findIndex(cd => {
-      return (
-        cd.id === sanData?.id ||
-        cd.name.toLowerCase() === sanData.name?.toLocaleLowerCase()
-      )
-    })
-  }
-
-  sanLostToCreature (creature) {
-    const sanData = this.encounteredCreaturesSanData(creature)
-    if (sanData) {
-      // check for if specie already encountered return max of both;
-      if (sanData.specie) {
-        return Math.max(sanData.specie.totalLoss || 0, sanData.totalLoss)
-      }
-
-      return sanData.totalLoss || 0
-    } else {
-      // That creature was never encountered. What about his specie.
-      const creatureSanData = CoC7Utilities.getCreatureSanData(creature)
-      if (creatureSanData.specie) {
-        const specieEncountered = this.encounteredCreaturesSanData(
-          creatureSanData.specie
-        )
-        if (specieEncountered) return specieEncountered.totalLoss
-      }
-      return 0 // Never encountered that specie or this creature.
+  sanLostToReason (sanReason) {
+    if (sanReason) {
+      const sanityLossEvent = this.getReasonSanLoss(sanReason)
+      return sanityLossEvent.totalLoss
     }
+    return 0
   }
 
-  maxPossibleSanLossToCreature (creature) {
-    // Do we know you ?
-    const sanData = this.encounteredCreaturesSanData(creature)
-    const creatureSanData = CoC7Utilities.getCreatureSanData(creature)
+  sanLossReasonEncountered (sanReason) {
+    if (sanReason) {
+      const sanityLossEvent = this.getReasonSanLoss(sanReason)
+      return sanityLossEvent.type !== ''
+    }
+    return false
+  }
 
-    if (sanData) {
-      // Was there any update to that creature ?
-      let changes = false
-      if (creatureSanData.sanLossMax !== sanData.sanLossMax) {
-        sanData.sanLossMax = creatureSanData.sanLossMax
-        changes = true
-      }
-      if (creatureSanData.specie && !sanData.specie) {
-        sanData.specie = creatureSanData.specie
-        changes = true
-      }
-      if (
-        creatureSanData.specie &&
-        creatureSanData.specie.sanLossMax !== sanData.specie.sanLossMax
-      ) {
-        sanData.specie.sanLossMax = creatureSanData.specie.sanLossMax
-        changes = true
-      }
-      if (sanData.totalLoss > sanData.sanLossMax) {
-        sanData.totalLoss = sanData.sanLossMax
-        changes = true
-      }
-      if (
-        sanData.specie &&
-        sanData.specie.totalLoss > sanData.specie.sanLossMax
-      ) {
-        sanData.specie.totalLoss = sanData.specie.sanLossMax
-        changes = true
-      }
-
-      if (changes) {
-        const encounteredCreaturesList = this.data.data.encounteredCreatures
-          ? duplicate(this.data.data.encounteredCreatures)
-          : []
-        const sanDataIndex = this.encounteredCreaturesSanDataIndex(creature)
-        encounteredCreaturesList[sanDataIndex] = sanData
-        if (sanData.specie) {
-          this._updateAllOfSameSpecie(encounteredCreaturesList, sanData.specie)
+  setReasonSanLoss (sanReason, sanLoss) {
+    if (sanReason !== '') {
+      const sanityLossEvents = duplicate(this.data.data.sanityLossEvents)
+      const index = sanityLossEvents.findIndex(
+        r => r.type.toLocaleLowerCase() === sanReason.toLocaleLowerCase()
+      )
+      if (sanLoss > 0) {
+        if (index === -1) {
+          sanityLossEvents.push({
+            type: sanReason,
+            totalLoss: sanLoss,
+            immunity: false
+          })
+        } else {
+          sanityLossEvents[index].totalLoss += sanLoss
         }
-
-        this.update({
-          'data.encounteredCreatures': encounteredCreaturesList
+      } else if (index > -1) {
+        sanityLossEvents.splice(index, 1)
+        sanityLossEvents.sort(function (left, right) {
+          return left.type.localeCompare(right.type)
         })
       }
-
-      return sanData.sanLossMax - sanData.totalLoss
-    }
-    // We don't know you.
-    if (creatureSanData) {
-      const sanLostToCreature = this.sanLostToCreature(creature)
-      return Math.max(0, creatureSanData.sanLossMax - sanLostToCreature)
-    }
-    return 99
-  }
-
-  creatureEncountered (creature) {
-    return !!~this.encounteredCreaturesSanDataIndex(creature)
-  }
-
-  creatureSpecieEncountered (creature) {
-    const creatureSanData = CoC7Utilities.getCreatureSanData(creature)
-    if (creatureSanData.specie) {
-      return !!~this.encounteredCreaturesSanDataIndex(creatureSanData.specie)
-    }
-    return this.creatureEncountered(creature)
-  }
-
-  _updateAllOfSameSpecie (encounteredCreaturesList, specieSanData) {
-    for (let index = 0; index < encounteredCreaturesList.length; index++) {
-      if (
-        encounteredCreaturesList[index].specie?.id === specieSanData.id ||
-        encounteredCreaturesList[index].specie?.name.toLowerCase() ===
-          specieSanData.name?.toLowerCase()
-      ) {
-        // New encounter with that specie.
-        if (
-          encounteredCreaturesList[index].specie.totalLoss !==
-          specieSanData.totalLoss
-        ) {
-          const delta =
-            specieSanData.totalLoss -
-            encounteredCreaturesList[index].specie.totalLoss
-          if (delta > 0) {
-            encounteredCreaturesList[index].specie = specieSanData
-            encounteredCreaturesList[index].totalLoss += delta
-            encounteredCreaturesList[index].totalLoss = Math.min(
-              encounteredCreaturesList[index].totalLoss,
-              encounteredCreaturesList[index].sanLossMax
-            )
-          }
-        }
-      }
-    }
-  }
-
-  _removeSpecie (encounteredCreaturesList, specieSanData) {
-    for (let index = 0; index < encounteredCreaturesList.length; index++) {
-      if (
-        encounteredCreaturesList[index].specie?.id === specieSanData.id ||
-        encounteredCreaturesList[index].specie?.name.toLowerCase() ===
-          specieSanData.name?.toLowerCase()
-      ) {
-        const previousSpecieLost =
-          encounteredCreaturesList[index].specie.totalLoss
-        delete encounteredCreaturesList[index].specie
-
-        encounteredCreaturesList[index].totalLoss =
-          encounteredCreaturesList[index].totalLoss - previousSpecieLost
-        if (encounteredCreaturesList[index].totalLoss < 0) {
-          encounteredCreaturesList[index].totalLoss = 0
-        }
-      }
-    }
-  }
-
-  async resetCreature (creature) {
-    const indexSanData = this.encounteredCreaturesSanDataIndex(creature)
-    if (~indexSanData) {
-      const creatureSanData = CoC7Utilities.getCreatureSanData(creature)
-      const encounteredCreaturesList = this.data.data.encounteredCreatures
-        ? duplicate(this.data.data.encounteredCreatures)
-        : []
-      encounteredCreaturesList.splice(indexSanData, 1)
-      creatureSanData.totalLoss = 0
-      if (creatureSanData.specie) delete creatureSanData.specie
-      this._updateAllOfSameSpecie(encounteredCreaturesList, creatureSanData)
-      await this.update({
-        'data.encounteredCreatures': encounteredCreaturesList
+      return this.update({
+        'data.sanityLossEvents': sanityLossEvents
       })
     }
   }
 
-  async resetSpecie (creature) {
-    const encounteredCreaturesList = this.data.data.encounteredCreatures
-      ? duplicate(this.data.data.encounteredCreatures)
-      : []
-    const creatureSanData = CoC7Utilities.getCreatureSanData(creature)
-    if (!creatureSanData.specie) return
-    const indexSanData = this.encounteredCreaturesSanDataIndex(
-      creatureSanData.specie
-    )
-    if (~indexSanData) {
-      encounteredCreaturesList.splice(indexSanData, 1)
+  maxLossToSanReason (sanReason, sanMaxFormula) {
+    const sanMax = new Roll(sanMaxFormula.toString()).evaluate({
+      maximize: true
+    }).total
+    const sanityLossEvent = this.getReasonSanLoss(sanReason)
+    if (sanityLossEvent.immunity) {
+      return 0
     }
-    this._removeSpecie(encounteredCreaturesList, creatureSanData.specie)
-    await this.update({
-      'data.encounteredCreatures': encounteredCreaturesList
-    })
-
-    return false
+    return Math.max(0, sanMax - sanityLossEvent.totalLoss)
   }
 
-  async looseSanToCreature (sanLoss, creature) {
-    let exactSanLoss = sanLoss
-    // Get that creature SAN data.
-    const creatureSanData = CoC7Utilities.getCreatureSanData(creature)
-
-    // Get actor SAN data for that creature.
-    const indexSanData = this.encounteredCreaturesSanDataIndex(creature)
-
-    // Check if that creature belongs to a specie and have we already encoutered it.
-    let indexSpeciesSanData = -1
-    if (creatureSanData.specie?.id) {
-      indexSpeciesSanData = this.encounteredCreaturesSanDataIndex(
-        creatureSanData.specie.id
-      )
+  async looseSan (sanReason, sanLoss) {
+    const sanityLossEvent = this.getReasonSanLoss(sanReason)
+    if (!sanityLossEvent.immunity) {
+      await this.setSan(this.san - sanLoss)
+      this.setReasonSanLoss(sanReason, sanLoss)
+      return sanLoss
     }
-    if (indexSpeciesSanData === -1 && creatureSanData.specie?.name) {
-      indexSpeciesSanData = this.encounteredCreaturesSanDataIndex(
-        creatureSanData.specie.name
-      )
-    }
-
-    // Copy the array for updating.
-    const encounteredCreaturesList = this.data.data.encounteredCreatures
-      ? duplicate(this.data.data.encounteredCreatures)
-      : []
-
-    // Creature already encountered.
-    if (~indexSanData) {
-      const oldSanData = encounteredCreaturesList[indexSanData]
-      let newSanData
-      // Update sanData with new SAN data (might have been updated ?)
-      if (creatureSanData) {
-        newSanData = creatureSanData
-        newSanData.totalLoss = oldSanData.totalLoss || 0
-        if (newSanData.specie) {
-          newSanData.specie.totalLoss = oldSanData.specie?.totalLoss
-            ? oldSanData.specie.totalLoss
-            : 0
-        } else {
-          if (oldSanData.specie) newSanData.specie = oldSanData.specie // Should never happen
-        }
-      }
-
-      newSanData.totalLoss = newSanData.totalLoss
-        ? newSanData.totalLoss + sanLoss
-        : sanLoss
-      if (newSanData.totalLoss > newSanData.sanLossMax) {
-        exactSanLoss =
-          exactSanLoss - (newSanData.totalLoss - newSanData.sanLossMax)
-        newSanData.totalLoss = newSanData.sanLossMax
-      }
-
-      // Credit the loss to that creature specie as well if it exists.
-      if (newSanData.specie) {
-        newSanData.specie.totalLoss = newSanData.specie.totalLoss
-          ? newSanData.specie.totalLoss + exactSanLoss
-          : exactSanLoss
-        if (newSanData.specie.totalLoss > newSanData.specie.sanLossMax) {
-          newSanData.specie.totalLoss = newSanData.specie.sanLossMax
-        }
-
-        // Update all creture from the same specie.
-        this._updateAllOfSameSpecie(encounteredCreaturesList, newSanData.specie)
-      }
-
-      encounteredCreaturesList[indexSanData] = newSanData
-      // Update the specie also :
-      if (~indexSpeciesSanData && newSanData.specie) {
-        encounteredCreaturesList[indexSpeciesSanData] = newSanData.specie
-      } else {
-        // We already encoutered that specie
-        // Should never happen (encountered that creature but never his specie).
-        if (newSanData.specie) encounteredCreaturesList.push(newSanData.specie)
-      }
-    } else {
-      // Creature never encountered.
-      const newSanData = creatureSanData
-      newSanData.totalLoss = 0
-
-      if (newSanData.specie) {
-        // Specie already encountered.
-        if (~indexSpeciesSanData) {
-          newSanData.specie.totalLoss =
-            encounteredCreaturesList[indexSpeciesSanData].totalLoss
-
-          // We already loss SAN to this specie of creature. The base los for this creature is the specie base loss.
-          newSanData.totalLoss = newSanData.specie.totalLoss
-          if (newSanData.totalLoss > newSanData.sanLossMax) {
-            newSanData.totalLoss = newSanData.sanLossMax
-          }
-        } else {
-          // We never encountered specie or creature.
-          newSanData.specie.totalLoss = 0
-          newSanData.totalLoss = 0
-        }
-      }
-
-      // Apply the san loss to that creature.
-      newSanData.totalLoss = newSanData.totalLoss + sanLoss
-
-      // If loss is more thant creature Max.
-      if (newSanData.totalLoss > newSanData.sanLossMax) {
-        // Get the exact san loss = loss - (overflow - max)
-        exactSanLoss =
-          exactSanLoss - (newSanData.totalLoss - newSanData.sanLossMax)
-        newSanData.totalLoss = newSanData.sanLossMax
-      }
-
-      // Deduct the exact loss to that specie.
-      if (newSanData.specie) {
-        // Wait for exact san LOSS before deduciting it from specie.
-        newSanData.specie.totalLoss = newSanData.specie.totalLoss + exactSanLoss
-        if (newSanData.specie.totalLoss > newSanData.specie.sanLossMax) {
-          newSanData.specie.totalLoss = newSanData.specie.sanLossMax
-        }
-
-        // If we now that specie update it. If we don't add it.
-        if (~indexSpeciesSanData) {
-          encounteredCreaturesList[indexSpeciesSanData] = newSanData.specie
-        } else {
-          encounteredCreaturesList.push(newSanData.specie)
-        }
-
-        // Update all creature from the same specie.
-        this._updateAllOfSameSpecie(encounteredCreaturesList, newSanData.specie)
-      }
-
-      encounteredCreaturesList.push(newSanData)
-    }
-
-    await this.setSan(this.san - exactSanLoss)
-    await this.update({
-      'data.encounteredCreatures': encounteredCreaturesList
-    })
-    return exactSanLoss
-  }
-
-  async looseSan (sanLoss, creature = null) {
-    if (creature) await this.looseSanToCreature(sanLoss, creature)
-    else await this.setSan(this.san - sanLoss)
-  }
-
-  get sanData () {
-    return CoC7Utilities.getCreatureSanData(this)
+    return 0
   }
 
   sanLoss (checkPassed) {
@@ -2024,9 +1756,15 @@ export class CoCActor extends Actor {
     return 2 * Number(this.data.data.characteristics.int.value)
   }
 
-  get hasSkillFlaggedForExp () {
+  get hasDevelopmentPhase () {
     for (const skill of this.skills) {
       if (skill.data.data.flags?.developement) return true
+    }
+    if (this.onlyRunOncePerSession) {
+      return false
+    }
+    for (const sanityLossEvent of this.data.data.sanityLossEvents) {
+      if (!sanityLossEvent.immunity) return true
     }
     return false
   }
@@ -2035,29 +1773,6 @@ export class CoCActor extends Actor {
     if (value < 0) value = 0
     if (value > this.sanMax) value = this.sanMax
     const loss = parseInt(this.data.data.attribs.san.value) - value
-    // if( creatureData){
-    //  const creatureIndex = this.data.data.encounteredCreatures.findIndex( c => {
-    //    if( c.id && c.id == creatureData.id) return true;
-    //    if( c.name && c.name.toLowerCase() == creatureData.name?.toLowerCase()) return true;
-    //    return false;});
-    //  let encounteredCreaturesList;
-    //  if( -1 < creatureIndex){
-    //    encounteredCreaturesList = this.data.data.encounteredCreatures ? duplicate( this.data.data.encounteredCreatures) : [];
-    //    const maxLossRemaining = encounteredCreaturesList[creatureIndex].maxLoss - encounteredCreaturesList[creatureIndex].totalLoss;
-    //    if( loss > maxLossRemaining) loss = maxLossRemaining;
-    //    encounteredCreaturesList[creatureIndex].totalLoss += loss;
-    //  } else {
-    //    if( loss > createData.maxLoss) loss = createData.maxLoss;
-    //    encounteredCreaturesList = [{
-    //        id: creatureData.id,
-    //        name: creatureData.name,
-    //        maxLoss: createData.maxLoss,
-    //        totalLoss: loss
-    //      }];
-    //  }
-
-    //  await this.item.update( { ['data.encounteredCreatures'] : encounteredCreaturesList});
-    // }
 
     if (loss > 0) {
       let totalLoss = parseInt(this.data.data.attribs.san.dailyLoss)
@@ -2748,10 +2463,12 @@ export class CoCActor extends Actor {
     const alwaysSuccessThreshold = 95
 
     const title = game.i18n.localize('CoC7.RollAll4Dev')
+    let skillsRolled = 0
     let message = '<p class="chat-card">'
     for (const item of this.items) {
       if (item.type === 'skill') {
         if (item.developementFlag) {
+          skillsRolled++
           const die = await new Die({ faces: 100 }).evaluate({ async: true })
           const skillValue = item.value
           let augment = null
@@ -2814,10 +2531,35 @@ export class CoCActor extends Actor {
         }
       }
     }
+    const sanityLossEvents = []
+    let changed = false
+    for (const sanityLossEvent of this.data.data.sanityLossEvents) {
+      if (sanityLossEvent.immunity) {
+        sanityLossEvents.push(sanityLossEvent)
+      } else if (sanityLossEvent.totalLoss > 1) {
+        sanityLossEvent.totalLoss--
+        sanityLossEvents.push(sanityLossEvent)
+        changed = true
+      } else {
+        changed = true
+      }
+    }
+    if (changed) {
+      if (skillsRolled) {
+        message += '<br>'
+      }
+      message += `<span>${game.i18n.format('CoC7.ReduceSanityLimits')}</span>`
+      await this.update({
+        'data.sanityLossEvents': sanityLossEvents
+      })
+    }
     if (!fastForward) {
       message += '</p>'
-      const speaker = { actor: this.actor }
-      await chatHelper.createMessage(title, message, { speaker: speaker })
+      const speaker = { actor: this }
+      await chatHelper.createMessage(skillsRolled ? title : '', message, {
+        speaker: speaker
+      })
+      this.onlyRunOncePerSession = true
     }
     return { failure: failure, success: success }
   }
@@ -3213,6 +2955,14 @@ export class CoCActor extends Actor {
       return parseInt(CM.data.data.value)
     }
     return 0
+  }
+
+  get mythosHardened () {
+    return this.getFlag('CoC7', 'mythosHardened') || false
+  }
+
+  async setMythosHardened () {
+    await this.setFlag('CoC7', 'mythosHardened', true)
   }
 
   get mythosInsanityExperienced () {

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -201,7 +201,6 @@ export class CoC7ActorSheet extends ActorSheet {
       }
 
       if (!data.data.biography) data.data.biography = []
-      if (!data.data.encounteredCreatures) data.data.encounteredCreatures = []
 
       data.pulpRuleArchetype = game.settings.get('CoC7', 'pulpRuleArchetype')
       data.pulpRuleOrganization = game.settings.get(
@@ -219,6 +218,26 @@ export class CoC7ActorSheet extends ActorSheet {
         // ce bloc devrait etre déplacé dans le bloc _updateFormData
         if (item.type === 'skill') {
           if (item.data.properties.special) {
+            if (typeof item.data.specialization === 'string') {
+              // updater.js didn't catch this
+              const parts = CoC7Item.getNamePartsSpec(
+                item.name,
+                item.data.specialization
+              )
+              const itemToUpdate = this.actor.items.get(item._id)
+              item.name = parts.name
+              item.data.specialization = {
+                group: parts.group,
+                type: parts.type
+              }
+              await itemToUpdate.update({
+                name: item.name,
+                'data.specialization': {
+                  group: item.data.specialization.group,
+                  type: item.data.specialization.type
+                }
+              })
+            }
             if (item.data.properties.fighting) {
               if (
                 item.data.specialization.group !==
@@ -960,7 +979,7 @@ export class CoC7ActorSheet extends ActorSheet {
           game.CoC7Tooltips.ToolTipHover !== null
         ) {
           const char = game.CoC7Tooltips.ToolTipHover.closest('.char-box')
-          if (typeof char !== 'undefined') {
+          if (typeof char !== 'undefined' && !!char) {
             const charId = char.dataset.characteristic
             const characteristic = sheet.actor.characteristics[charId]
             let toolTip = game.i18n.format('CoC7.ToolTipSkill', {

--- a/module/actors/sheets/container.js
+++ b/module/actors/sheets/container.js
@@ -78,7 +78,8 @@ export class CoC7ContainerSheet extends ActorSheet {
       !sheetData.data.flags.locked
     sheetData.showInventoryTalents =
       Object.prototype.hasOwnProperty.call(sheetData.itemsByType, 'talent') ||
-      (!data.data.flags.locked && game.settings.get('CoC7', 'pulpRuleTalents'))
+      (!sheetData.data.flags.locked &&
+        game.settings.get('CoC7', 'pulpRuleTalents'))
     sheetData.showInventoryWeapons =
       Object.prototype.hasOwnProperty.call(sheetData.itemsByType, 'weapon') ||
       !sheetData.data.flags.locked

--- a/module/actors/sheets/npc-sheet.js
+++ b/module/actors/sheets/npc-sheet.js
@@ -94,7 +94,11 @@ export class CoC7NPCSheet extends CoC7ActorSheet {
       const linkData = {
         check: 'sanloss',
         sanMin: this.actor.data.data.special.sanLoss.checkPassed,
-        sanMax: this.actor.data.data.special.sanLoss.checkFailled
+        sanMax: this.actor.data.data.special.sanLoss.checkFailled,
+        sanReason: this.actor.data.data.infos.type?.length
+          ? this.actor.data.data.infos.type
+          : this.actor.name,
+        tokenKey: this.actor.actorKey
       }
       if (game.settings.get('core', 'rollMode') === 'blindroll') {
         linkData.blind = true
@@ -111,7 +115,15 @@ export class CoC7NPCSheet extends CoC7ActorSheet {
         )
       }
     } else {
-      SanCheckCard.checkTargets(this.actor.tokenKey, event.shiftKey)
+      const sanData = {
+        sanMax: this.actor.sanLossCheckFailled,
+        sanMin: this.actor.sanLossCheckPassed,
+        sanReason: this.actor.data.data.infos.type?.length
+          ? this.actor.data.data.infos.type
+          : this.actor.name,
+        tokenKey: this.actor.actorKey
+      }
+      SanCheckCard.checkTargets(sanData, event.shiftKey)
     }
   }
 

--- a/module/apps/create-mythos-encounters.js
+++ b/module/apps/create-mythos-encounters.js
@@ -1,0 +1,53 @@
+/* global $, FormApplication, game, mergeObject */
+export class CoC7CreateMythosEncounter extends FormApplication {
+  static get defaultOptions () {
+    return mergeObject(super.defaultOptions, {
+      classes: ['coc7'],
+      title: game.i18n.localize('CoC7.SanityLossTypeDialogTitle'),
+      template: 'systems/CoC7/templates/apps/sanity-loss-type.hbs',
+      height: 'auto'
+    })
+  }
+
+  async getData () {
+    const data = await super.getData()
+    data.isImmunity = data.object.type === 'immunity'
+    return data
+  }
+
+  activateListeners (html) {
+    html.find('.field_type').change(this._onSelectChange.bind(this))
+    html.find('.dialog-button').click(this._onButtonClick.bind(this))
+    super.activateListeners(html)
+  }
+
+  _onButtonClick (event) {
+    if (event.currentTarget.dataset.button === 'add') {
+      const html = $(event.currentTarget).closest('.window-content')
+      const type = html.find('.field_type').val()
+      const name = html.find('.field_name').val()
+      const value = parseInt(html.find('.field_value').val())
+      const sanityLossEvents = (this.object.actor.data.data.sanityLossEvents ?? [])
+      sanityLossEvents.push({
+        type: name,
+        totalLoss: value,
+        immunity: (type === 'immunity')
+      })
+      sanityLossEvents.sort(function (left, right) {
+        return left.type.localeCompare(right.type)
+      })
+      this.object.actor.update({ 'data.sanityLossEvents': sanityLossEvents })
+    }
+    this.close()
+  }
+
+  _onSelectChange (event) {
+    const html = $(event.currentTarget).closest('.window-content')
+    this.object.name = html.find('.field_name').val()
+    this.object.type = html.find('.field_type').val()
+    this.render(true)
+  }
+
+  async _updateObject (event, formData) {
+  }
+}

--- a/module/apps/link.js
+++ b/module/apps/link.js
@@ -389,6 +389,9 @@ export class CoC7Link {
         if (this._linkData.difficulty) {
           options += `,difficulty:${this._linkData.difficulty}`
         }
+        if (this._linkData.sanReason) {
+          options += `,sanReason:${this._linkData.sanReason}`
+        }
         if (this._linkData.modifier) {
           options += `,modifier:${this._linkData.modifier}`
         }

--- a/module/apps/parser.js
+++ b/module/apps/parser.js
@@ -125,7 +125,7 @@ export class CoC7Parser {
     html,
     data /* chatMessage, data/*, option, user */
   ) {
-    // @coc7.sanloss[sanMax:1D6,sanMin:1,difficulty:++,modifier:-1]{Hard San Loss (-1) 1/1D6}
+    // @coc7.sanloss[sanMax:1D6,sanMin:1,sanReason:Ghouls,difficulty:++,modifier:-1]{Hard San Loss (-1) 1/1D6}
     // @coc7.check[type:charac,name:STR,difficulty:+,modifier:-1]{Hard STR check(-1)}
     // @coc7.check[type:attrib,name:lck,difficulty:+,modifier:-1]{Hard luck check(-1)}
     // @coc7.check[type:skill,name:anthropology,difficulty:+,modifier:-1]{Hard Anthropology check(-1)}
@@ -445,16 +445,9 @@ export class CoC7Parser {
               break
 
             case 'sanloss': {
-              SanCheckCard.create(token.actor.id, options, {
+              SanCheckCard.create(token.actor.actorKey, options, {
                 fastForward: event.shiftKey
               })
-              // const check = new CoC7SanCheck(
-              //   token.actor.id,
-              //   options.sanMin,
-              //   options.sanMax,
-              //   undefined != options.difficulty?CoC7Utilities.convertDifficulty(options.difficulty):CoC7Check.difficultyLevel.regular,
-              //   undefined != options.modifier?Number(options.modifier):0);
-              // check.toMessage( event.shiftKey);
               break
             }
 

--- a/module/chat.js
+++ b/module/chat.js
@@ -1058,14 +1058,7 @@ export class CoC7Chat {
 
       case 'reset-creature-san-data': {
         const sanCheck = SanCheckCard.getFromCard(card)
-        await sanCheck.resetCreatureSanData()
-        await sanCheck.updateChatCard()
-        break
-      }
-
-      case 'reset-specie-san-data': {
-        const sanCheck = SanCheckCard.getFromCard(card)
-        await sanCheck.resetSpecieSanData()
+        await sanCheck.clearSanLossReason()
         await sanCheck.updateChatCard()
         break
       }

--- a/module/chat/card-actor.js
+++ b/module/chat/card-actor.js
@@ -136,7 +136,7 @@ export class ChatCardActor {
     if (this.actor) {
       speakerData.actor = this.actor
       if (this.token) {
-        speakerData.token = this.token
+        speakerData.token = this.token.document
       }
       speaker = ChatMessage.getSpeaker(speakerData)
     } else {

--- a/module/chat/cards/san-check.js
+++ b/module/chat/cards/san-check.js
@@ -1,9 +1,7 @@
 /* global $, game, renderTemplate, Roll, ui */
-
 import { COC7 } from '../../config.js'
 import { CoC7Check } from '../../check.js'
 import { CoC7Dice } from '../../dice.js'
-import { CoC7Utilities } from '../../utilities.js'
 import { ChatCardActor } from '../card-actor.js'
 import { createInlineRoll, chatHelper } from '../helper.js'
 
@@ -12,7 +10,7 @@ function replacer (key, value) {
     return undefined // remove from result
   }
 
-  const exclude = ['_actor', '_creature']
+  const exclude = ['_actor']
   if (exclude.includes(key)) {
     return undefined
   }
@@ -24,6 +22,7 @@ function replacer (key, value) {
 
   return value // return as is
 }
+
 export class SanCheckCard extends ChatCardActor {
   constructor (actorKey = null, sanData = {}, options = {}) {
     super(
@@ -32,6 +31,7 @@ export class SanCheckCard extends ChatCardActor {
         ? Boolean(options.fastForward)
         : false
     )
+    sanData.sanReason = sanData.sanReason ?? ''
     this.sanData = sanData
     this.options = options
     if (sanData.modifier && !isNaN(Number(sanData.modifier))) {
@@ -40,7 +40,6 @@ export class SanCheckCard extends ChatCardActor {
     if (sanData.difficulty && !isNaN(Number(sanData.difficulty))) {
       this.options.sanDifficulty = Number(sanData.difficulty)
     }
-    // this.options.obj={test:1,test2:2};
     this.state = {}
   }
 
@@ -62,15 +61,9 @@ export class SanCheckCard extends ChatCardActor {
       : 0
   }
 
-  get creature () {
-    // TODO : check constructor
-    if (
-      this.sanData.creatureKey &&
-      (!this.__creature || this.__creature.constructor.name === 'Object')
-    ) {
-      this.__creature = chatHelper.getActorFromKey(this.sanData.creatureKey) // REFACTORING (2)
-    }
-    return this.__creature
+  get sanLossSource () {
+    if (!this.sanData.tokenKey) return null
+    return chatHelper.getActorFromKey(this.sanData.tokenKey)
   }
 
   get involuntaryAction () {
@@ -95,60 +88,34 @@ export class SanCheckCard extends ChatCardActor {
           ? Number(this.sanData.sanMin)
           : this.sanData.sanMin
       }
-
-      const formula = this.creature?.sanLoss(this.sanCheck.passed) || 0
-      if (formula) {
-        if (!isNaN(Number(formula))) return Number(formula)
-        return formula
-      }
       return 0
     }
     return null
   }
 
-  get sanLostToThisCreature () {
-    if (this.creature) return this.actor.sanLostToCreature(this.creature)
-    return undefined
+  get sanLostToReason () {
+    return this.actor.sanLostToReason(this.sanData.sanReason)
   }
 
-  get maxSanLossToThisCreature () {
-    if (this.creature) {
-      return this.actor.maxPossibleSanLossToCreature(this.creature)
-    }
-    return undefined
+  get maxPossibleSanLoss () {
+    return this.actor.maxLossToSanReason(
+      this.sanData.sanReason,
+      this.sanData.sanMax
+    )
   }
 
   get maxSanLoss () {
-    if (this.creature) return this.maxSanLossToThisCreature
-    if (this.sanData.sanMax) {
-      if (!isNaN(Number(this.sanData.sanMax))) {
-        return Number(this.sanData.sanMax)
-      }
-      return new Roll(this.sanData.sanMax).evaluate({ maximize: true }).total
-    }
-    return null
+    return new Roll(this.sanData.sanMax).evaluate({
+      maximize: true
+    }).total
   }
 
-  get creatureEncountered () {
-    if (this.creature) return this.actor.creatureEncountered(this.creature)
-    return undefined
-  }
-
-  get creatureSpecieEncountered () {
-    if (this.creature) {
-      return this.actor.creatureSpecieEncountered(this.creature)
-    }
-    return undefined
+  get sanLossReasonEncountered () {
+    return this.actor.sanLossReasonEncountered(this.sanData.sanReason)
   }
 
   get firstEncounter () {
     return !this.actor.mythosInsanityExperienced
-  }
-
-  get creatureHasSpecie () {
-    const creatureSanData = CoC7Utilities.getCreatureSanData(this.creature)
-    if (creatureSanData.specie) return true
-    return false
   }
 
   get isActorLoosingSan () {
@@ -160,23 +127,15 @@ export class SanCheckCard extends ChatCardActor {
     // The san loss is a 0
     if (this.sanLossFormula === 0) return false
 
-    if (this.creature) {
-      // Creature has no san loss (what are we doing here ???)
-      if (!this.creature.sanLossMax) return false
-
-      // Actor already encountered that creature and lost already more or equal than max creature SAN loss.
-      if (
-        this.actor.sanLostToCreature(this.creature) >= this.creature.sanLossMax
-      ) {
-        this.state.immuneToCreature = true
-        return false
-      }
-
-      // Max possible actor loos to this creature is 0
-      if (this.actor.maxPossibleSanLossToCreature(this.creature) === 0) {
-        this.state.immuneToCreature = true
-        return false
-      }
+    if (
+      this.sanData.sanReason &&
+      this.actor.maxLossToSanReason(
+        this.sanData.sanReason,
+        this.sanData.sanMax
+      ) === 0
+    ) {
+      this.state.immuneToCreature = true
+      return false
     }
 
     return true
@@ -236,7 +195,6 @@ export class SanCheckCard extends ChatCardActor {
         )
         this.state.boutOfMadnessResolved = true
         await this.triggerInsanity()
-        // if( this.state.indefinitelyInsane) this.actor.
         break
       }
       case 'boutOfMadnessOver': {
@@ -244,13 +202,11 @@ export class SanCheckCard extends ChatCardActor {
         await this.triggerInsanity()
         break
       }
-
       case 'noMythosGained': {
         this.state.cthulhuMythosAwarded = true
         this.mythosGain = 0
         break
       }
-
       case 'cthulhuMythosAwarded': {
         let amountGained = 1
         if (!this.actor.mythosInsanityExperienced) {
@@ -311,61 +267,61 @@ export class SanCheckCard extends ChatCardActor {
       this.sanLoss = 0
     } else if (typeof this.sanLossFormula === 'number') {
       this.state.sanLossRolled = true
-      if (this.creature) {
-        this.sanLoss = Math.min(
-          this.sanLossFormula,
-          this.maxSanLossToThisCreature
+      if (this.sanData.sanReason) {
+        this.sanLoss = this.actor.maxLossToSanReason(
+          this.sanData.sanReason,
+          this.sanLossFormula
         )
-        if (this.sanLossFormula > this.maxSanLossToThisCreature) {
+        if (this.sanLoss < this.sanLossFormula) {
           this.state.limitedLossToCreature = true
         }
-      } else this.sanLoss = this.sanLossFormula
+      } else {
+        this.sanLoss = this.sanLossFormula
+      }
     } else if (this.sanCheck.isFumble) {
       this.state.sanLossRolled = true
-      this.sanLoss = this.maxSanLoss
-    } else if (this.creature) {
+      this.sanLoss = this.actor.maxLossToSanReason(
+        this.sanData.sanReason,
+        this.sanData.sanMax
+      )
+    } else if (this.sanData.sanReason) {
       const min = new Roll(this.sanLossFormula).evaluate({
         minimize: true
       }).total
-      if (min >= this.maxSanLossToThisCreature) {
+      const max = this.actor.maxLossToSanReason(
+        this.sanData.sanReason,
+        this.sanData.sanMax
+      )
+      if (min >= max) {
         this.state.sanLossRolled = true
-        this.sanLoss = this.maxSanLossToThisCreature
+        this.sanLoss = max
         this.state.limitedLossToCreature = true
       }
     }
   }
 
   async rollSanLoss () {
-    if (this.creature) {
-      // this.sanLossRoll = new Roll(`{${this.sanLossFormula},${this.maxSanLossToThisCreature}}kl`);
-      this.sanLossRoll = new Roll(`${this.sanLossFormula}`)
-    } else {
-      this.sanLossRoll = new Roll(`${this.sanLossFormula}`)
-    }
+    this.sanLossRoll = new Roll(`${this.sanLossFormula}`)
 
     await this.sanLossRoll.roll({ async: true })
 
     await CoC7Dice.showRollDice3d(this.sanLossRoll)
 
-    if (this.creature) {
-      // Will never happen
-      if (this.sanLossRoll.total > this.maxSanLossToThisCreature) {
-        this.state.limitedLossToCreature = true
-      }
+    const max = this.actor.maxLossToSanReason(
+      this.sanData.sanReason,
+      this.sanData.sanMax
+    )
+
+    if (this.sanLossRoll.total > max) {
+      this.state.limitedLossToCreature = true
     }
 
-    this.sanLoss = this.creature
-      ? Math.min(this.sanLossRoll.total, this.maxSanLossToThisCreature)
-      : this.sanLossRoll.total
+    this.sanLoss = Math.min(this.sanLossRoll.total, max)
     this.state.sanLossRolled = true
   }
 
   async applySanLoss () {
-    if (this.creature) {
-      await this.actor.looseSanToCreature(this.sanLoss, this.creature)
-    } else {
-      await this.actor.looseSan(this.sanLoss)
-    }
+    await this.actor.looseSan(this.sanData.sanReason, this.sanLoss)
 
     if (this.sanLoss > 0) this.state.actorLostSan = true
     this.state.sanLossApplied = true
@@ -382,7 +338,7 @@ export class SanCheckCard extends ChatCardActor {
 
     if (this.sanLoss < 5) {
       this.state.intRolled = true
-      if (this.actor.isIndefInsane) {
+      if (this.actor.hasIndefInsane) {
         this.state.insanity = true
         this.state.shaken = true
         this.state.insanityTableRolled = false
@@ -437,21 +393,15 @@ export class SanCheckCard extends ChatCardActor {
 
   async triggerInsanity () {
     this.state.boutOfMadnessOver = true
-    if (this.state.indefinitelyInsane)
+    if (this.state.indefinitelyInsane) {
       await this.actor.setCondition(COC7.status.indefInsane)
+    }
     this.state.finish = true
   }
 
-  async resetCreatureSanData () {
-    await this.actor.resetCreature(this.creature)
-    if (!this.creatureEncountered && !this.creatureSpecieEncountered) {
-      this.state.keepCreatureSanData = true
-    }
-  }
-
-  async resetSpecieSanData () {
-    await this.actor.resetSpecie(this.creature)
-    if (!this.creatureEncountered && !this.creatureSpecieEncountered) {
+  async clearSanLossReason () {
+    await this.actor.setReasonSanLoss(this.sanData.sanReason, 0)
+    if (!this.sanLossReasonEncountered) {
       this.state.keepCreatureSanData = true
     }
   }
@@ -491,23 +441,16 @@ export class SanCheckCard extends ChatCardActor {
     return 'systems/CoC7/templates/chat/cards/san-check.html'
   }
 
-  static checkTargets (creatureKey, fastForward = false) {
+  static checkTargets (sanData, fastForward = false) {
     const targets = [...game.user.targets]
     if (targets.length) {
       for (const t of targets) {
-        // TODO : ? Make async call to create ?
         if (t.actor.isToken) {
-          SanCheckCard.create(
-            t.actor.tokenKey,
-            { creatureKey: creatureKey },
-            { fastForward: fastForward }
-          )
+          SanCheckCard.create(t.actor.tokenKey, sanData, {
+            fastForward: fastForward
+          })
         } else {
-          SanCheckCard.create(
-            t.actor.id,
-            { creatureKey: creatureKey },
-            { fastForward: fastForward }
-          )
+          SanCheckCard.create(t.actor.id, sanData, { fastForward: fastForward })
         }
       }
     } else {
@@ -517,8 +460,7 @@ export class SanCheckCard extends ChatCardActor {
 
   static async create (...args) {
     const chatCard = new SanCheckCard(...args)
-
-    if (chatCard.actor.isIndefInsane) {
+    if (chatCard.actor.hasIndefInsane) {
       chatCard.state.alreadyInsane = true
     }
 
@@ -530,10 +472,6 @@ export class SanCheckCard extends ChatCardActor {
       chatCard.state.permanentlyInsane = true
 
       chatCard.state.finish = true
-    }
-
-    if (!chatCard.creatureEncountered && !chatCard.creatureSpecieEncountered) {
-      chatCard.state.keepCreatureSanData = true
     }
 
     const html = await renderTemplate(SanCheckCard.template, chatCard)
@@ -578,8 +516,6 @@ export class SanCheckCard extends ChatCardActor {
     if (sanCheckCard.sanLossRoll?.constructor?.name === 'Object') {
       sanCheckCard.sanLossRoll = Roll.fromData(sanCheckCard.sanLossRoll)
     }
-
-    // sanCheckCard.sanCheck?.toMessage();
 
     return sanCheckCard
   }

--- a/module/items/item.js
+++ b/module/items/item.js
@@ -262,7 +262,6 @@ export class CoC7Item extends Item {
   }
 
   get shortName () {
-    console.log(this.data)
     if (
       this.data.data.properties.special &&
       this.data.data.specialization.type.length

--- a/module/scripts/load-templates.js
+++ b/module/scripts/load-templates.js
@@ -14,6 +14,8 @@ export const preloadHandlebarsTemplates = async function () {
     'systems/CoC7/templates/actors/parts/actor-inventory.html',
     'systems/CoC7/templates/actors/parts/actor-inventory-items.html',
     'systems/CoC7/templates/actors/parts/actor-background.html',
+    'systems/CoC7/templates/actors/parts/actor-mythos-enounters.hbs',
+    'systems/CoC7/templates/actors/parts/actor-keeper-mythos-enounters.hbs',
     'systems/CoC7/templates/actors/parts/actor-skills-v2.html',
     'systems/CoC7/templates/actors/parts/actor-weapons-v2.html',
     'systems/CoC7/templates/actors/parts/character-development-v2.html',

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -116,56 +116,6 @@ export class CoC7Utilities {
     ui.notifications.infos('Do some stuff')
   }
 
-  static getCreatureSanData (creature) {
-    let creatureData
-    let actor
-    if (creature.constructor.name === 'CoCActor') {
-      actor = creature
-    }
-
-    if (typeof creature === 'string') {
-      actor = CoC7Utilities.getActorFromString(creature)
-    }
-
-    if (actor) {
-      if (actor.isToken) {
-        const specie = game.actors.get(actor.id)
-        // The token has a different maximum san loss.
-        // We assume it's a special represantant of his specie.
-        // The san loss for encoutered creature will counted for that token in particular
-        // and for the all specie
-        if (specie && specie.sanLossMax !== actor.sanLossMax) {
-          creatureData = {
-            id: actor.token.id,
-            name: actor.name,
-            sanLossMax: actor.sanLossMax,
-            specie: {
-              id: specie.id,
-              name: specie.name,
-              sanLossMax: specie.sanLossMax
-            }
-          }
-        } else {
-          // If they induce the same SAN loos credit everything to the specie.
-          // If the actor doen't exist in actor directory use the token data instead.
-          creatureData = {
-            id: specie ? specie.id : actor.id,
-            name: specie ? specie.name : actor.name,
-            sanLossMax: specie ? specie.sanLossMax : actor.sanLossMax
-          }
-        }
-      } else {
-        creatureData = {
-          id: actor.id,
-          name: actor.name,
-          sanLossMax: actor.sanLossMax
-        }
-      }
-      return creatureData
-    } else if (typeof creature === 'object') return creature
-    return null
-  }
-
   static getActorFromString (actorString) {
     let actor
 

--- a/styles/sheets/character.less
+++ b/styles/sheets/character.less
@@ -330,6 +330,12 @@
             list-style-type: decimal;
           }
 
+          .character-background {
+            .editor {
+              height: calc(100% - 40px);
+            }
+          }
+
           .tab {
             height: 100%;
           }

--- a/styles/sheets/sheets.less
+++ b/styles/sheets/sheets.less
@@ -72,6 +72,30 @@ h3.keeper-only-tab i {
     overflow: auto;
     .bio-section {
       padding: 0 2px;
+      .bio-section-value {
+        height: max-content;
+        resize: none;
+        font-family: customSheetFont, 'Palatino Linotype', serif;
+        font-size: 0.75rem;
+      }
+      div.bio-section-type,
+      div.item-controls {
+        padding: 2px 0;
+      }
+      div.bio-section-value {
+        padding: 5px;
+        background: rgba(0, 0, 0, 0.05);
+        border: 1px solid var(--color-border-dark);
+        border-radius: 3px;
+        color: #000;
+        div.bio-section-values {
+          flex: 0 0 40px;
+          text-align: center;
+          input {
+            width: 28px;
+          }
+        }
+      }
     }
   }
 

--- a/template.json
+++ b/template.json
@@ -181,7 +181,7 @@
         "archetype": null
       },
       "biography": [],
-      "encounteredCreatures": [],
+      "sanityLossEvents": [],
       "backstory": "",
       "indefiniteInsanityLevel": {
         "value": 0,

--- a/templates/actors/character-sheet-v2.html
+++ b/templates/actors/character-sheet-v2.html
@@ -219,23 +219,54 @@
             {{> "systems/CoC7/templates/actors/parts/actor-inventory.html"}}
           </div>
 
-          <div class="tab coc7 sheet actor temp-retro-compat restore-list-styles" data-group="primary" data-tab="background">
+          <div class="tab coc7 sheet actor temp-retro-compat restore-list-styles character-background" data-group="primary" data-tab="background">
             {{#if oneBlockBackStory}}
               {{editor content=data.backstory target="data.backstory" button=true owner=owner editable=editable}}
+              {{> "systems/CoC7/templates/actors/parts/actor-mythos-enounters.hbs"}}
             {{else}}
               {{> "systems/CoC7/templates/actors/parts/actor-background.html"}}
             {{/if}}
           </div>
 
           {{#if isGM}}
-            <div class="tab coc7 sheet actor temp-retro-compat restore-list-styles" data-group="primary" data-tab="keeper">
-              <div style="height: calc(100% - 20px);">
-                {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
-              </div>
-              <div>
-                {{#if hasConditions}}
-                  <a class="clear_conditions button">Clear All Conditions</a>
-                {{/if}}
+            <div class="tab coc7 sheet actor temp-retro-compat restore-list-styles character-background" data-group="primary" data-tab="keeper">
+              {{editor content=data.description.keeper target="data.description.keeper" button=true owner=owner editable=editable}}
+              {{#if hasConditions}}
+                <div><a class="clear_conditions button">Clear All Conditions</a></div>
+              {{/if}}
+              <div class="flexrow">
+                {{> "systems/CoC7/templates/actors/parts/actor-keeper-mythos-enounters.hbs"}}
+                <div class="flexcol bio-section" style="flex: 0 0 50%;">
+                  <div class="flexrow" style="flex: initial;">
+                    <label style="height: 1rem;margin: 0;border: 0;font-family: customSheetFont, 'Palatino Linotype', serif;font-size: .75rem;flex: 1;">{{localize 'CoC7.BackgroundFlags'}}</label>
+                  </div>
+                  <div class="bio-section-value" style="min-height: 80px;">
+                    <div class="flexrow">
+                      <div class="bio-section-type">{{localize 'CoC7.BackgroundFlagsMythosExperienced'}}</div>
+                      <div class="item-controls">
+                        <a class="item-control toggle-keeper-flags" title="{{localize 'CoC7.BackgroundFlagsMythosExperienced'}}" data-flag="mythosInsanityExperienced">
+                          {{#if actor.mythosInsanityExperienced}}
+                            <i class="far fa-check-square"></i>
+                          {{else}}
+                            <i class="far fa-square"></i>
+                          {{/if}}
+                        </a>
+                      </div>
+                    </div>
+                    <div class="flexrow">
+                      <div class="bio-section-type">{{localize 'CoC7.BackgroundFlagsMythosHardened'}}</div>
+                      <div class="item-controls">
+                        <a class="item-control toggle-keeper-flags" title="{{localize 'CoC7.BackgroundFlagsMythosHardened'}}" data-flag="mythosHardened">
+                          {{#if actor.mythosHardened}}
+                            <i class="far fa-check-square"></i>
+                          {{else}}
+                            <i class="far fa-square"></i>
+                          {{/if}}
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           {{/if}}

--- a/templates/actors/parts/actor-background.html
+++ b/templates/actors/parts/actor-background.html
@@ -3,25 +3,26 @@
     <div class='add-new-section button' >{{localize 'CoC7.BackgroundNewSection'}}</div>
 </div>
 {{/unless}}
-<div class='flexrow'>
-{{#each data.biography as |section index|}}
-<div class='flexcol bio-section' data-index='{{index}}' style='flex: 0 0 50%;'>
-    {{#if ../data.flags.locked}}
-    <div class='flexrow' style='flex: initial;'>
-        <label style='height: 1rem;margin: 0;border: 0;font-family: customSheetFont, "Palatino Linotype", serif;font-size: .75rem;'>{{section.title}}</label>
-    </div>
-    {{else}}
-    <div class='flexrow' style='flex: initial;'>
-        <input class='bio-section-title' style='height: fit-content;margin: 0;border: 0;font-family: customSheetFont, "Palatino Linotype", serif;font-size: 0.75rem;font-weight: bolder;'  type="text" value="{{section.title}}" placeholder="{{localize 'CoC7.BackgroundSectionNameHolder'}}">
-        <div class="flex1" style='height: fit-content;'></div>
-        <div class="item-controls" style='height: fit-content;font-size: 10px;line-height: 18px;'>
+  <div class='flexrow'>
+  {{#each data.biography as |section index|}}
+    <div class='flexcol bio-section' data-index='{{index}}' style='flex: 0 0 50%;'>
+      {{#if ../data.flags.locked}}
+        <div class='flexrow' style='flex: initial;'>
+          <label style='height: 1rem;margin: 0;border: 0;font-family: customSheetFont, "Palatino Linotype", serif;font-size: .75rem;'>{{section.title}}</label>
+        </div>
+      {{else}}
+        <div class='flexrow' style='flex: initial;'>
+          <input class='bio-section-title' style='height: fit-content;margin: 0;border: 0;font-family: customSheetFont, "Palatino Linotype", serif;font-size: 0.75rem;font-weight: bolder;'  type="text" value="{{section.title}}" placeholder="{{localize 'CoC7.BackgroundSectionNameHolder'}}">
+          <div class="flex1" style='height: fit-content;'></div>
+          <div class="item-controls" style='height: fit-content;font-size: 10px;line-height: 18px;'>
             <a class="delete-section" title="{{localize 'CoC7.BackgroundDeleteSection'}}"><i class="fas fa-trash"></i></a>
             {{#unless section.isFirst}}<a class="move-section-up" title="{{localize 'CoC7.BackgroundSectionMoveUp'}}"><i class="fas fa-caret-up"></i></a>{{/unless}}
             {{#unless section.isLast}}<a class="move-section-down" title="{{localize 'CoC7.BackgroundSectionMoveDown'}}"><i class="fas fa-caret-down"></i></a>{{/unless}}
+          </div>
         </div>
+      {{/if}}
+      <textarea class='bio-section-value' rows="4" >{{section.value}}</textarea>
     </div>
-    {{/if}}
-    <textarea class='bio-section-value' style='height: max-content;resize: none;font-family: customSheetFont, "Palatino Linotype", serif;font-size: 0.75rem;' rows="4" >{{section.value}}</textarea>
-</div>
-{{/each}}
+  {{/each}}
+  {{> "systems/CoC7/templates/actors/parts/actor-mythos-enounters.hbs"}}
 </div>

--- a/templates/actors/parts/actor-keeper-mythos-enounters.hbs
+++ b/templates/actors/parts/actor-keeper-mythos-enounters.hbs
@@ -1,0 +1,43 @@
+<div class="flexcol bio-section" style="flex: 0 0 50%;">
+  <div class="flexrow" style="flex: initial;">
+    <label style="height: 1rem;margin: 0;border: 0;font-family: customSheetFont, 'Palatino Linotype', serif;font-size: .75rem;flex: 1;">{{localize 'CoC7.SanityLossEncounters'}}</label>
+    <div class="item-controls" style="height: fit-content;font-size: 10px;flex: 0 0 16px;">
+      <a class="sanity-loss-type-add" title="{{localize 'CoC7.AddSanityLossEncounter'}}" data-type="encounter"><i class="fas fa-plus-square"></i></a>
+    </div>
+  </div>
+  <div class="bio-section-value" style="min-height: 80px;">
+    {{#each data.sanityLossEvents as |sanityLossEvent mythosOffset|}}
+      {{#unless sanityLossEvent.immunity}}
+        <div class="flexrow" data-offset="{{mythosOffset}}">
+          <div class="bio-section-type">{{sanityLossEvent.type}}</div>
+          <div class="bio-section-values">
+            <input class="mythosEncountersTotalLoss" type="text" value="{{sanityLossEvent.totalLoss}}" data-dtype="Number">
+          </div>
+          <div class="item-controls">
+            <a class="item-control sanity-loss-type-delete" title="{{localize 'CoC7.DeleteSanityLossEncounter'}}"><i class="fas fa-trash"></i></a>
+          </div>
+        </div>
+      {{/unless}}
+    {{/each}}
+  </div>
+</div>
+<div class="flexcol bio-section" style="flex: 0 0 50%;">
+  <div class="flexrow" style="flex: initial;">
+    <label style="height: 1rem;margin: 0;border: 0;font-family: customSheetFont, 'Palatino Linotype', serif;font-size: .75rem;flex: 1;">{{localize 'CoC7.SanityLossImmunities'}}</label>
+    <div class="item-controls" style="height: fit-content;font-size: 10px;flex: 0 0 16px;">
+      <a class="sanity-loss-type-add" title="{{localize 'CoC7.AddSanityLossImmunity'}}" data-type="immunity"><i class="fas fa-plus-square"></i></a>
+    </div>
+  </div>
+  <div class="bio-section-value" style="min-height: 80px;">
+    {{#each data.sanityLossEvents as |sanityLossEvent mythosOffset|}}
+      {{#if sanityLossEvent.immunity}}
+        <div class="flexrow" data-offset="{{mythosOffset}}">
+          <div class="bio-section-type">{{sanityLossEvent.type}}</div>
+          <div class="item-controls">
+            <a class="item-control sanity-loss-type-delete" title="{{localize 'CoC7.DeleteSanityLossImmunity'}}"><i class="fas fa-trash"></i></a>
+          </div>
+        </div>
+      {{/if}}
+    {{/each}}
+  </div>
+</div>

--- a/templates/actors/parts/actor-mythos-enounters.hbs
+++ b/templates/actors/parts/actor-mythos-enounters.hbs
@@ -1,0 +1,25 @@
+{{#if data.sanityLossEvents}}
+  <div class="flexcol bio-section" style="flex: 0 0 50%;">
+    <div class="flexrow" style="flex: initial;">
+      <label style="height: 1rem;margin: 0;border: 0;font-family: customSheetFont, 'Palatino Linotype', serif;font-size: .75rem;">{{localize 'CoC7.BackgroundEncounters'}}</label>
+    </div>
+    <div class="bio-section-value" style="min-height: 80px;">
+      {{#each data.sanityLossEvents as |sanityLossEvent mythosOffset|}}
+        <div class="flexrow">
+          <div>{{sanityLossEvent.type}}</div>
+          <div class="bio-section-values">
+            {{#if sanityLossEvent.immunity}}
+              <i class="fas fa-shield-alt" title="{{localize 'CoC7.SanityLossImmunity'}}"></i>
+            {{else}}
+              {{sanityLossEvent.totalLoss}}
+            {{/if}}
+          </div>
+        </div>
+      {{else}}
+        <div class="flexrow">
+          -
+        </div>
+      {{/each}}
+    </div>
+  </div>
+{{/if}}

--- a/templates/actors/parts/development-controls.html
+++ b/templates/actors/parts/development-controls.html
@@ -62,7 +62,7 @@
       {{/if}}
 
       {{#unless allowDevelopment}}
-        <div class="header-section  {{#if hasSkillFlaggedForExp}}flagged4dev{{/if}}" title="{{localize 'CoC7.SkillTotalExperience'}}">
+        <div class="header-section  {{#if hasDevelopmentPhase}}flagged4dev{{/if}}" title="{{localize 'CoC7.SkillTotalExperience'}}">
           <label>{{localize 'CoC7.SkillTotalExperience'}}:</label>
           <span>{{totalExperience}}</span>
         </div>
@@ -74,7 +74,7 @@
   <div class="experience">
     {{#if allowDevelopment}}
       <div class="header-section" title="{{localize 'CoC7.SkillTotalExperience'}}">
-        {{#if hasSkillFlaggedForExp}}
+        {{#if hasDevelopmentPhase}}
           <div class="skill-developement button" title="{{localize 'CoC7.DevelopemmentPhase'}}">{{localize 'CoC7.DevelopemmentPhase'}}</div>
         {{/if}}
         {{#if developmentRollForLuck}}

--- a/templates/apps/link-creation.html
+++ b/templates/apps/link-creation.html
@@ -66,6 +66,10 @@
                 <label>{{ localize 'CoC7.MaxSanloss' }} :</label>
                 <input type="text" name="sanMax" value="{{data.sanMax}}"/>
             </div>
+            <div class="form-group">
+                <label>{{ localize 'CoC7.SanityLossTypeReason' }} :</label>
+                <input type="text" name="sanReason" value="{{data.sanReason}}"/>
+            </div>
         {{/if}}
 
         {{#if fromGame}}

--- a/templates/apps/sanity-loss-type.hbs
+++ b/templates/apps/sanity-loss-type.hbs
@@ -1,0 +1,34 @@
+<form>
+  <div class="form-group" style="margin: 0 0 10px;">
+    {{ localize 'CoC7.SanityLossTypeDialogBody' }}
+  </div>
+  <div class="form-group">
+    <label>{{ localize 'CoC7.AddSanityLossEncounter' }}</label>
+    <select class="field_type">
+      {{#select object.type}}
+        <option value="encounter">{{ localize 'CoC7.SanityLossEncounter' }}</option>
+        <option value="immunity">{{ localize 'CoC7.SanityLossImmunity' }}</option>
+      {{/select}}
+    </select>
+  </div>
+  <div class="form-group">
+    <label>{{ localize 'CoC7.SanityLossTypeReason' }}</label>
+    <input type="text" class="field_name" value="{{object.name}}" />
+  </div>
+  {{#unless isImmunity}}
+    <div class="form-group">
+      <label>{{ localize 'CoC7.SanityLossTypeValue' }}</label>
+      <input type="text" class="field_value" value="{{object.value}}" data-dtype="Number">
+    </div>
+  {{/unless}}
+  <div class="flexrow" style="margin: 10px 0 0;">
+    <button class="dialog-button add" type="button" data-button="add">
+      <i class="fas fa-check"></i>
+      {{ localize 'Activate' }}
+    </button>
+    <button class="dialog-button close" type="button" data-button="close">
+      <i class="fas fa-ban"></i>
+      {{ localize 'Cancel' }}
+    </button>
+  </div>
+</form>

--- a/templates/chat/cards/san-check.html
+++ b/templates/chat/cards/san-check.html
@@ -3,14 +3,16 @@
     <header class="card-header">
       <div class="left-portrait">
         {{#if displayActorOnCard}}
-        <img class="portrait open-actor" data-actor-key="{{actor.actorKey}}" src="{{actor.img}}" title="{{actor.name}}"/>
+          <img class="portrait open-actor" data-actor-key="{{actor.actorKey}}" src="{{actor.img}}" title="{{actor.name}}"/>
         {{/if}}
       </div>
       <div class="card-title">
         {{ localize 'CoC7.SanityCheck' }}
       </div>
       <div class="right-portrait">
-        <img class="portrait open-actor" data-actor-key="{{creature.actorKey}}"  src="{{creature.img}}" title="{{creature.name}}"/>
+        {{#if sanLossSource}}
+          <img class="portrait open-actor" data-actor-key="{{sanLossSource.actorKey}}"  src="{{sanLossSource.img}}" title="{{sanLossSource.name}}"/>
+        {{/if}}
       </div>
     </header>
   {{/unless}}
@@ -24,15 +26,8 @@
   <div class="status-list">
     <div class="status">{{localize 'CoC7.DailyLoss'}}: {{actor.dailySanLoss}}</div>
     <div class="status">{{localize 'CoC7.Sanity'}}: {{actor.san}}/{{actor.sanMax}}</div>
-    {{#if creature}}
-      {{#if creatureEncountered}}<div class="status">Creature encountered</div>{{/if}}
-      {{#if creatureSpecieEncountered}}<div class="status">Specie encountered</div>{{/if}}
-      <div class="status">Already lost: {{sanLostToThisCreature}}</div>
-      <div class="status">Creature max loss: {{creature.sanLossMax}}</div>
-      <div class="status">Max loss to this creature: {{maxSanLossToThisCreature}}</div>
-    {{else}}
-      <div class="status">Max loss: {{maxSanLoss}}</div>
-    {{/if}}
+    {{#if sanLossReasonEncountered}}<div class="status">Already encountered "{{sanData.sanReason}}" lost {{sanLostToReason}}/{{maxSanLoss}}</div>{{/if}}
+    <div class="status">Max loss: {{maxPossibleSanLoss}}</div>
     {{#if state.sanRolled}}
       {{#if sanCheck.failed}}
         <div class="status">Check failed</div>
@@ -212,7 +207,7 @@
       <div class="status">{{ localize 'CoC7.BoutActive'}}</div>
     {{/if}}
 
-    {{#if creature}}
+    {{#if sanData.sanReason}}
       {{#if state.insanity}}
         {{#if sanLoss}}
           {{#unless state.cthulhuMythosAwarded}}
@@ -228,24 +223,22 @@
         {{/if}}
       {{/if}}
 
-      {{#if creatureEncountered}}<div class="status">Creature encountered</div>{{/if}}
-      {{#if creatureHasSpecie}}{{#if creatureSpecieEncountered}}<div class="status">Specie encountered</div>{{/if}}{{/if}}
-      <div class="status">{{ localize 'CoC7.AlreadyLost'}}: {{sanLostToThisCreature}}</div>
-      <div class="status">{{ localize 'CoC7.CreatureMaxLoss'}}: {{creature.sanLossMax}}</div>
-      <div class="status">{{ localize 'CoC7.MaxLossToCreature'}}: {{maxSanLossToThisCreature}}</div>
+      {{#if sanData.sanReason}}
+        {{#if sanLossReasonEncountered}}
+          <div class="status">Already encountered "{{sanData.sanReason}}"</div>
+          <div class="status">{{ localize 'CoC7.AlreadyLost'}}: {{sanLostToReason}}</div>
+          <div class="status">{{ localize 'CoC7.CreatureMaxLoss'}}: {{maxSanLoss}}</div>
+        {{/if}}
+      {{/if}}
+      <div class="status">Max loss: {{maxPossibleSanLoss}}</div>
 
       {{#unless state.keepCreatureSanData}}
         <div class='card-buttons'>
 
-        {{#if creatureEncountered}}
+        {{#if sanLossReasonEncountered}}
           <button data-action="reset-creature-san-data">{{ localize 'CoC7.ResetCreatureSan' }}</button>
-        {{/if}}
-        {{#if creatureHasSpecie}}
-          {{#if creatureSpecieEncountered}}
-            <button data-action="reset-specie-san-data">{{ localize 'CoC7.ResetSpecieSan' }}</button>
-          {{/if}}
-        {{/if}}
           <button data-action="advance-state" data-state="keepCreatureSanData">{{ localize 'CoC7.KeepData' }}</button>
+        {{/if}}
         </div>
       {{/unless}}
 


### PR DESCRIPTION
## Description.
Show sanity loss encounters on character sheet with total loss to each
Add sanity loss type to links e.g. @coc7.sanloss[sanMax:1D8,sanMin:0,sanReason:Zombie]
GM character sheet toggle for Mythos Hardened (WIP) and Initial Insanity Mythos Awarded
GM character sheet add/remove sanity loss encounters/immunities
Immunities are listed in the Investigator Handbook "Optional Rule: Experienced Investigators"
During investigator development phase reduce all encounter values by one resolves #934

## Screenshots.
Players can see the values on the background tab
![image](https://user-images.githubusercontent.com/43982555/161644584-52059102-6254-42c1-8097-fff86c2eaade.png)

Keepers can see and edit encounters, immunities, and toggle flags
![image](https://user-images.githubusercontent.com/43982555/161644710-15454500-2fee-4a4c-8028-a8e3b0b3169f.png)

Updated link creation
![image](https://user-images.githubusercontent.com/43982555/161645842-a5062d1b-aaf8-4710-8bba-4e02d0549710.png)

Update Development Phase messages, no skills ticked, skills ticked, no encounters above zero loss
![image](https://user-images.githubusercontent.com/43982555/161645982-740452e7-85a2-4aa1-8138-e7843eaccd07.png)

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to change).
