### PR TITLE
First version of The Dhole's House JSON importer

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -734,6 +734,8 @@
   "CoC7.ActorImporterSummary": "Import an NPC or Creature from description and stats. Just paste the corresponding plain text",
   "CoC7.PasteTheDataBelow": "Paste the raw text data below",
   "CoC7.TextFieldInvalidCharacters": "There are invalid characters in the text, please fix them or they will be removed",
+  "CoC7.TextFieldInvalidJSON": "Unable to parse the JSON, please try again",
+  "CoC7.ActorImporterUploadError": "Import stopped, unable to write image",
   "CoC7.SelectActorType": "Select actor type",
   "CoC7.NonPlayingCharacter": "Non Playing Character (NPC)",
   "CoC7.Creature": "Creature",
@@ -810,6 +812,7 @@
 
   "CoC7.UnableToInteractWithChatCard": "You are not able to interact with this message, if you need to make a change please ask your Keeper to select the options for you",
   "CoC7.UnableToCopyToClipboard": "Unable to copy to clipboard, this is likely due to your browser security settings.",
+  "CoC7.UnableToUploadDholeImage": "You do not have permission to upload images, if you import the default avatar will be used.",
 
   "CoC7.MessageTitleSelectUserToGiveTo": "Give item to another character",
   "CoC7.MessageSelectUserToGiveTo": "Which character would you like to give this item to?",

--- a/lang/en.json
+++ b/lang/en.json
@@ -757,6 +757,9 @@
   "CoC7.ImportActorItemsItemWorldModuleSystem": "Items / World / Modules / System",
   "CoC7.ImportActorItemsWorldModuleItemSystem": "World / Modules / Items / System",
 
+  "CoC7.DholeHouseActorImporter": "Dholehouse Actor Importer",
+  "CoC7.DholeHouseActorImporterSummary": "Paste the JSON data copied from the DholeHouse below",
+
   "CoC7.HowToTranslateTitle": "How to translate?",
   "CoC7.HowToTranslateWarning": "Do not install any modules you do not trust.",
   "CoC7.HowToTranslateInstallBabele": "Install/Update Babele module from Foundry's module manager.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -753,6 +753,7 @@
   "CoC7.ImportedUnnamedCharacter": "Imported unnamed character",
   "CoC7.CreatedImportedCharactersFolder": "Created 'Imported Characters' folder",
   "CoC7.ImportedCharactersFolder": "Imported characters",
+  "CoC7.PickDirectory": "Pick Directory",
   "CoC7.ImportSkillItemLocations": "Look for skills/spells/weapons in",
   "CoC7.ImportActorItemsNone": "None",
   "CoC7.ImportActorItemsItem": "Items",
@@ -806,6 +807,8 @@
   "CoC7.Settings.PulpRules.FasterRecovery.Hint": "Natural healing is increased to two hit points per day",
   "CoC7.Settings.PulpRules.IgnoreMajorWounds.Name": "Ignore Major Wounds",
   "CoC7.Settings.PulpRules.IgnoreMajorWounds.Hint": "",
+  "CoC7.Settings.DholeUpload.Directory.Name": "The Dhole's House image upload directory",
+  "CoC7.Settings.DholeUpload.Directory.Hint": "Upload path for The Dhole's House avatars, relative to the Foundry/Data directory.",
 
   "CoC7.Maximize": "Maximize",
   "CoC7.Summarize": "Summarize",

--- a/lang/en.json
+++ b/lang/en.json
@@ -757,8 +757,9 @@
   "CoC7.ImportActorItemsItemWorldModuleSystem": "Items / World / Modules / System",
   "CoC7.ImportActorItemsWorldModuleItemSystem": "World / Modules / Items / System",
 
-  "CoC7.DholeHouseActorImporter": "Dholehouse Actor Importer",
-  "CoC7.DholeHouseActorImporterSummary": "Paste the JSON data copied from the DholeHouse below",
+  "CoC7.DholeHouseActorImporter": "The Dhole's House Actor Importer JSON",
+  "CoC7.DholeHouseActorImporterSummary": "Paste the JSON data copied from The Dhole's House Actor below",
+  "CoC7.DholeHouseActorImporterSource": "Imported from The Dhole's House Actor",
 
   "CoC7.HowToTranslateTitle": "How to translate?",
   "CoC7.HowToTranslateWarning": "Do not install any modules you do not trust.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -759,10 +759,14 @@
   "CoC7.ImportActorItemsItem": "Items",
   "CoC7.ImportActorItemsItemWorldModuleSystem": "Items / World / Modules / System",
   "CoC7.ImportActorItemsWorldModuleItemSystem": "World / Modules / Items / System",
+  "CoC7.ActorImported": "New {actorType} imported: {actorName}",
 
   "CoC7.DholeHouseActorImporter": "The Dhole's House Actor Importer JSON",
-  "CoC7.DholeHouseActorImporterSummary": "Paste the JSON data copied from The Dhole's House Actor below",
+  "CoC7.DholeHouseActorImporterSummary": "Export your DholeHouse's character as JSON and upload it here.",
+  "CoC7.DholeHouseImportingName": "About to import: ",
+  "CoC7.DholeHousePickYourJSONFile": "Pick the JSON file exported from The Dhole's House",
   "CoC7.DholeHouseActorImporterSource": "Imported from The Dhole's House Actor",
+  "CoC7.DholeHouseInvalidActor": "The selected JSON doesn't seem to be a valid Dhole's House exported character",
 
   "CoC7.HowToTranslateTitle": "How to translate?",
   "CoC7.HowToTranslateWarning": "Do not install any modules you do not trust.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -736,6 +736,7 @@
   "CoC7.TextFieldInvalidCharacters": "There are invalid characters in the text, please fix them or they will be removed",
   "CoC7.TextFieldInvalidJSON": "Unable to parse the JSON, please try again",
   "CoC7.ActorImporterUploadError": "Import stopped, unable to write image",
+  "CoC7.FileUploadError": "Unable to write image, file upload error",
   "CoC7.SelectActorType": "Select actor type",
   "CoC7.NonPlayingCharacter": "Non Playing Character (NPC)",
   "CoC7.Creature": "Creature",

--- a/module/actor-directory.js
+++ b/module/actor-directory.js
@@ -12,9 +12,7 @@ export class CoC7ActorDirectory extends ActorDirectory {
           '</a>'
       )
     html.find('.actor-import').click(() => {
-      CoC7ActorImporterDialog.create({
-        title: game.i18n.localize('CoC7.ActorImporter')
-      })
+      CoC7ActorImporterDialog.create()
     })
   }
 }

--- a/module/apps/actor-importer-dialog.js
+++ b/module/apps/actor-importer-dialog.js
@@ -1,4 +1,4 @@
-/* global $, CONFIG, FormApplication, game, Hooks, mergeObject, ui */
+/* global $, CONFIG, FormApplication, game, Hooks, mergeObject, ui, FileReader */
 
 import { CoC7ActorImporter } from './actor-importer.js'
 import { CoC7DholeHouseActorImporter } from './dholehouse_importer.js'

--- a/module/apps/actor-importer-dialog.js
+++ b/module/apps/actor-importer-dialog.js
@@ -1,6 +1,7 @@
 /* global $, CONFIG, Dialog, game, Hooks, renderTemplate, ui */
 
 import { CoC7ActorImporter } from './actor-importer.js'
+import { CoC7DholeHouseActorImporter } from './dholehouse_importer.js'
 import { CoC7ActorImporterRegExp } from './actor-importer-regexp.js'
 import { CoC7Utilities } from '../utilities.js'
 
@@ -89,7 +90,7 @@ export class CoC7ActorImporterDialog extends Dialog {
     // console.debug('updated:', updated)
   }
 
