### PR TITLE
fix #1017 and keep roll mode

### DIFF
--- a/module/check.js
+++ b/module/check.js
@@ -1670,11 +1670,11 @@ export class CoC7Check {
       chatData.whisper = []
       chatData.blind = false
       ChatMessage.applyRollMode(chatData)
-    } else {
-      chatData.whisper = []
-      chatData.blind = false
-      ChatMessage.applyRollMode(chatData, game.settings.get('core', 'rollMode'))
-    }
+    } //else {
+      // chatData.whisper = []
+      // chatData.blind = false
+      // ChatMessage.applyRollMode(chatData, game.settings.get('core', 'rollMode'))
+    //}
 
     if (chatData.blind) {
       this.isBlind = true
@@ -1706,7 +1706,7 @@ export class CoC7Check {
       } else chatData.type = CONST.CHAT_MESSAGE_TYPES.OTHER
     }
 
-    if (forceRoll && this.dice?.roll) {
+    if (forceRoll && this.dice?.roll && (game.user.isGM || !this.isBlind)) {
       await CoC7Dice.showRollDice3d(this.dice.roll)
     }
 


### PR DESCRIPTION
Address issue #1017.
Do not change the RollMode of the message when player click on roll

## Description.

Fix issue where dice were shown to player during blind GM Roll.
Fix issue where a whispered roll chat message was made public when player was clicking on roll.

## Motivation and Context.

https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/issues/1017
## Screenshots.

<!-- If appropriate. -->

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
