### PR TITLE
Devmenu

### DIFF
--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -27,7 +27,7 @@ export class CoC7ActorSheet extends ActorSheet {
     data.editable = this.isEditable // MODIF 0.8.x : editable removed
     /******************/
 
-    data.showHiddenDevMenu = game.settings.get('CoC7', 'hiddendebugmenu')
+    data.showHiddenDevMenu = game.settings.get('CoC7', 'hiddendevmenu')
 
     data.hasToken = !!this.token
     data.canDragToken = data.hasToken && game.user.isGM

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -27,6 +27,8 @@ export class CoC7ActorSheet extends ActorSheet {
     data.editable = this.isEditable // MODIF 0.8.x : editable removed
     /******************/
 
+    data.showHiddenDevMenu = game.settings.get('CoC7', 'hiddendebugmenu')
+
     data.hasToken = !!this.token
     data.canDragToken = data.hasToken && game.user.isGM
     data.linkedActor = this.actor.data?.token?.actorLink
@@ -848,43 +850,13 @@ export class CoC7ActorSheet extends ActorSheet {
       .find('a.coc7-link')
       .on('dragstart', event => CoC7Parser._onDragCoC7Link(event))
 
+    /**
+     * This is used for dev purposes only !
+     */
     html.find('.test-trigger').click(async event => {
-      // await OpposedCheckCard.dispatch({
-      //   type: OpposedCheckCard.defaultConfig.type,
-      //   combat: false,
-      //   action: 'new',
-      //   roll: {
-      //     characteristic: 'str',
-      //     actor: this.actor.actorKey
-      //   }
-      // })
-      // await OpposedCheckCard.dispatch({
-      //   type: OpposedCheckCard.defaultConfig.type,
-      //   combat: false,
-      //   action: 'new',
-      //   roll: {
-      //     characteristic: 'con'
-      // actor: this.actor.actorKey
-      //   }
-      // })
-      // const val = getProperty( this.actor, 'data.data.attribs.san.value');
-      // this.actor.enterBoutOfMadness( true, 10);
-      // const roll = new CoC7Check();
-      // roll.actor = this.actorKey;
-      // roll.attribute = 'san';
-      // roll.difficulty = this.options.sanDifficulty || CoC7Check.difficultyLevel.regular;
-      // roll.diceModifier = this.options.sanModifier || 0;
-      // await roll._perform();
-      // for (const effect of this.actor.effects) {
-      //  await effect.sheet.render(true);
-      //  // effect.delete();
-      // }
-      // for (const e of this.actor.effects) { e.delete() }
-      // await setProperty( this.actor, 'data.data.encounteredCreatures', []);
-      // await this.actor.update( {['data.encounteredCreatures'] : []});
-      // if (event.shiftKey) ui.notifications.info('Shift cliecked')
-      // SanCheckCard.create( this.actor.actorKey, {min:'1D10',max:'1D12'}, {fastForward:event.shiftKey});
+      if(!game.settings.get('CoC7', 'hiddendevmenu')) return
     })
+
     html
       .find('.skill-name.rollable')
       .mouseenter(this.toolTipSkillEnter.bind(this))

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -121,7 +121,10 @@ Hooks.on('renderSettingsConfig', (app, html, options) => {
 })
 
 Hooks.once('init', async function () {
-  if (typeof CONST.COMPATIBILITY_MODES !== 'undefined' && !isNewerVersion(game.version, '10.300')) {
+  if (
+    typeof CONST.COMPATIBILITY_MODES !== 'undefined' &&
+    !isNewerVersion(game.version, '10.300')
+  ) {
     // hide compatibility warnings while we still support v9 and v10 with the same version
     CONFIG.compatibility.mode = CONST.COMPATIBILITY_MODES.SILENT
   }
@@ -134,6 +137,12 @@ Hooks.once('init', async function () {
     },
     cards: {
       DamageCard: DamageCard
+    },
+    dev: {
+      dice: {
+        alwaysCrit: false,
+        alwaysFumble: false
+      }
     }
   }
   Combat.prototype.rollInitiative = rollInitiative

--- a/module/dice.js
+++ b/module/dice.js
@@ -11,9 +11,9 @@ export class CoC7Dice {
       }
     }
     let roll
-    if (game.CoC7.dev.dice.alwaysCrit && game.settings.get('CoC7', 'debugmode')) {
+    if (game.CoC7.dev.dice.alwaysCrit && game.settings.get('CoC7', 'hiddendebugmenu')) {
       roll = Roll.fromData(CoC7Dice.crit01)
-    } else  if (game.CoC7.dev.dice.alwaysFumble && game.settings.get('CoC7', 'debugmode')) {
+    } else  if (game.CoC7.dev.dice.alwaysFumble && game.settings.get('CoC7', 'hiddendebugmenu')) {
       roll = Roll.fromData(CoC7Dice.fumble99)
     }
     else{

--- a/module/dice.js
+++ b/module/dice.js
@@ -10,14 +10,23 @@ export class CoC7Dice {
         alternativeDice = game.settings.get('CoC7', 'tenDieBonus')
       }
     }
-    const roll = await new Roll(
-      '1dt' +
-        (alternativeDice !== ''
-          ? '+1do[' + alternativeDice + ']'
-          : '+1dt'
-        ).repeat(Math.abs(modif)) +
-        '+1d10'
-    ).roll({ async: true })
+    let roll
+    if (game.CoC7.dev.dice.alwaysCrit && game.settings.get('CoC7', 'debugmode')) {
+      roll = Roll.fromData(CoC7Dice.crit01)
+    } else  if (game.CoC7.dev.dice.alwaysFumble && game.settings.get('CoC7', 'debugmode')) {
+      roll = Roll.fromData(CoC7Dice.fumble99)
+    }
+    else{
+      roll = await new Roll(
+        '1dt' +
+          (alternativeDice !== ''
+            ? '+1do[' + alternativeDice + ']'
+            : '+1dt'
+          ).repeat(Math.abs(modif)) +
+          '+1d10'
+      ).roll({ async: true })
+    }
+
     const result = {
       unit: {
         total: 0,
@@ -30,6 +39,7 @@ export class CoC7Dice {
       total: 0,
       roll: roll
     }
+
     if (rollMode) result.rollMode = rollMode
     if (hideDice) result.hideDice = hideDice
     for (const d of roll.dice) {
@@ -172,5 +182,96 @@ export class CoC7Dice {
       output[key].total = output[key].unit.total + output[key].tens.total
     }
     return output
+  }
+
+  // Predetermined value of dice, used only for DEV and test purposes
+  static fumble99 = {
+    class: 'Roll',
+    options: {},
+    dice: [],
+    formula: '1dt + 1d10',
+    terms: [
+      {
+        class: 'CoC7DecaderDie',
+        options: {},
+        evaluated: true,
+        number: 1,
+        faces: 10,
+        modifiers: [],
+        results: [
+          {
+            result: 9,
+            active: true
+          }
+        ]
+      },
+      {
+        class: 'OperatorTerm',
+        options: {},
+        evaluated: true,
+        operator: '+'
+      },
+      {
+        class: 'Die',
+        options: {},
+        evaluated: true,
+        number: 1,
+        faces: 10,
+        modifiers: [],
+        results: [
+          {
+            result: 9,
+            active: true
+          }
+        ]
+      }
+    ],
+    total: 99,
+    evaluated: true
+  }
+
+  static crit01 = {
+    class: 'Roll',
+    options: {},
+    dice: [],
+    formula: '1dt + 1d10',
+    terms: [
+      {
+        class: 'CoC7DecaderDie',
+        options: {},
+        evaluated: true,
+        number: 1,
+        faces: 10,
+        modifiers: [],
+        results: [
+          {
+            result: 10,
+            active: true
+          }
+        ]
+      },
+      {
+        class: 'OperatorTerm',
+        options: {},
+        evaluated: true,
+        operator: '+'
+      },
+      {
+        class: 'Die',
+        options: {},
+        evaluated: true,
+        number: 1,
+        faces: 10,
+        modifiers: [],
+        results: [
+          {
+            result: 1,
+            active: true
+          }
+        ]
+      }
+    ],
+    total: 1,
+    evaluated: true
   }
 }

--- a/module/dice.js
+++ b/module/dice.js
@@ -11,9 +11,9 @@ export class CoC7Dice {
       }
     }
     let roll
-    if (game.CoC7.dev.dice.alwaysCrit && game.settings.get('CoC7', 'hiddendebugmenu')) {
+    if (game.CoC7.dev.dice.alwaysCrit && game.settings.get('CoC7', 'hiddendevmenu')) {
       roll = Roll.fromData(CoC7Dice.crit01)
-    } else  if (game.CoC7.dev.dice.alwaysFumble && game.settings.get('CoC7', 'hiddendebugmenu')) {
+    } else  if (game.CoC7.dev.dice.alwaysFumble && game.settings.get('CoC7', 'hiddendevmenu')) {
       roll = Roll.fromData(CoC7Dice.fumble99)
     }
     else{

--- a/module/menu.js
+++ b/module/menu.js
@@ -30,6 +30,7 @@ export class CoC7Menu {
   static getButtons (controls) {
     canvas.coc7gmtools = new CoC7MenuLayer()
     const isGM = game.user.isGM
+    const isDev = game.settings.get('CoC7', 'debugmode')
     controls.push({
       name: 'coc7menu',
       title: 'CoC7.GmTools',
@@ -86,6 +87,41 @@ export class CoC7Menu {
         }
       ]
     })
+    if (isDev) {
+      canvas.coc7DevTools = new CoC7MenuLayer()
+      controls.push({
+        name: 'coc7DevMenu',
+        title:
+          "Dev tools. If you don't know what it is, you don't need it and you shouldn't use it !!",
+        layer: 'coc7DevTools',
+        icon: 'game-icon game-icon-police-badge',
+        visible: isGM,
+        tools: [
+          {
+            toggle: true,
+            icon: 'game-icon game-icon-dice-fire',
+            name: 'alwaysCrit',
+            active: game.CoC7.dev.dice.alwaysCrit,
+            title: 'All rolls will crit',
+            onClick: toggle => {
+              game.CoC7.dev.dice.alwaysFumble = false
+              game.CoC7.dev.dice.alwaysCrit = toggle
+            }
+          },
+          {
+            toggle: true,
+            icon: 'game-icon game-icon-fire-extinguisher',
+            name: 'alwaysFumble',
+            active: game.CoC7.dev.dice.alwaysFumble,
+            title: 'All rolls will fumble',
+            onClick: toggle => {
+              game.CoC7.dev.dice.alwaysFumble = toggle
+              game.CoC7.dev.dice.alwaysCrit = false
+            }
+          }
+        ]
+      })
+    }
   }
 
   static renderControls (app, html, data) {

--- a/module/menu.js
+++ b/module/menu.js
@@ -30,7 +30,7 @@ export class CoC7Menu {
   static getButtons (controls) {
     canvas.coc7gmtools = new CoC7MenuLayer()
     const isGM = game.user.isGM
-    const showHiddenDevMenu = game.settings.get('CoC7', 'hiddendebugmenu')
+    const showHiddenDevMenu = game.settings.get('CoC7', 'hiddendevmenu')
     controls.push({
       name: 'coc7menu',
       title: 'CoC7.GmTools',

--- a/module/menu.js
+++ b/module/menu.js
@@ -30,7 +30,7 @@ export class CoC7Menu {
   static getButtons (controls) {
     canvas.coc7gmtools = new CoC7MenuLayer()
     const isGM = game.user.isGM
-    const isDev = game.settings.get('CoC7', 'debugmode')
+    const showHiddenDevMenu = game.settings.get('CoC7', 'hiddendebugmenu')
     controls.push({
       name: 'coc7menu',
       title: 'CoC7.GmTools',
@@ -87,7 +87,7 @@ export class CoC7Menu {
         }
       ]
     })
-    if (isDev) {
+    if (showHiddenDevMenu) {
       canvas.coc7DevTools = new CoC7MenuLayer()
       controls.push({
         name: 'coc7DevMenu',

--- a/module/scripts/register-settings.js
+++ b/module/scripts/register-settings.js
@@ -451,7 +451,7 @@ export function registerSettings () {
   /**
    * Other settings
    */
-   game.settings.register('CoC7', 'hiddendebugmenu', {
+   game.settings.register('CoC7', 'hiddendevmenu', {
     name: 'Hidden dev menu',
     hint: 'Use at your own risk',
     scope: 'world',

--- a/module/scripts/register-settings.js
+++ b/module/scripts/register-settings.js
@@ -435,7 +435,7 @@ export function registerSettings () {
   game.settings.register('CoC7', 'debugmode', {
     name: 'SETTINGS.DebugMode',
     hint: 'SETTINGS.DebugModeHint',
-    scope: 'world',
+    scope: 'client',
     config: true,
     type: Boolean,
     default: false
@@ -451,6 +451,14 @@ export function registerSettings () {
   /**
    * Other settings
    */
+   game.settings.register('CoC7', 'hiddendebugmenu', {
+    name: 'Hidden dev menu',
+    hint: 'Use at your own risk',
+    scope: 'world',
+    config: false,
+    type: Boolean,
+    default: false
+  })
   game.settings.register('CoC7', 'developmentEnabled', {
     name: 'Dev phased allowed',
     scope: 'world',

--- a/styles/dev.less
+++ b/styles/dev.less
@@ -1,0 +1,6 @@
+.floating-debug {
+    position: absolute;
+    left: -40px;
+    color: darkred;
+    font-size: 2rem;
+}

--- a/styles/system/index.less
+++ b/styles/system/index.less
@@ -32,3 +32,4 @@
 @import '../sheets/summary.less';
 @import 'tooltips.less';
 @import 'compendiums.less';
+@import '../dev.less';

--- a/templates/actors/character-sheet-v2.html
+++ b/templates/actors/character-sheet-v2.html
@@ -1,4 +1,10 @@
 <form class="{{cssClass}} flexcol {{#if permissionLimited}}permission-limited{{/if}}" autocomplete="off" data-actor-id="{{actor.id}}" {{#if tokenId}}data-token-id="{{tokenId}}" {{/if}}>
+  {{#if showHiddenDevMenu}}
+  <div class="floating-debug">
+    <a class="test-trigger" title='Test Icon, if you see that and do not know why, then you should not click it'>
+      <i class="game-icon game-icon-test-tubes"></i></a>
+  </div>
+  {{/if}}
   {{#unless permissionLimited}}
   <div class="token-extras">
 	{{#if canDragToken}}


### PR DESCRIPTION
Hidden dev menu

## Description.

This allows for some hidden dev specifics menu.
to show the menus execute: game.settings.set('CoC7', 'hiddendevmenu', true)
to hide the menus execute: game.settings.set('CoC7', 'hiddendevmenu', false)
and refresh.
This will show an additional menu on the left side to allow forcing of fumbles and crits on all dice rolls.
This add a button on sheet to call a test function.

## Motivation and Context.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->

## Screenshots.

![image](https://user-images.githubusercontent.com/65915923/182140449-e9d6fca1-1209-46b0-9957-237ebc50495e.png)
![image](https://user-images.githubusercontent.com/65915923/182140482-649bdbd2-8edf-43ae-b721-88cbee57a65b.png)


## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Other
