### PR TITLE
Fixed damage card not showing properly

### DIFF
--- a/styles/chat/damage.less
+++ b/styles/chat/damage.less
@@ -5,7 +5,7 @@
   }
   .options {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     flex-wrap: nowrap;
     align-items: center;
   }


### PR DESCRIPTION
Fixed damage card critical or empaling result not showing properly;

## Description.

Damage card critical or empaling result doesn't show properly, instead its text is vertical and superposed with other chat messages.

## Motivation and Context.

Fix the bug.

## Screenshots.

Before the fix:
![image](https://user-images.githubusercontent.com/29607988/166385943-189a3de9-7981-4301-828f-c5f47be6fad5.png)

After the fix:
![image](https://user-images.githubusercontent.com/29607988/166386479-ff7d659b-fd22-4c0a-b235-f42895fe3718.png)

## Types of Changes.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
