### PR TITLE
DSN fix dice faces that use images

### DIFF
--- a/module/apps/decader-die-other.js
+++ b/module/apps/decader-die-other.js
@@ -1,0 +1,7 @@
+import { CoC7DecaderDie } from './decader-die.js'
+
+export class CoC7DecaderDieOther extends CoC7DecaderDie {
+  static get DENOMINATION () {
+    return 'o'
+  }
+}

--- a/module/apps/decader-dsn-faces.js
+++ b/module/apps/decader-dsn-faces.js
@@ -1,0 +1,26 @@
+/* global game */
+export class CoC7DecaderDSNFaces {
+  construtor () {
+    this.selected = ''
+  }
+
+  setFaces () {
+    let selected = game.user.getFlag('dice-so-nice', 'appearance')?.global.system
+    if (selected !== this.selected) {
+      let data
+      let destination
+      let sourceDie = game.dice3d.DiceFactory.systems[selected]?.dice.find(d => d.type === 'd100')
+      if (typeof sourceDie === 'undefined') {
+        sourceDie = game.dice3d.DiceFactory.systems.standard.dice.find(d => d.type === 'd100')
+        selected = 'standard'
+      }
+      if (typeof sourceDie !== 'undefined') {
+        destination = game.dice3d.DiceFactory.systems.standard.dice.findIndex(d => d.type === 'dt')
+        data = Object.assign({}, sourceDie)
+        data.type = 'dt'
+        game.dice3d.DiceFactory.systems.standard.dice[destination] = Object.assign(sourceDie.constructor.prototype, data)
+      }
+      this.selected = selected
+    }
+  }
+}

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -115,18 +115,6 @@ Hooks.on('renderSettingsConfig', (app, html, options) => {
     )
 })
 
-Hooks.once('diceSoNiceReady', dice3d => {
-  dice3d.addDicePreset(
-    {
-      type: 'dt',
-      labels: ['10', '20', '30', '40', '50', '60', '70', '80', '90', '00'],
-      fontScale: 0.75,
-      system: 'standard'
-    },
-    'dt'
-  )
-})
-
 Hooks.once('init', async function () {
   game.CoC7 = {
     macros: {

--- a/module/dice.js
+++ b/module/dice.js
@@ -12,8 +12,9 @@ export class CoC7Dice {
     }
     const roll = await new Roll(
       '1dt' +
-        (
-          '+1dt' + (alternativeDice !== '' ? '[' + alternativeDice + ']' : '')
+        (alternativeDice !== ''
+          ? '+1do[' + alternativeDice + ']'
+          : '1dt'
         ).repeat(Math.abs(modif)) +
         '+1d10'
     ).roll({ async: true })

--- a/module/hooks/dice-so-nice-ready.js
+++ b/module/hooks/dice-so-nice-ready.js
@@ -1,0 +1,20 @@
+/* global game, Hooks */
+import { CoC7DecaderDSNFaces } from '../apps/decader-dsn-faces.js'
+
+export function listen () {
+  Hooks.once('diceSoNiceReady', dice3d => {
+    dice3d.addDicePreset({
+      type: 'dt',
+      labels: ['10', '20', '30', '40', '50', '60', '70', '80', '90', '00'],
+      fontScale: 0.75,
+      system: 'standard'
+    })
+    dice3d.addDicePreset({
+      type: 'do',
+      labels: ['10', '20', '30', '40', '50', '60', '70', '80', '90', '00'],
+      fontScale: 0.75,
+      system: 'standard'
+    })
+    game.CoC7DecaderDSNFaces = new CoC7DecaderDSNFaces()
+  })
+}

--- a/module/hooks/dice-so-nice-roll-start.js
+++ b/module/hooks/dice-so-nice-roll-start.js
@@ -1,0 +1,6 @@
+/* global game, Hooks */
+export function listen () {
+  Hooks.on('diceSoNiceRollStart', dice3d => {
+    game.CoC7DecaderDSNFaces.setFaces()
+  })
+}

--- a/module/hooks/index.js
+++ b/module/hooks/index.js
@@ -1,4 +1,6 @@
 import * as Init from './init.js'
+import * as DiceSoNiceReady from './dice-so-nice-ready.js'
+import * as DiceSoNiceRollStart from './dice-so-nice-roll-start.js'
 import * as Ready from './ready.js'
 import * as RenderActorSheet from './render-actor-sheet.js'
 import * as RenderChatMessage from './render-chat-message.js'
@@ -15,5 +17,7 @@ export const CoC7Hooks = {
     RenderDialog.listen()
     RenderItemSheet.listen()
     RenderPause.listen()
+    DiceSoNiceReady.listen()
+    DiceSoNiceRollStart.listen()
   }
 }

--- a/module/scripts/register-settings.js
+++ b/module/scripts/register-settings.js
@@ -1,5 +1,6 @@
 /* global CONFIG, game */
 import { CoC7DecaderDie } from '../apps/decader-die.js'
+import { CoC7DecaderDieOther } from '../apps/decader-die-other.js'
 import { CoC7GameRuleSettings } from './game-rules.js'
 
 export function registerSettings () {
@@ -467,4 +468,5 @@ export function registerSettings () {
   }
   CONFIG.debug.hooks = !!game.settings.get('CoC7', 'debugmode')
   CONFIG.Dice.terms.t = CoC7DecaderDie
+  CONFIG.Dice.terms.o = CoC7DecaderDieOther
 }

--- a/module/updater.js
+++ b/module/updater.js
@@ -3,9 +3,10 @@ import { CoC7Item } from './items/item.js'
 
 export class Updater {
   static async checkForUpdate () {
-    this.systemUpdateVersion = String(
-      game.settings.get('CoC7', 'systemUpdateVersion')
-    )
+    this.systemUpdateVersion = game.settings.get('CoC7', 'systemUpdateVersion')
+      ? String(game.settings.get('CoC7', 'systemUpdateVersion'))
+      : '0'
+
     const runMigrate = isNewerVersion(
       game.system.data.version,
       this.systemUpdateVersion


### PR DESCRIPTION
## Description.
Copy DSN selected faces for d100 setup over dt decader when rolling for the first time
Add second decader type to allow bonus/penalty dice to appear different when using image faces

## Motivation and Context.
If using Dice So Nice with image faces instead of text a it looks like a d10 is rolled instead of the decader

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