-  submit (button) {
+  async submit (button) {
     if (button.cssClass === 'getExampleNow') {
       const content = CoC7ActorImporterRegExp.getExampleText(
         $('#coc-entity-lang :selected').val()
@@ -98,6 +99,9 @@ export class CoC7ActorImporterDialog extends Dialog {
         return ui.notifications.info(game.i18n.localize('CoC7.Copied'))
       })
       return
+    }
+    if (button.cssClass === 'dholehouseImporter') {
+      await CoC7DholeHouseActorImporter.pasteDholeHouseJSONDialog()
     }
     if (
       $('#coc-pasted-character-data').val().trim() !== '' ||
@@ -129,6 +133,10 @@ export class CoC7ActorImporterDialog extends Dialog {
               icon: '<i class="fas fa-file-import"></i>',
               label: game.i18n.localize('CoC7.Import'),
               callback: CoC7ActorImporterDialog.importActor
+            },
+            dholehouseImporter: {
+              icon: '<i class="fas fa-file-import"></i>',
+              label: game.i18n.localize('CoC7.DholeHouseActorImporter')
             },
             getExampleNow: {
               icon: '<i class="fas fa-info-circle"></i>',

--- a/module/apps/actor-importer-dialog.js
+++ b/module/apps/actor-importer-dialog.js
@@ -180,8 +180,8 @@ export class CoC7ActorImporterDialog extends FormApplication {
   //  * create it's the default web to crate the CoC7ActorImporterDialog
   //  */
   static async create (options = {}) {
-    options.importType = options.importType ?? 'dholehouse'
-    options.language = options.language ?? null
+    options.importType = options.importType ?? 'npc'
+    options.language = options.language ?? CoC7ActorImporterRegExp.checkLanguage(null);
     options.convert6E = options.language ?? 'coc-guess'
     options.source = options.source ?? 'iwms'
     options.characterData = options.characterData ?? ''

--- a/module/apps/actor-importer.js
+++ b/module/apps/actor-importer.js
@@ -1,4 +1,4 @@
-/* global Actor, CONFIG, duplicate, Folder, game, ui */
+/* global Actor, CONFIG, duplicate, game, ui */
 import { CoC7ActorImporterRegExp } from './actor-importer-regexp.js'
 import { CoCActor } from '../actors/actor.js'
 import { CoC7Item } from '../items/item.js'
@@ -730,7 +730,6 @@ export class CoC7ActorImporter {
     return npc
   }
 
-
   /**
    * actorData, convert parseCharacter data into Actor data
    * @param {Object} pc object with the data extracted from the character as returned from `parseCharacter`
@@ -1078,7 +1077,7 @@ export class CoC7ActorImporter {
    * @param {Object} the entity object as obtained from `parseCharacter`
    * @return the same object but with updated characteristics for 7 edition
    */
-  async convert7E(creature) {
+  async convert7E (creature) {
     if (CONFIG.debug.CoC7Importer) {
       console.debug('Converting npc', creature)
     }

--- a/module/apps/actor-importer.js
+++ b/module/apps/actor-importer.js
@@ -2,6 +2,7 @@
 import { CoC7ActorImporterRegExp } from './actor-importer-regexp.js'
 import { CoCActor } from '../actors/actor.js'
 import { CoC7Item } from '../items/item.js'
+import { CoC7Utilities } from '../utilities.js'
 
 /**
  * CoC7ActorImporter helper class to import an Actor from the raw text description.
@@ -634,7 +635,7 @@ export class CoC7ActorImporter {
    */
   async createEntity (characterData, entityType) {
     const importedCharactersFolder =
-      await this.createImportCharactersFolderIfNotExists()
+      await CoC7Utilities.createImportCharactersFolderIfNotExists()
     if (entityType !== 'npc') {
       entityType = 'creature'
     }
@@ -729,34 +730,6 @@ export class CoC7ActorImporter {
     return npc
   }
 
-  /**
-   * Creates a folder on the actors tab called "Imported Characters" if the folder doesn't exist.
-   * @returns {Folder} the importedCharactersFolder
-   */
-  async createImportCharactersFolderIfNotExists () {
-    let folderName = game.i18n.localize('CoC7.ImportedCharactersFolder')
-    if (folderName === 'CoC7.ImportedCharactersFolder') {
-      folderName = 'Imported characters'
-    }
-    let importedCharactersFolder = game.folders.find(
-      entry => entry.data.name === folderName && entry.data.type === 'Actor'
-    )
-    if (
-      importedCharactersFolder === null ||
-      typeof importedCharactersFolder === 'undefined'
-    ) {
-      // Create the folder
-      importedCharactersFolder = await Folder.create({
-        name: folderName,
-        type: 'Actor',
-        parent: null
-      })
-      ui.notifications.info(
-        game.i18n.localize('CoC7.CreatedImportedCharactersFolder')
-      )
-    }
-    return importedCharactersFolder
-  }
 
   /**
    * actorData, convert parseCharacter data into Actor data
@@ -838,7 +811,7 @@ export class CoC7ActorImporter {
     name = name.toLowerCase()
     let existing = null
     for (let o = 0, oM = this.itemLocations.length; o < oM; o++) {
-      switch (this.itemLocations.substr(o, 1)) {
+      switch (this.itemLocations.substring(o, 1)) {
         case 'i':
           existing = game.items.find(
             item =>
@@ -1105,7 +1078,7 @@ export class CoC7ActorImporter {
    * @param {Object} the entity object as obtained from `parseCharacter`
    * @return the same object but with updated characteristics for 7 edition
    */
-  async convert7E (creature) {
+  async convert7E(creature) {
     if (CONFIG.debug.CoC7Importer) {
       console.debug('Converting npc', creature)
     }

--- a/module/apps/dholehouse_importer.js
+++ b/module/apps/dholehouse_importer.js
@@ -1,4 +1,4 @@
-/* global Actor, game, ui */
+/* global Actor, game, ui, fetch */
 import { CoC7DirectoryPicker } from '../scripts/coc7-directory-picker.js'
 import { CoC7Item } from '../items/item.js'
 import { CoC7Utilities } from '../utilities.js'
@@ -216,7 +216,7 @@ export class CoC7DholeHouseActorImporter {
     const characterSkill = skills.find(i => {
       return (
         i.data.data?.skillName === checkName ||
-        i.data.data?.skillName.indexOf(checkName) > -1
+        i.data.data?.skillName?.indexOf(checkName) > -1
       )
     })
     return characterSkill

--- a/module/apps/dholehouse_importer.js
+++ b/module/apps/dholehouse_importer.js
@@ -1,4 +1,4 @@
-import { CoCActor } from '../actors/actor.js'
+/* global Actor, game */
 import { CoC7Item } from '../items/item.js'
 import { CoC7Utilities } from '../utilities.js'
 
@@ -6,322 +6,336 @@ import { CoC7Utilities } from '../utilities.js'
  * CoC7ActorImporter helper class to import an Actor from the raw text description.
  */
 export class CoC7DholeHouseActorImporter {
-/**
- * Compose the Backstory from the different blocks.
- * @param {} backstoryJSON DholeHouse backstory JSON
- * @returns HTML with the formatted backstory
- */
-  static getBackstory(backstoryJSON) {
-  let backstory = `<h2>Backstory</h2>\n`
-  if (backstoryJSON.description !== null) {
-    backstory += `<h3>Description</h3>
+  /**
+   * Compose the Backstory from the different blocks.
+   * @param {} backstoryJSON DholeHouse backstory JSON
+   * @returns HTML with the formatted backstory
+   */
+  static getBackstory (backstoryJSON) {
+    let backstory = '<h2>Backstory</h2>\n'
+    if (backstoryJSON.description !== null) {
+      backstory += `<h3>Description</h3>
       <div class="description">
       ${backstoryJSON.description}
       </div>\n`
-  }
-  if (backstoryJSON.traits !== null) {
-    backstory += `<h3>Traits</h3>
+    }
+    if (backstoryJSON.traits !== null) {
+      backstory += `<h3>Traits</h3>
       <div class="traits">
       ${backstoryJSON.traits}
       <div>\n`
-  }
-  if (backstoryJSON.ideology !== null) {
-    backstory += `<h3>Ideology</h3>
+    }
+    if (backstoryJSON.ideology !== null) {
+      backstory += `<h3>Ideology</h3>
       <div class="ideology">
       ${backstoryJSON.ideology}
       <div>\n`
-  }
-  if (backstoryJSON.injurues !== null) {
-    backstory += `<h3>Injuries</h3>
+    }
+    if (backstoryJSON.injurues !== null) {
+      backstory += `<h3>Injuries</h3>
       <div class="injuries">
       ${backstoryJSON.injurues}
       <div>\n`
-  }
-  if (backstoryJSON.people !== null) {
-    backstory += `<h3>People</h3>
+    }
+    if (backstoryJSON.people !== null) {
+      backstory += `<h3>People</h3>
       <div class="people">
       ${backstoryJSON.people}
       <div>\n`
-  }
-  if (backstoryJSON.phobias !== null) {
-    backstory += `<h3>Phobias</h3>
+    }
+    if (backstoryJSON.phobias !== null) {
+      backstory += `<h3>Phobias</h3>
       <div class="phobias">
       ${backstoryJSON.phobias}
       <div>\n`
-  }
-  if (backstoryJSON.locations !== null) {
-    backstory += `<h3>Locations</h3>
+    }
+    if (backstoryJSON.locations !== null) {
+      backstory += `<h3>Locations</h3>
       <div class="locations">
       ${backstoryJSON.locations}
       <div>\n`
-  }
-  if (backstoryJSON.tomes !== null) {
-    backstory += `<h3>Tomes</h3>
+    }
+    if (backstoryJSON.tomes !== null) {
+      backstory += `<h3>Tomes</h3>
       <div class="tomes">
       ${backstoryJSON.tomes}
       <div>\n`
-  }
-  if (backstoryJSON.possessions !== null) {
-    backstory += `<h3>Possessions</h3>
+    }
+    if (backstoryJSON.possessions !== null) {
+      backstory += `<h3>Possessions</h3>
       <div class="possessions">
       ${backstoryJSON.possessions}
       <div>\n`
-  }
-  if (backstoryJSON.encounters !== null) {
-    backstory += `<h3>Encounters</h3>
+    }
+    if (backstoryJSON.encounters !== null) {
+      backstory += `<h3>Encounters</h3>
       <div class="encounters">
       ${backstoryJSON.encounters}
       <div>\n`
+    }
+    return backstory
   }
-  return backstory;
-}
-/**
- *
- * @param {JSON} dholeHouseData DholeHouseJSON
- * @returns
- */
-static convertDholeHouseCharacterData(dholeHouseData) {
-  console.log(dholeHouseData)
-  dholeHouseData = dholeHouseData.Investigator
-  const cData = {
-    "name": dholeHouseData.PersonalDetails.Name,
-    "actor": {
-      "characteristics": {
-        "str": { "value": dholeHouseData.Characteristics.STR},
-        "con": { "value": dholeHouseData.Characteristics.CON},
-        "siz": { "value": dholeHouseData.Characteristics.SIZ},
-        "dex": { "value": dholeHouseData.Characteristics.DEX},
-        "app": { "value": dholeHouseData.Characteristics.APP},
-        "int": { "value": dholeHouseData.Characteristics.INT},
-        "pow": { "value": dholeHouseData.Characteristics.POW},
-        "edu": { "value": dholeHouseData.Characteristics.EDU},
-      },
-      "attribs": {
-        "san": {
-          "value": dholeHouseData.Characteristics.Sanity,
-          "max": dholeHouseData.Characteristics.SanityMax
-        },
-        "hp": { "value": dholeHouseData.Characteristics.HitPts,
-                "max": dholeHouseData.Characteristics.HitPtsMax },
-        "mp": { "value": dholeHouseData.Characteristics.MagicPts,
-                "max": dholeHouseData.Characteristics.MagicPtsMax },
-        "lck": { "value": dholeHouseData.Characteristics.Luck,
-                "max": dholeHouseData.Characteristics.LuckMax},
-        "mov": { "value": dholeHouseData.Characteristics.Move,
-                "max": dholeHouseData.Characteristics.Move},
-        "db": { "value": dholeHouseData.Characteristics.DamageBonus },
-        "build": { "value": dholeHouseData.Characteristics.Build}
-      },
-      "infos": {
-        "occupation": dholeHouseData.PersonalDetails.Occupation,
-        "age": dholeHouseData.PersonalDetails.Age,
-        "sex": dholeHouseData.PersonalDetails.Gender,
-        "residence": dholeHouseData.PersonalDetails.Residence,
-        "birthplace": dholeHouseData.PersonalDetails.Birthplace,
-      },
-      "backstory": CoC7DholeHouseActorImporter.getBackstory(dholeHouseData.Backstory),
-      "description": {
-        "keeper": `Imported from  Dholehouse`
-      }
-    },
-    "skills": CoC7DholeHouseActorImporter.extractSkills(dholeHouseData.Skills.Skill ?? []),
-    "possesions":CoC7DholeHouseActorImporter.extractPossessions(dholeHouseData.Possessions?.item ?? [])
-  }
-  return cData;
-}
 
-static extractSkills(dholeHousekills) {
-  const skills = []
-  for (const skill of dholeHousekills) {
-    let name = skill.name
-    let specialization = ""
-    let isSpecial = false
-    let isOccupational = false
-    const value = skill.value
-    if (skill.subskill === "None" && skill.value === "1" && skill.half === "0"
-    && skill.fifth === "0") {
-      continue;
-    }
-    if (skill.subskill && skill.subskill !== "None") {
-      name = skill.subskill;
-      specialization = skill.name
-      isSpecial = true;
-    }
-    if (skill.occupation) {
-      isOccupational = true;
-    }
-    console.log("skill name: ", name, " skill value: ", value , " specialization: ", specialization)
-    skills.push({
-      "type": "skill",
-      "name": name,
-      "data": {
-        "skillName": name,
-        "specialization": specialization,
-        "properties": {
-          "special": isSpecial,
-          "fighting": specialization === "Fighting",
-          "firearm": specialization === "Firearms",
-          "combat": specialization === "Fighting" || specialization === "Firearms"
+  /**
+   *
+   * @param {JSON} dholeHouseData DholeHouseJSON
+   * @returns
+   */
+  static convertDholeHouseCharacterData (dholeHouseData) {
+    console.log(dholeHouseData)
+    dholeHouseData = dholeHouseData.Investigator
+    const cData = {
+      name: dholeHouseData.PersonalDetails.Name,
+      actor: {
+        characteristics: {
+          str: { value: dholeHouseData.Characteristics.STR },
+          con: { value: dholeHouseData.Characteristics.CON },
+          siz: { value: dholeHouseData.Characteristics.SIZ },
+          dex: { value: dholeHouseData.Characteristics.DEX },
+          app: { value: dholeHouseData.Characteristics.APP },
+          int: { value: dholeHouseData.Characteristics.INT },
+          pow: { value: dholeHouseData.Characteristics.POW },
+          edu: { value: dholeHouseData.Characteristics.EDU }
         },
-        "flags": { "occupation": isOccupational },
-        "base": Number(value),
-        "value": Number(value)
+        attribs: {
+          san: {
+            value: dholeHouseData.Characteristics.Sanity,
+            max: dholeHouseData.Characteristics.SanityMax
+          },
+          hp: {
+            value: dholeHouseData.Characteristics.HitPts,
+            max: dholeHouseData.Characteristics.HitPtsMax
+          },
+          mp: {
+            value: dholeHouseData.Characteristics.MagicPts,
+            max: dholeHouseData.Characteristics.MagicPtsMax
+          },
+          lck: {
+            value: dholeHouseData.Characteristics.Luck,
+            max: dholeHouseData.Characteristics.LuckMax
+          },
+          mov: {
+            value: dholeHouseData.Characteristics.Move,
+            max: dholeHouseData.Characteristics.Move
+          },
+          db: { value: dholeHouseData.Characteristics.DamageBonus },
+          build: { value: dholeHouseData.Characteristics.Build }
+        },
+        infos: {
+          occupation: dholeHouseData.PersonalDetails.Occupation,
+          age: dholeHouseData.PersonalDetails.Age,
+          sex: dholeHouseData.PersonalDetails.Gender,
+          residence: dholeHouseData.PersonalDetails.Residence,
+          birthplace: dholeHouseData.PersonalDetails.Birthplace
+        },
+        backstory: CoC7DholeHouseActorImporter.getBackstory(
+          dholeHouseData.Backstory
+        ),
+        description: {
+          keeper: game.i18n.localize('CoC7.DholeHouseActorImporterSource')
+        }
+      },
+      skills: CoC7DholeHouseActorImporter.extractSkills(
+        dholeHouseData.Skills.Skill ?? []
+      ),
+      possesions: CoC7DholeHouseActorImporter.extractPossessions(
+        dholeHouseData.Possessions?.item ?? []
+      )
+    }
+    return cData
+  }
+
+  static extractSkills (dholeHousekills) {
+    const skills = []
+    for (const skill of dholeHousekills) {
+      let name = skill.name
+      let specialization = ''
+      let isSpecial = false
+      let isOccupational = false
+      const value = skill.value
+      if (
+        skill.subskill === 'None' &&
+        skill.value === '1' &&
+        skill.half === '0' &&
+        skill.fifth === '0'
+      ) {
+        continue
       }
+      if (skill.subskill && skill.subskill !== 'None') {
+        name = skill.subskill
+        specialization = skill.name
+        isSpecial = true
+      }
+      if (skill.occupation) {
+        isOccupational = true
+      }
+      console.log(
+        'skill name: ',
+        name,
+        ' skill value: ',
+        value,
+        ' specialization: ',
+        specialization
+      )
+      const skillName = name
+      if (['Language (Other)', 'Language (Own)'].includes(specialization)) {
+        specialization = 'Language'
+      }
+      if (isSpecial) {
+        const parts = CoC7Item.getNamePartsSpec(skillName, specialization)
+        name = parts.name
+      }
+      skills.push({
+        type: 'skill',
+        name: name,
+        data: {
+          skillName: skillName,
+          specialization: specialization,
+          properties: {
+            special: isSpecial,
+            fighting: specialization === 'Fighting',
+            firearm: specialization === 'Firearms',
+            combat:
+              specialization === 'Fighting' || specialization === 'Firearms'
+          },
+          flags: { occupation: isOccupational },
+          base: Number(value),
+          value: Number(value)
+        }
+      })
+    }
+    console.log(skills)
+    return skills
+  }
+
+  static findWeaponSkillId (skillName, character) {
+    const skills = character.getEmbeddedCollection('Item')
+    const checkName = skillName.replace(/^\((.+)\)$/, '$1')
+    const characterSkill = skills.find(i => {
+      return (
+        i.data.data?.skillName === checkName ||
+        i.data.data?.skillName.indexOf(checkName) !== false
+      )
     })
+    return characterSkill?.id
   }
-  console.log(skills);
-  return skills
-}
 
-static findWeaponSkillId(skillName, character) {
-   const  skills =  character.getEmbeddedCollection('Item')
-   const characterSkill = skills.find( i => i.data?.skillName === skillName)
-   console.log(characterSkill)
-   console.log(skillName)
-   return characterSkill?.id
-}
-
-static extractPossessions(dholehousePossessions) {
-
-  const items = []
-  for (const item of dholehousePossessions) {
-  items.push({
-      "name": item.description,
-      "type": 'item',
-      "description": {
-        "value": item.description,
-      },
-      "quantity": 1,
-      "weight": 0,
-      "attributes": {}
-    });
+  static extractPossessions (dholehousePossessions) {
+    const items = []
+    for (const item of dholehousePossessions) {
+      items.push({
+        name: item.description,
+        type: 'item',
+        description: {
+          value: item.description
+        },
+        quantity: 1,
+        weight: 0,
+        attributes: {}
+      })
+    }
+    return items
   }
-  return items;
-}
 
-static extractWeapons (dholehouseWeapons, character) {
-
-  const weapons = []
-  if (!Array.isArray(dholehouseWeapons)) {
-    dholehouseWeapons = [dholehouseWeapons]
+  static extractWeapons (dholehouseWeapons, character) {
+    const weapons = []
+    if (!Array.isArray(dholehouseWeapons)) {
+      dholehouseWeapons = [dholehouseWeapons]
+    }
+    for (const weapon of dholehouseWeapons) {
+      weapons.push({
+        name: weapon.name,
+        type: 'weapon',
+        description: {
+          value: weapon.Name
+        },
+        wpnType: '',
+        skill: {
+          main: {
+            name: weapon.skillname,
+            id: CoC7DholeHouseActorImporter.findWeaponSkillId(
+              weapon.skillname,
+              character
+            )
+          },
+          alternativ: {
+            name: '',
+            id: ''
+          }
+        },
+        range: {
+          normal: {
+            value: 0,
+            units: '',
+            damage: weapon.damage
+          },
+          long: {
+            value: 0,
+            units: '',
+            damage: ''
+          },
+          extreme: {
+            value: 0,
+            units: '',
+            damage: ''
+          }
+        },
+        usesPerRound: {
+          normal: 1,
+          max: null,
+          burst: null
+        },
+        bullets: null,
+        ammo: weapon.ammo,
+        malfunction: weapon.malf,
+        blastRadius: null,
+        properties: {
+          melee: weapon.skillname === 'Brawl',
+          // "rngd": weapon.skillname === "Handgun" || weapon.skillname === "Throw",
+          rngd: weapon.range !== 'None' || weapon.skillname !== '-',
+          thrown: weapon.skillname === 'Throw'
+        },
+        eras: {},
+        price: {}
+      })
+    }
+    return weapons
   }
-  for (const weapon of dholehouseWeapons ) {
-  weapons.push({
-      "name": weapon.name,
-      "type": 'weapon',
-      "description": {
-        "value": weapon.Name,
-      },
-      "wpnType": "",
-      "skill": {
-        "main": {
-          "name": weapon.skillname,
-          "id": CoC7DholeHouseActorImporter.findWeaponSkillId(weapon.skillname, character)
-        },
-        "alternativ": {
-          "name": "",
-          "id": ""
-        }
-      },
-      "range": {
-        "normal": {
-          "value": 0,
-          "units": "",
-          "damage": weapon.damage
-        },
-        "long": {
-          "value": 0,
-          "units": "",
-          "damage": ""
-        },
-        "extreme": {
-          "value": 0,
-          "units": "",
-          "damage": ""
-        }
-      },
-      "usesPerRound": {
-        "normal": 1,
-        "max": null,
-        "burst": null
-      },
-      "bullets": null,
-      "ammo": weapon.ammo,
-      "malfunction": weapon.malf,
-      "blastRadius": null,
-      "properties": {
-        "melee": weapon.skillname === "Brawl",
-        //"rngd": weapon.skillname === "Handgun" || weapon.skillname === "Throw",
-        "rngd": weapon.range !== "None" || weapon.skillname !== "-",
-        "thrown": weapon.skillname === "Throw"
-      },
-      "eras": {},
-      "price": {}
+
+  static async createNPCFromDholeHouse (dholeHouseCharacterData) {
+    const characterData =
+      CoC7DholeHouseActorImporter.convertDholeHouseCharacterData(
+        dholeHouseCharacterData
+      )
+    console.log(characterData)
+    const importedCharactersFolder =
+      await CoC7Utilities.createImportCharactersFolderIfNotExists()
+    const actorData = {
+      name: characterData.name,
+      type: 'character',
+      img:
+        'data:image/png;base64,' +
+        dholeHouseCharacterData.Investigator.PersonalDetails.Portrait,
+      folder: importedCharactersFolder.id,
+      data: characterData.actor
+    }
+    const npc = await Actor.create(actorData)
+    console.log(characterData.items)
+    await npc.createEmbeddedDocuments('Item', characterData.skills, {
+      renderSheet: false
     })
+    await npc.createEmbeddedDocuments('Item', characterData.possesions, {
+      renderSheet: false
+    })
+    const weapons = CoC7DholeHouseActorImporter.extractWeapons(
+      dholeHouseCharacterData.Investigator.Weapons?.weapon ?? [],
+      npc
+    )
+    console.log('weapons', weapons)
+    await npc.createEmbeddedDocuments('Item', weapons, {
+      renderSheet: false
+    })
+
+    return npc
   }
-  return weapons
-}
-
-
-static async createNPCFromDholeHouse(dholeHouseCharacterData) {
-  const characterData = CoC7DholeHouseActorImporter.convertDholeHouseCharacterData(dholeHouseCharacterData)
-  console.log(characterData)
-  const importedCharactersFolder =
-    await CoC7Utilities.createImportCharactersFolderIfNotExists()
-  const actorData = {
-    name: characterData.name,
-    type: 'character',
-    img: 'data:image/png;base64,'+ dholeHouseCharacterData.Investigator.PersonalDetails.Portrait,
-    folder: importedCharactersFolder.id,
-    data: characterData.actor
-  }
-  const npc = await Actor.create(actorData)
-  console.log(characterData.items)
-  await npc.createEmbeddedDocuments('Item', characterData.skills, {
-    renderSheet: false
-  })
-  await npc.createEmbeddedDocuments('Item', characterData.possesions, {
-    renderSheet: false
-  })
-  const weapons = CoC7DholeHouseActorImporter.extractWeapons(dholeHouseCharacterData.Investigator.Weapons?.weapon ?? [], npc)
-  console.log("weapons", weapons)
-  await npc.createEmbeddedDocuments('Item', weapons, {
-    renderSheet: false
-  })
-
-  return npc
-}
-
-static async pasteDholeHouseJSONDialog(data = {}) {
-
-  const html = await renderTemplate('systems/CoC7/templates/apps/dholehouse-actor-importer.html')
-  new Dialog({
-    title: 'Paste the JSON from the DholeHouse',
-    content: html,
-    buttons: {
-      import: {
-        icon: '<i class="fas fa-file-import"></i>',
-        label: 'Import',
-        callback: async html => {
-          console.debug('html', html)
-          let text = html.find('#coc-dholehouse-pasted-character-json-data').val().trim()
-          console.debug('received text', '##' + text + '##')
-          const characterJSON = JSON.parse(text)
-          const character  = await CoC7DholeHouseActorImporter.createNPCFromDholeHouse(characterJSON)
-          console.debug('character:', character)
-          ui.notifications.info('Created Character: ' + character.data?.name)
-          await character.sheet.render(true)
-        }
-      },
-      no: {
-        icon: '<i class="fas fa-times"></i>',
-        label: 'Cancel'
-      }
-    },
-    default: 'import'
-  }, {
-    width: 800
-  }).render(true)
-}
-
 }

--- a/module/apps/dholehouse_importer.js
+++ b/module/apps/dholehouse_importer.js
@@ -1,0 +1,327 @@
+import { CoCActor } from '../actors/actor.js'
+import { CoC7Item } from '../items/item.js'
+import { CoC7Utilities } from '../utilities.js'
+
+/**
+ * CoC7ActorImporter helper class to import an Actor from the raw text description.
+ */
+export class CoC7DholeHouseActorImporter {
+/**
+ * Compose the Backstory from the different blocks.
+ * @param {} backstoryJSON DholeHouse backstory JSON
+ * @returns HTML with the formatted backstory
+ */
+  static getBackstory(backstoryJSON) {
+  let backstory = `<h2>Backstory</h2>\n`
+  if (backstoryJSON.description !== null) {
+    backstory += `<h3>Description</h3>
+      <div class="description">
+      ${backstoryJSON.description}
+      </div>\n`
+  }
+  if (backstoryJSON.traits !== null) {
+    backstory += `<h3>Traits</h3>
+      <div class="traits">
+      ${backstoryJSON.traits}
+      <div>\n`
+  }
+  if (backstoryJSON.ideology !== null) {
+    backstory += `<h3>Ideology</h3>
+      <div class="ideology">
+      ${backstoryJSON.ideology}
+      <div>\n`
+  }
+  if (backstoryJSON.injurues !== null) {
+    backstory += `<h3>Injuries</h3>
+      <div class="injuries">
+      ${backstoryJSON.injurues}
+      <div>\n`
+  }
+  if (backstoryJSON.people !== null) {
+    backstory += `<h3>People</h3>
+      <div class="people">
+      ${backstoryJSON.people}
+      <div>\n`
+  }
+  if (backstoryJSON.phobias !== null) {
+    backstory += `<h3>Phobias</h3>
+      <div class="phobias">
+      ${backstoryJSON.phobias}
+      <div>\n`
+  }
+  if (backstoryJSON.locations !== null) {
+    backstory += `<h3>Locations</h3>
+      <div class="locations">
+      ${backstoryJSON.locations}
+      <div>\n`
+  }
+  if (backstoryJSON.tomes !== null) {
+    backstory += `<h3>Tomes</h3>
+      <div class="tomes">
+      ${backstoryJSON.tomes}
+      <div>\n`
+  }
+  if (backstoryJSON.possessions !== null) {
+    backstory += `<h3>Possessions</h3>
+      <div class="possessions">
+      ${backstoryJSON.possessions}
+      <div>\n`
+  }
+  if (backstoryJSON.encounters !== null) {
+    backstory += `<h3>Encounters</h3>
+      <div class="encounters">
+      ${backstoryJSON.encounters}
+      <div>\n`
+  }
+  return backstory;
+}
+/**
+ *
+ * @param {JSON} dholeHouseData DholeHouseJSON
+ * @returns
+ */
+static convertDholeHouseCharacterData(dholeHouseData) {
+  console.log(dholeHouseData)
+  dholeHouseData = dholeHouseData.Investigator
+  const cData = {
+    "name": dholeHouseData.PersonalDetails.Name,
+    "actor": {
+      "characteristics": {
+        "str": { "value": dholeHouseData.Characteristics.STR},
+        "con": { "value": dholeHouseData.Characteristics.CON},
+        "siz": { "value": dholeHouseData.Characteristics.SIZ},
+        "dex": { "value": dholeHouseData.Characteristics.DEX},
+        "app": { "value": dholeHouseData.Characteristics.APP},
+        "int": { "value": dholeHouseData.Characteristics.INT},
+        "pow": { "value": dholeHouseData.Characteristics.POW},
+        "edu": { "value": dholeHouseData.Characteristics.EDU},
+      },
+      "attribs": {
+        "san": {
+          "value": dholeHouseData.Characteristics.Sanity,
+          "max": dholeHouseData.Characteristics.SanityMax
+        },
+        "hp": { "value": dholeHouseData.Characteristics.HitPts,
+                "max": dholeHouseData.Characteristics.HitPtsMax },
+        "mp": { "value": dholeHouseData.Characteristics.MagicPts,
+                "max": dholeHouseData.Characteristics.MagicPtsMax },
+        "lck": { "value": dholeHouseData.Characteristics.Luck,
+                "max": dholeHouseData.Characteristics.LuckMax},
+        "mov": { "value": dholeHouseData.Characteristics.Move,
+                "max": dholeHouseData.Characteristics.Move},
+        "db": { "value": dholeHouseData.Characteristics.DamageBonus },
+        "build": { "value": dholeHouseData.Characteristics.Build}
+      },
+      "infos": {
+        "occupation": dholeHouseData.PersonalDetails.Occupation,
+        "age": dholeHouseData.PersonalDetails.Age,
+        "sex": dholeHouseData.PersonalDetails.Gender,
+        "residence": dholeHouseData.PersonalDetails.Residence,
+        "birthplace": dholeHouseData.PersonalDetails.Birthplace,
+      },
+      "backstory": CoC7DholeHouseActorImporter.getBackstory(dholeHouseData.Backstory),
+      "description": {
+        "keeper": `Imported from  Dholehouse`
+      }
+    },
+    "skills": CoC7DholeHouseActorImporter.extractSkills(dholeHouseData.Skills.Skill ?? []),
+    "possesions":CoC7DholeHouseActorImporter.extractPossessions(dholeHouseData.Possessions?.item ?? [])
+  }
+  return cData;
+}
+
+static extractSkills(dholeHousekills) {
+  const skills = []
+  for (const skill of dholeHousekills) {
+    let name = skill.name
+    let specialization = ""
+    let isSpecial = false
+    let isOccupational = false
+    const value = skill.value
+    if (skill.subskill === "None" && skill.value === "1" && skill.half === "0"
+    && skill.fifth === "0") {
+      continue;
+    }
+    if (skill.subskill && skill.subskill !== "None") {
+      name = skill.subskill;
+      specialization = skill.name
+      isSpecial = true;
+    }
+    if (skill.occupation) {
+      isOccupational = true;
+    }
+    console.log("skill name: ", name, " skill value: ", value , " specialization: ", specialization)
+    skills.push({
+      "type": "skill",
+      "name": name,
+      "data": {
+        "skillName": name,
+        "specialization": specialization,
+        "properties": {
+          "special": isSpecial,
+          "fighting": specialization === "Fighting",
+          "firearm": specialization === "Firearms",
+          "combat": specialization === "Fighting" || specialization === "Firearms"
+        },
+        "flags": { "occupation": isOccupational },
+        "base": Number(value),
+        "value": Number(value)
+      }
+    })
+  }
+  console.log(skills);
+  return skills
+}
+
+static findWeaponSkillId(skillName, character) {
+   const  skills =  character.getEmbeddedCollection('Item')
+   const characterSkill = skills.find( i => i.data?.skillName === skillName)
+   console.log(characterSkill)
+   console.log(skillName)
+   return characterSkill?.id
+}
+
+static extractPossessions(dholehousePossessions) {
+
+  const items = []
+  for (const item of dholehousePossessions) {
+  items.push({
+      "name": item.description,
+      "type": 'item',
+      "description": {
+        "value": item.description,
+      },
+      "quantity": 1,
+      "weight": 0,
+      "attributes": {}
+    });
+  }
+  return items;
+}
+
+static extractWeapons (dholehouseWeapons, character) {
+
+  const weapons = []
+  if (!Array.isArray(dholehouseWeapons)) {
+    dholehouseWeapons = [dholehouseWeapons]
+  }
+  for (const weapon of dholehouseWeapons ) {
+  weapons.push({
+      "name": weapon.name,
+      "type": 'weapon',
+      "description": {
+        "value": weapon.Name,
+      },
+      "wpnType": "",
+      "skill": {
+        "main": {
+          "name": weapon.skillname,
+          "id": CoC7DholeHouseActorImporter.findWeaponSkillId(weapon.skillname, character)
+        },
+        "alternativ": {
+          "name": "",
+          "id": ""
+        }
+      },
+      "range": {
+        "normal": {
+          "value": 0,
+          "units": "",
+          "damage": weapon.damage
+        },
+        "long": {
+          "value": 0,
+          "units": "",
+          "damage": ""
+        },
+        "extreme": {
+          "value": 0,
+          "units": "",
+          "damage": ""
+        }
+      },
+      "usesPerRound": {
+        "normal": 1,
+        "max": null,
+        "burst": null
+      },
+      "bullets": null,
+      "ammo": weapon.ammo,
+      "malfunction": weapon.malf,
+      "blastRadius": null,
+      "properties": {
+        "melee": weapon.skillname === "Brawl",
+        //"rngd": weapon.skillname === "Handgun" || weapon.skillname === "Throw",
+        "rngd": weapon.range !== "None" || weapon.skillname !== "-",
+        "thrown": weapon.skillname === "Throw"
+      },
+      "eras": {},
+      "price": {}
+    })
+  }
+  return weapons
+}
+
+
+static async createNPCFromDholeHouse(dholeHouseCharacterData) {
+  const characterData = CoC7DholeHouseActorImporter.convertDholeHouseCharacterData(dholeHouseCharacterData)
+  console.log(characterData)
+  const importedCharactersFolder =
+    await CoC7Utilities.createImportCharactersFolderIfNotExists()
+  const actorData = {
+    name: characterData.name,
+    type: 'character',
+    img: 'data:image/png;base64,'+ dholeHouseCharacterData.Investigator.PersonalDetails.Portrait,
+    folder: importedCharactersFolder.id,
+    data: characterData.actor
+  }
+  const npc = await Actor.create(actorData)
+  console.log(characterData.items)
+  await npc.createEmbeddedDocuments('Item', characterData.skills, {
+    renderSheet: false
+  })
+  await npc.createEmbeddedDocuments('Item', characterData.possesions, {
+    renderSheet: false
+  })
+  const weapons = CoC7DholeHouseActorImporter.extractWeapons(dholeHouseCharacterData.Investigator.Weapons?.weapon ?? [], npc)
+  console.log("weapons", weapons)
+  await npc.createEmbeddedDocuments('Item', weapons, {
+    renderSheet: false
+  })
+
+  return npc
+}
+
+static async pasteDholeHouseJSONDialog(data = {}) {
+
+  const html = await renderTemplate('systems/CoC7/templates/apps/dholehouse-actor-importer.html')
+  new Dialog({
+    title: 'Paste the JSON from the DholeHouse',
+    content: html,
+    buttons: {
+      import: {
+        icon: '<i class="fas fa-file-import"></i>',
+        label: 'Import',
+        callback: async html => {
+          console.debug('html', html)
+          let text = html.find('#coc-dholehouse-pasted-character-json-data').val().trim()
+          console.debug('received text', '##' + text + '##')
+          const characterJSON = JSON.parse(text)
+          const character  = await CoC7DholeHouseActorImporter.createNPCFromDholeHouse(characterJSON)
+          console.debug('character:', character)
+          ui.notifications.info('Created Character: ' + character.data?.name)
+          await character.sheet.render(true)
+        }
+      },
+      no: {
+        icon: '<i class="fas fa-times"></i>',
+        label: 'Cancel'
+      }
+    },
+    default: 'import'
+  }, {
+    width: 800
+  }).render(true)
+}
+
+}

--- a/module/apps/dholehouse_importer.js
+++ b/module/apps/dholehouse_importer.js
@@ -1,4 +1,5 @@
-/* global Actor, File, FilePicker, game, ui */
+/* global Actor, game, ui */
+import { CoC7DirectoryPicker } from '../scripts/coc7-directory-picker.js'
 import { CoC7Item } from '../items/item.js'
 import { CoC7Utilities } from '../utilities.js'
 
@@ -250,7 +251,6 @@ export class CoC7DholeHouseActorImporter {
       )
       const damage = weapon.damage.replace(/\+DB/i, '')
       const addb = damage !== weapon.damage
-      console.log(addb, damage, weapon.damage)
       weapons.push({
         name: weapon.name,
         type: 'weapon',
@@ -323,18 +323,8 @@ export class CoC7DholeHouseActorImporter {
     const importedCharactersFolder =
       await CoC7Utilities.createImportCharactersFolderIfNotExists()
     // To be made a setting to allow S3 buckets
-    try {
-      await FilePicker.createDirectory(
-        'data',
-        'worlds/' + game.world.id + '/dhole-images'
-      )
-    } catch (e) {
-      if (!e.startsWith('EEXIST')) {
-        ui.notifications.error(
-          game.i18n.localize('CoC7.ActorImporterUploadError')
-        )
-        return false
-      }
+    if (!CoC7DirectoryPicker.createDefaultDirectory()) {
+      return false
     }
     const actorData = {
       name: characterData.name,
@@ -354,17 +344,15 @@ export class CoC7DholeHouseActorImporter {
       for (let i = 0; i < pngtext.length; i++) {
         pngnums[i] = pngtext.charCodeAt(i)
       }
-      FilePicker.upload(
-        'data',
-        'worlds/' + game.world.id + '/dhole-images/',
-        new File([new Uint8Array(pngnums)], 'avatar-' + npc.id + '.png', {
-          type: 'image/png'
-        })
+      const filename = CoC7DirectoryPicker.uploadToDefaultDirectory(
+        new Uint8Array(pngnums),
+        'avatar-' + npc.id + '.png'
       )
-      npc.update({
-        img:
-          'worlds/' + game.world.id + '/dhole-images/avatar-' + npc.id + '.png'
-      })
+      if (filename !== false) {
+        npc.update({
+          img: filename
+        })
+      }
     }
 
     console.log(characterData.items)

--- a/module/hooks/index.js
+++ b/module/hooks/index.js
@@ -7,6 +7,7 @@ import * as RenderChatMessage from './render-chat-message.js'
 import * as RenderDialog from './render-dialog.js'
 import * as RenderItemSheet from './render-item-sheet.js'
 import * as RenderPause from './render-pause.js'
+import * as RenderSettingsConfig from './render-settings-config.js'
 
 export const CoC7Hooks = {
   listen () {
@@ -19,5 +20,6 @@ export const CoC7Hooks = {
     RenderPause.listen()
     DiceSoNiceReady.listen()
     DiceSoNiceRollStart.listen()
+    RenderSettingsConfig.listen()
   }
 }

--- a/module/hooks/render-settings-config.js
+++ b/module/hooks/render-settings-config.js
@@ -1,0 +1,8 @@
+/* global Hooks */
+import { CoC7DirectoryPicker } from '../scripts/coc7-directory-picker.js'
+
+export function listen () {
+  Hooks.on('renderSettingsConfig', (app, html, user) => {
+    CoC7DirectoryPicker.processHtml(html)
+  })
+}

--- a/module/menu.js
+++ b/module/menu.js
@@ -59,10 +59,7 @@ export class CoC7Menu {
           icon: 'fas fa-user-plus',
           name: 'actor-import',
           title: 'CoC7.ActorImporter',
-          onClick: async () =>
-            await CoC7ActorImporterDialog.create({
-              title: game.i18n.localize('CoC7.ActorImporter')
-            })
+          onClick: async () => await CoC7ActorImporterDialog.create()
         },
         {
           toggle: true,

--- a/module/scripts/coc7-directory-picker.js
+++ b/module/scripts/coc7-directory-picker.js
@@ -1,0 +1,121 @@
+/* global $, File, FilePicker, game, ui */
+export class CoC7DirectoryPicker extends FilePicker {
+  get title () {
+    return game.i18n.localize('CoC7.PickDirectory')
+  }
+
+  _onSubmit (event) {
+    event.preventDefault()
+    const path = event.target.target.value
+    const activeSource = this.activeSource
+    const bucket = event.target.bucket ? event.target.bucket.value : null
+    this.field.value = CoC7DirectoryPicker.format({
+      activeSource,
+      bucket,
+      path
+    })
+    this.close()
+  }
+
+  static DefaultDirectory (val) {
+    return val === null ? '' : String(val)
+  }
+
+  static format (value) {
+    return value.bucket !== null
+      ? `[${value.activeSource}:${value.bucket}] ${value.path}`
+      : `[${value.activeSource}] ${value.path}`
+  }
+
+  static parse (raw) {
+    const str = raw ?? ''
+    const matches = str.match(/^\[([^:]+)(:(.+))?\]\s*(.+)?$/u)
+
+    if (matches) {
+      return {
+        activeSource: matches[1],
+        bucket: matches[3] ?? '',
+        current: matches[4]
+      }
+    }
+    return {
+      activeSource: 'data',
+      bucket: null,
+      current: str
+    }
+  }
+
+  static processHtml (html) {
+    $(html)
+      .find('input[data-dtype="DefaultDirectory"]')
+      .each((i, el) => {
+        const input = $(el)
+        input.prop('readonly', true)
+        if (!input.next().length) {
+          const picker = new CoC7DirectoryPicker({
+            field: input[0],
+            ...CoC7DirectoryPicker.parse(input.val())
+          })
+          const pickerButton = $(
+            '<button type="button" class="file-picker" title="' +
+              game.i18n.localize('CoC7.PickDirectory') +
+              '"><i class="fas fa-file-import fa-fw"></i></button>'
+          )
+          pickerButton.on('click', () => {
+            picker.render(true)
+          })
+          input.parent().append(pickerButton)
+        }
+      })
+  }
+
+  activateListeners (html) {
+    super.activateListeners(html)
+
+    $(html)
+      .find('ol.files-list')
+      .remove()
+    $(html)
+      .find('footer div')
+      .remove()
+    $(html)
+      .find('footer button')
+      .text(game.i18n.localize('CoC7.PickDirectory'))
+  }
+
+  static async createDefaultDirectory () {
+    const parsed = CoC7DirectoryPicker.parse(
+      game.settings.get('CoC7', 'dholeUploadDirectory')
+    )
+    try {
+      await CoC7DirectoryPicker.createDirectory(
+        parsed.activeSource,
+        parsed.current,
+        { bucket: parsed.bucket }
+      )
+      return true
+    } catch (e) {
+      if (!e.startsWith('EEXIST')) {
+        ui.notifications.error(
+          game.i18n.localize('CoC7.ActorImporterUploadError')
+        )
+        return false
+      }
+    }
+  }
+
+  static uploadToDefaultDirectory (file, filename) {
+    const parsed = CoC7DirectoryPicker.parse(
+      game.settings.get('CoC7', 'dholeUploadDirectory')
+    )
+    FilePicker.upload(
+      parsed.activeSource,
+      parsed.current,
+      new File([file], filename, {
+        type: 'image/png'
+      }),
+      { bucket: parsed.bucket }
+    )
+    return parsed.current + '/' + filename
+  }
+}

--- a/module/scripts/coc7-directory-picker.js
+++ b/module/scripts/coc7-directory-picker.js
@@ -104,11 +104,11 @@ export class CoC7DirectoryPicker extends FilePicker {
     }
   }
 
-  static uploadToDefaultDirectory (file, filename) {
+  static async uploadToDefaultDirectory (file, filename) {
     const parsed = CoC7DirectoryPicker.parse(
       game.settings.get('CoC7', 'dholeUploadDirectory')
     )
-    FilePicker.upload(
+    const response = await FilePicker.upload(
       parsed.activeSource,
       parsed.current,
       new File([file], filename, {
@@ -116,6 +116,10 @@ export class CoC7DirectoryPicker extends FilePicker {
       }),
       { bucket: parsed.bucket }
     )
+    if (!response.path) {
+      ui.notifications.error(game.i18n.localize('CoC7.FileUploadError'))
+      return false
+    }
     return parsed.current + '/' + filename
   }
 }

--- a/module/scripts/register-settings.js
+++ b/module/scripts/register-settings.js
@@ -2,6 +2,7 @@
 import { CoC7DecaderDie } from '../apps/decader-die.js'
 import { CoC7DecaderDieOther } from '../apps/decader-die-other.js'
 import { CoC7GameRuleSettings } from './game-rules.js'
+import { CoC7DirectoryPicker } from './coc7-directory-picker.js'
 
 export function registerSettings () {
   /**
@@ -16,6 +17,15 @@ export function registerSettings () {
     restricted: true
   })
   CoC7GameRuleSettings.registerSettings()
+
+  game.settings.register('CoC7', 'dholeUploadDirectory', {
+    name: 'CoC7.Settings.DholeUpload.Directory.Name',
+    hint: 'CoC7.Settings.DholeUpload.Directory.Hint',
+    scope: 'world',
+    config: true,
+    type: CoC7DirectoryPicker.DefaultDirectory,
+    default: '[data] worlds/' + game.world.id + '/dhole-images'
+  })
 
   /**
    * Initiative

--- a/module/updater.js
+++ b/module/updater.js
@@ -435,7 +435,7 @@ export class Updater {
           value: item.data.description,
           keeper: ''
         }
-      } else if (typeof item.data.description === 'undefined') {
+      } else if (typeof item.data.description === 'undefined' || item.data.description === null) {
         updateData['data.description'] = {
           value: '',
           keeper: ''

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -705,4 +705,34 @@ export class CoC7Utilities {
 
     return qString
   }
+
+    /**
+   * Creates a folder on the actors tab called "Imported Characters" if the folder doesn't exist.
+   * @returns {Folder} the importedCharactersFolder
+   */
+  static async createImportCharactersFolderIfNotExists () {
+    let folderName = game.i18n.localize('CoC7.ImportedCharactersFolder')
+    if (folderName === 'CoC7.ImportedCharactersFolder') {
+      folderName = 'Imported characters'
+    }
+    let importedCharactersFolder = game.folders.find(
+      entry => entry.data.name === folderName && entry.data.type === 'Actor'
+    )
+    if (
+      importedCharactersFolder === null ||
+      typeof importedCharactersFolder === 'undefined'
+    ) {
+      // Create the folder
+      importedCharactersFolder = await Folder.create({
+        name: folderName,
+        type: 'Actor',
+        parent: null
+      })
+      ui.notifications.info(
+        game.i18n.localize('CoC7.CreatedImportedCharactersFolder')
+      )
+    }
+    return importedCharactersFolder
+  }
+
 }

--- a/templates/apps/actor-importer.html
+++ b/templates/apps/actor-importer.html
@@ -1,13 +1,21 @@
 <form autocomplete="off">
   <h2>{{localize 'CoC7.ActorImporter'}}</h2>
+  {{#if (eq importType "dholehouse")}}
+  <div id="coc-prompt" data-text="{{localize 'CoC7.DholeHouseActorImporterSummary'}}">{{localize 'CoC7.DholeHouseActorImporterSummary'}}</div>
+  {{#unless canUpload}}
+      <div class="error">{{localize 'CoC7.UnableToUploadDholeImage'}}</div>
+  {{/unless}}
+    <div class="form-group-stacked">
+  {{else}}
   <p>{{localize 'CoC7.ActorImporterSummary'}}</p>
+  {{/if}}
   <div class="form-group">
     <label for="coc-entity-type">{{localize 'CoC7.SelectActorType'}}:</label>
     <select id="coc-entity-type" name="coc-entity-type">
       {{#select importType}}
-        <option value="dholehouse">{{localize 'CoC7.DholeHouseActorImporter'}}</option>
         <option value="npc">{{localize 'CoC7.NonPlayingCharacter'}}</option>
         <option value="creature">{{localize 'CoC7.Creature'}}</option>
+        <option value="dholehouse">{{localize 'CoC7.DholeHouseActorImporter'}}</option>
       {{/select}}
     </select>
   </div>
@@ -42,17 +50,23 @@
       </select>
     </div>
   {{/if}}
-  {{#if (or (eq importType "npc") (eq importType "creature"))}}
+  {{#if (eq importType "dholehouse")}}
+      <label for="dholehouse-json-file-picker">{{localize 'CoC7.DholeHousePickYourJSONFile'}}</label><br/>
+      <input id="dholehouse-json-file-picker" name="dholehouse-json-file-picker" type="file" accept="application/json" />
+    </div>
+    <div id="dholehouse-character-preview" class="form-group">
+        <p><strong>{{localize 'CoC7.DholeHouseImportingName'}}</strong><br/>
+        <span id="dholehouse-character-name"</span>
+        </p>
+        {{!-- By defaults the image is a transparent pixel to be replaced when the JSON is loaded --}}
+        <img id="dholehouse-character-portrait" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=" />
+    </div>
+    {{else}}
     <div id="coc-prompt" data-text="{{localize 'CoC7.PasteTheDataBelow'}}" data-extended="limit">{{localize 'CoC7.PasteTheDataBelow'}}</div>
-  {{else if (eq importType "dholehouse")}}
-    <div id="coc-prompt" data-text="{{localize 'CoC7.DholeHouseActorImporterSummary'}}">{{localize 'CoC7.DholeHouseActorImporterSummary'}}</div>
-    {{#unless canUpload}}
-      <div class="error">{{localize 'CoC7.UnableToUploadDholeImage'}}</div>
-    {{/unless}}
+    <div class="form-group">
+      <textarea id="coc-pasted-character-data" name="coc-pasted-character-data" rows="30" style="min-height:300px" placeholder="{{placeholder}}">{{characterData}}</textarea>
+    </div>
   {{/if}}
-  <div class="form-group">
-   <textarea id="coc-pasted-character-data" name="coc-pasted-character-data" rows="30" style="min-height:300px" placeholder="{{placeholder}}">{{characterData}}</textarea>
-  </div>
   <div class="dialog-buttons flexrow">
     <button class="submit-button" data-button="import">
       <i class="fas fa-file-import"></i>
@@ -63,8 +77,6 @@
         <i class="fas fa-info-circle"></i>
         {{localize 'CoC7.getTheExample'}}
       </button>
-    {{else}}
-      <div></div>
     {{/if}}
     <button class="submit-button" data-button="no">
       <i class="fas fa-times"></i>

--- a/templates/apps/actor-importer.html
+++ b/templates/apps/actor-importer.html
@@ -43,9 +43,12 @@
     </div>
   {{/if}}
   {{#if (or (eq importType "npc") (eq importType "creature"))}}
-    <div id="coc-prompt" data-text="{{localize 'CoC7.PasteTheDataBelow'}}">{{localize 'CoC7.PasteTheDataBelow'}}</div>
+    <div id="coc-prompt" data-text="{{localize 'CoC7.PasteTheDataBelow'}}" data-extended="limit">{{localize 'CoC7.PasteTheDataBelow'}}</div>
   {{else if (eq importType "dholehouse")}}
-    <div id="coc-prompt">{{localize 'CoC7.DholeHouseActorImporterSummary'}}</div>
+    <div id="coc-prompt" data-text="{{localize 'CoC7.DholeHouseActorImporterSummary'}}">{{localize 'CoC7.DholeHouseActorImporterSummary'}}</div>
+    {{#unless canUpload}}
+      <div class="error">{{localize 'CoC7.UnableToUploadDholeImage'}}</div>
+    {{/unless}}
   {{/if}}
   <div class="form-group">
    <textarea id="coc-pasted-character-data" name="coc-pasted-character-data" rows="30" style="min-height:300px" placeholder="{{placeholder}}">{{characterData}}</textarea>

--- a/templates/apps/actor-importer.html
+++ b/templates/apps/actor-importer.html
@@ -1,41 +1,71 @@
 <form autocomplete="off">
-    <h2>{{localize 'CoC7.ActorImporter'}}</h2>
-    <p>{{localize 'CoC7.ActorImporterSummary'}}</p>
+  <h2>{{localize 'CoC7.ActorImporter'}}</h2>
+  <p>{{localize 'CoC7.ActorImporterSummary'}}</p>
+  <div class="form-group">
+    <label for="coc-entity-type">{{localize 'CoC7.SelectActorType'}}:</label>
+    <select id="coc-entity-type" name="coc-entity-type">
+      {{#select importType}}
+        <option value="dholehouse">{{localize 'CoC7.DholeHouseActorImporter'}}</option>
+        <option value="npc">{{localize 'CoC7.NonPlayingCharacter'}}</option>
+        <option value="creature">{{localize 'CoC7.Creature'}}</option>
+      {{/select}}
+    </select>
+  </div>
+  {{#if (or (eq importType "npc") (eq importType "creature"))}}
     <div class="form-group">
-        <label for="coc-entity-type">{{localize 'CoC7.SelectActorType'}}:</label>
-        <select id="coc-entity-type" name="coc-entity-type">
-            <option value="npc">{{localize 'CoC7.NonPlayingCharacter'}}</option>
-            <option value="creature">{{localize 'CoC7.Creature'}}</option>
-        </select>
+      <label for="coc-convert-6E">{{localize 'CoC7.ConvertFrom6Edition'}}:</label>
+      <select id="coc-convert-6E" name="coc-convert-6E">
+        {{#select convert6E}}
+          <option value="coc-guess">{{localize 'CoC7.Guess'}}</option>
+          <option value="coc-convert">{{localize 'CoC7.Convert'}}</option>
+          <option value="coc-no-convert">{{localize 'CoC7.NoConvert'}}</option>
+        {{/select}}
+      </select>
     </div>
     <div class="form-group">
-        <label for="coc-convert-6E">{{localize 'CoC7.ConvertFrom6Edition'}}:</label>
-        <select id="coc-convert-6E" name="coc-convert-6E">
-            <option value="coc-guess">{{localize 'CoC7.Guess'}}</option>
-            <option value="coc-convert">{{localize 'CoC7.Convert'}}</option>
-            <option value="coc-no-convert">{{localize 'CoC7.NoConvert'}}</option>
-        </select>
-    </div>
-     <div class="form-group">
-        <label for="coc-entity-lang">{{localize 'CoC7.SelectSourceLanguage'}}:</label>
-        <select id="coc-entity-lang" name="coc-entity-lang">
+      <label for="coc-entity-lang">{{localize 'CoC7.SelectSourceLanguage'}}:</label>
+      <select id="coc-entity-lang" name="coc-entity-lang">
         {{#each languages as |key id|}}
-            <option value="{{id}}"{{#if (eq ../language id)}} selected="selected"{{/if}}>{{localize key}}</option>
+          <option value="{{id}}"{{#if (eq ../language id)}} selected="selected"{{/if}}>{{localize key}}</option>
         {{/each}}
-        </select>
+      </select>
     </div>
     <div class="form-group">
-        <label for="source">{{localize 'CoC7.ImportSkillItemLocations'}}:</label>
-        <select id="source" name="source">
-            <option value="">{{localize 'CoC7.ImportActorItemsNone'}}</option>
-            <option value="i">{{localize 'CoC7.ImportActorItemsItem'}}</option>
-            <option value="iwms" selected="selected">{{localize 'CoC7.ImportActorItemsItemWorldModuleSystem'}}</option>
-            <option value="wmis">{{localize 'CoC7.ImportActorItemsWorldModuleItemSystem'}}</option>
-        </select>
+      <label for="source">{{localize 'CoC7.ImportSkillItemLocations'}}:</label>
+      <select id="source" name="source">
+        {{#select source}}
+          <option value="">{{localize 'CoC7.ImportActorItemsNone'}}</option>
+          <option value="i">{{localize 'CoC7.ImportActorItemsItem'}}</option>
+          <option value="iwms">{{localize 'CoC7.ImportActorItemsItemWorldModuleSystem'}}</option>
+          <option value="wmis">{{localize 'CoC7.ImportActorItemsWorldModuleItemSystem'}}</option>
+        {{/select}}
+      </select>
     </div>
-    <div id="coc-prompt">{{localize 'CoC7.PasteTheDataBelow'}}</div>
-    <div class="form-group">
-        <textarea id="coc-pasted-character-data" name="coc-pasted-character-data" rows="30"
-            style="min-height:300px" placeholder=""></textarea>
-    </div>
+  {{/if}}
+  {{#if (or (eq importType "npc") (eq importType "creature"))}}
+    <div id="coc-prompt" data-text="{{localize 'CoC7.PasteTheDataBelow'}}">{{localize 'CoC7.PasteTheDataBelow'}}</div>
+  {{else if (eq importType "dholehouse")}}
+    <div id="coc-prompt">{{localize 'CoC7.DholeHouseActorImporterSummary'}}</div>
+  {{/if}}
+  <div class="form-group">
+   <textarea id="coc-pasted-character-data" name="coc-pasted-character-data" rows="30" style="min-height:300px" placeholder="{{placeholder}}">{{characterData}}</textarea>
+  </div>
+  <div class="dialog-buttons flexrow">
+    <button class="submit-button" data-button="import">
+      <i class="fas fa-file-import"></i>
+      {{localize 'CoC7.Import'}}
+    </button>
+    {{#if (or (eq importType "npc") (eq importType "creature"))}}
+      <button class="submit-button" data-button="getExampleNow">
+        <i class="fas fa-info-circle"></i>
+        {{localize 'CoC7.getTheExample'}}
+      </button>
+    {{else}}
+      <div></div>
+    {{/if}}
+    <button class="submit-button" data-button="no">
+      <i class="fas fa-times"></i>
+      {{localize 'CoC7.Cancel'}}
+    </button>
+  </div>
 </form>

--- a/templates/apps/dholehouse-actor-importer.html
+++ b/templates/apps/dholehouse-actor-importer.html
@@ -1,0 +1,7 @@
+<form autocomplete="off">
+    <h2>{{localize 'CoC7.DholeHouseActorImporter'}}</h2>
+    <p>{{localize 'CoC7.DholeHouseActorImporterSummary'}}</p>
+    <div class="form-group">
+        <textarea id="coc-dholehouse-pasted-character-json-data" name="coc-pasted-character-data" rows="30" style="min-height:300px" ></textarea>
+    </div>
+</form>

--- a/templates/apps/dholehouse-actor-importer.html
+++ b/templates/apps/dholehouse-actor-importer.html
@@ -1,7 +1,0 @@
-<form autocomplete="off">
-    <h2>{{localize 'CoC7.DholeHouseActorImporter'}}</h2>
-    <p>{{localize 'CoC7.DholeHouseActorImporterSummary'}}</p>
-    <div class="form-group">
-        <textarea id="coc-dholehouse-pasted-character-json-data" name="coc-pasted-character-data" rows="30" style="min-height:300px" ></textarea>
-    </div>
-</form>


### PR DESCRIPTION
## Description.

I've added a new button to the Import Actor Dialog to show a **new** Dialog to import a JSON character exported from The Dhole's House (https://www.dholeshouse.org/). 
I don't really like the flow (too many clicks), but I've not found a better one so far :disappointed:  

**Notes:** 
* Currently DholeHouse only allows to export your own characters, not the ones from the library. 
* Only tested with 7E characters, but doing a conversion from 6E ones should probably easy.
* Weapon Skills are not properly set :disappointed: 
* I've moved `createImportCharactersFolderIfNotExists` to `utilities.js`
* Includes a little fix on _migrateItemKeeperNotes to Handle the case when item.data.description is null

## Motivation and Context.

This new feature will add the possibility of importing characters already created on the DholeHouse website.

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
