### PR TITLE
Fix sanity loss on books and opposedCard/combinedCard message selection

### DIFF
--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -1526,11 +1526,14 @@ export class CoCActor extends Actor {
   }
 
   getReasonSanLoss (sanReason) {
-    return (
-      this.data.data.sanityLossEvents.filter(
-        r => r.type.toLocaleLowerCase() === sanReason.toLocaleLowerCase()
-      )[0] ?? { type: '', totalLoss: 0, immunity: false }
-    )
+    if (typeof sanReason === 'string') {
+      return (
+        this.data.data.sanityLossEvents.filter(
+          r => r.type.toLocaleLowerCase() === sanReason.toLocaleLowerCase()
+        )[0] ?? { type: '', totalLoss: 0, immunity: false }
+      )
+    }
+    return { type: '', totalLoss: 0, immunity: false }
   }
 
   sanLostToReason (sanReason) {
@@ -1550,7 +1553,7 @@ export class CoCActor extends Actor {
   }
 
   setReasonSanLoss (sanReason, sanLoss) {
-    if (sanReason !== '') {
+    if (typeof sanReason === 'string' && sanReason !== '') {
       const sanityLossEvents = duplicate(this.data.data.sanityLossEvents)
       const index = sanityLossEvents.findIndex(
         r => r.type.toLocaleLowerCase() === sanReason.toLocaleLowerCase()

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -1665,6 +1665,8 @@ export class CoC7ActorSheet extends ActorSheet {
 
       data.roll = roll.JSONRollData
 
+      data._rollMode = game.settings.get('core', 'rollMode')
+
       OpposedCheckCard.dispatch(data)
     } else {
       const data = {
@@ -1708,6 +1710,8 @@ export class CoC7ActorSheet extends ActorSheet {
       if (roll.attrib === 'db') return
 
       data.roll = roll.JSONRollData
+
+      data._rollMode = game.settings.get('core', 'rollMode')
 
       CombinedCheckCard.dispatch(data)
     }

--- a/module/chat/cards/roll-card.js
+++ b/module/chat/cards/roll-card.js
@@ -71,13 +71,13 @@ export class RollCard {
   static async dispatch (data) {
     if (game.user.isGM) {
       let messages = ui.chat.collection.filter(message => {
-        const notDiffernetInitiator = message.getFlag('CoC7', 'initiator')
         if (
           this.defaultConfig.type === message.getFlag('CoC7', 'type') &&
-          message.getFlag('CoC7', 'state') !== 'resolved' &&
-          (typeof notDiffernetInitiator === 'undefined' ||
-            notDiffernetInitiator === data.roll.initiator)
+          message.getFlag('CoC7', 'state') !== 'resolved'
         ) {
+          if (['combinedCard'].includes(this.defaultConfig.type)) {
+            return message.getFlag('CoC7', 'initiator') === data.roll.initiator
+          }
           return true
         }
         return false
@@ -97,6 +97,9 @@ export class RollCard {
       let card
       if (!messages.length) card = new this()
       else card = await this.fromMessage(messages[0])
+      if (typeof data._rollMode !== 'undefined') {
+        card._rollMode = data._rollMode
+      }
       await card.process(data)
     } else game.socket.emit('system.CoC7', data)
   }

--- a/module/chat/cards/san-check.js
+++ b/module/chat/cards/san-check.js
@@ -105,7 +105,7 @@ export class SanCheckCard extends ChatCardActor {
   }
 
   get maxSanLoss () {
-    return new Roll(this.sanData.sanMax).evaluate({
+    return new Roll(this.sanData.sanMax.toString()).evaluate({
       maximize: true
     }).total
   }


### PR DESCRIPTION
## Description.
Fix sanity loss on books - resolves #1082
Fix opposedCard/combinedCard message selection - resolves #1081

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
