### PR TITLE
San refactor onefifth

### DIFF
--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -101,6 +101,19 @@ export class CoCActor extends Actor {
       }
     }
 
+    /**
+     * Removal of 1/5 sanity 
+     * this is to remove the 
+    */
+    if (!this.data.data.attribs.san.dailyLimit) {
+      if (this.data.data.attribs.san.oneFifthSanity) {
+        const s = this.data.data.attribs.san.oneFifthSanity.split('/')
+        if (s[1] && !isNaN(Number(s[1])))
+          this.data.data.attribs.san.dailyLimit = Number(s[1])
+        else this.data.data.attribs.san.dailyLimit = 0
+      } else this.data.data.attribs.san.dailyLimit = 0
+    }
+
     // return computed values or fixed values if not auto.
     // this.data.data.attribs.mov.rawValue = this.mov
     // this.data.data.attribs.db.rawValue = this.db
@@ -152,14 +165,14 @@ export class CoCActor extends Actor {
     this.data.data.attribs.build.value = this.build
 
     this.data.data.attribs.hp.max = this.hpMax
-    if( this.hp === null) this.data.data.attribs.hp.value = this.hpMax
+    if (this.hp === null) this.data.data.attribs.hp.value = this.hpMax
     // if( this.hpMax && this.hpMax < this.hp) this.data.data.attribs.hp.value = this.hpMax
 
     this.data.data.attribs.mp.max = this.mpMax
-    if( this.mp === null) this.data.data.attribs.mp.value = this.mpMax
+    if (this.mp === null) this.data.data.attribs.mp.value = this.mpMax
 
     this.data.data.attribs.san.max = this.sanMax
-    if( this.san === null) this.data.data.attribs.san.value = this.sanMax
+    if (this.san === null) this.data.data.attribs.san.value = this.sanMax
 
     //Apply effects to those value.
     const filterMatrix = [
@@ -1067,7 +1080,9 @@ export class CoCActor extends Actor {
               if (data.data.characteristics.values.pow) {
                 updateData['data.attribs.san.value'] =
                   data.data.characteristics.values.pow
-                updateData['data.attribs.san.dailyLimit'] = Math.floor(data.data.characteristics.values.pow / 5)
+                updateData['data.attribs.san.dailyLimit'] = Math.floor(
+                  data.data.characteristics.values.pow / 5
+                )
                 updateData['data.attribs.mp.max'] = Math.floor(
                   data.data.characteristics.values.pow / 5
                 )
@@ -1624,11 +1639,10 @@ export class CoCActor extends Actor {
 
   async setHp (value) {
     if (value < 0) value = 0
-    if (value > this.data.data.attribs.hp.max){
+    if (value > this.data.data.attribs.hp.max) {
       value = parseInt(this.data.data.attribs.hp.max)
     }
     return await this.update({ 'data.attribs.hp.value': value })
-    
   }
 
   async addUniqueItems (skillList, flag = null) {
@@ -1845,7 +1859,8 @@ export class CoCActor extends Actor {
 
   async setMp (value) {
     if (value < 0) value = 0
-    if (value > parseInt(this.data.data.attribs.mp.max)) value = parseInt(this.data.data.attribs.mp.max)
+    if (value > parseInt(this.data.data.attribs.mp.max))
+      value = parseInt(this.data.data.attribs.mp.max)
     return await this.update({ 'data.attribs.mp.value': value })
   }
 
@@ -1954,16 +1969,18 @@ export class CoCActor extends Actor {
 
   async setSan (value) {
     if (value < 0) value = 0
-    if (value > this.data.data.attribs.san.max) value = this.data.data.attribs.san.max
+    if (value > this.data.data.attribs.san.max)
+      value = this.data.data.attribs.san.max
     const loss = parseInt(this.data.data.attribs.san.value) - value
 
-    if( !this.data.data.attribs.san.dailyLimit){
-      if( this.data.data.attribs.san.oneFifthSanity){
-        const s = this.data.data.attribs.san.oneFifthSanity.split('/')
-        if( s[1] && !isNaN(Number(s[1]))) this.data.data.attribs.san.dailyLimit = Number(s[1])
-        else this.data.data.attribs.san.dailyLimit = 0
-      } else this.data.data.attribs.san.dailyLimit = 0
-    }
+    // if (!this.data.data.attribs.san.dailyLimit) {
+    //   if (this.data.data.attribs.san.oneFifthSanity) {
+    //     const s = this.data.data.attribs.san.oneFifthSanity.split('/')
+    //     if (s[1] && !isNaN(Number(s[1])))
+    //       this.data.data.attribs.san.dailyLimit = Number(s[1])
+    //     else this.data.data.attribs.san.dailyLimit = 0
+    //   } else this.data.data.attribs.san.dailyLimit = 0
+    // }
 
     if (loss > 0) {
       let totalLoss = parseInt(this.data.data.attribs.san.dailyLoss)
@@ -3080,7 +3097,11 @@ export class CoCActor extends Actor {
   }
 
   async setOneFifthSanity () {
-    await this.update({ 'data.attribs.san.dailyLimit': Math.floor(this.data.data.attribs.san.value / 5) })
+    await this.update({
+      'data.attribs.san.dailyLimit': Math.floor(
+        this.data.data.attribs.san.value / 5
+      )
+    })
   }
 
   get fightingSkills () {
@@ -3265,7 +3286,9 @@ export class CoCActor extends Actor {
       const healthBefore = parseInt(
         event.originalEvent.currentTarget.defaultValue
       )
-      const healthAfter = parseInt(event.originalEvent.currentTarget.value) || this.data.data.attribs.hp.max
+      const healthAfter =
+        parseInt(event.originalEvent.currentTarget.value) ||
+        this.data.data.attribs.hp.max
       let damageTaken
       // is healing
       if (healthAfter > healthBefore) return await this.setHp(healthAfter)

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -558,15 +558,15 @@ export class CoC7ActorSheet extends ActorSheet {
     // }
 
     if (!['vehicle'].includes(this.actor.data.type)) {
-      if (
-        data.data.attribs.san.value == null &&
-        data.data.characteristics.pow.value != null
-      ) {
-        data.data.attribs.san.value = data.data.characteristics.pow.value
-      }
-      if (data.data.attribs.san.value > data.data.attribs.san.max) {
-        data.data.attribs.san.value = data.data.attribs.san.max
-      }
+      // if (
+      //   data.data.attribs.san.value == null &&
+      //   data.data.characteristics.pow.value != null
+      // ) {
+      //   data.data.attribs.san.value = data.data.characteristics.pow.value
+      // }
+      // if (data.data.attribs.san.value > data.data.attribs.san.max) {
+      //   data.data.attribs.san.value = data.data.attribs.san.max
+      // }
 
       if (data.data.biography instanceof Array && data.data.biography.length) {
         data.data.biography[0].isFirst = true
@@ -910,8 +910,9 @@ export class CoC7ActorSheet extends ActorSheet {
           typeof game.CoC7Tooltips.ToolTipHover !== 'undefined' &&
           game.CoC7Tooltips.ToolTipHover !== null
         ) {
-          const isCombat =
-            game.CoC7Tooltips.ToolTipHover.classList?.contains('combat')
+          const isCombat = game.CoC7Tooltips.ToolTipHover.classList?.contains(
+            'combat'
+          )
           const item = game.CoC7Tooltips.ToolTipHover.closest('.item')
           if (typeof item !== 'undefined') {
             const skillId = item.dataset.skillId
@@ -933,8 +934,8 @@ export class CoC7ActorSheet extends ActorSheet {
                     game.settings.get('CoC7', 'stanbyGMRolls') &&
                     sheet.actor.hasPlayerOwner
                       ? game.i18n.format('CoC7.ToolTipKeeperStandbySkill', {
-                        name: sheet.actor.name
-                      })
+                          name: sheet.actor.name
+                        })
                       : ''
                 })
             }
@@ -973,8 +974,8 @@ export class CoC7ActorSheet extends ActorSheet {
                     game.settings.get('CoC7', 'stanbyGMRolls') &&
                     sheet.actor.hasPlayerOwner
                       ? game.i18n.format('CoC7.ToolTipKeeperStandbySkill', {
-                        name: sheet.actor.name
-                      })
+                          name: sheet.actor.name
+                        })
                       : ''
                 })
             }
@@ -1016,8 +1017,8 @@ export class CoC7ActorSheet extends ActorSheet {
                         game.settings.get('CoC7', 'stanbyGMRolls') &&
                         sheet.actor.hasPlayerOwner
                           ? game.i18n.format('CoC7.ToolTipKeeperStandbySkill', {
-                            name: sheet.actor.name
-                          })
+                              name: sheet.actor.name
+                            })
                           : ''
                     })
                 }
@@ -1043,8 +1044,8 @@ export class CoC7ActorSheet extends ActorSheet {
                         (game.settings.get('CoC7', 'stanbyGMRolls') &&
                         sheet.actor.hasPlayerOwner
                           ? game.i18n.format('CoC7.ToolTipKeeperStandbySkill', {
-                            name: sheet.actor.name
-                          })
+                              name: sheet.actor.name
+                            })
                           : '')
                     })
                 }
@@ -1292,8 +1293,7 @@ export class CoC7ActorSheet extends ActorSheet {
   async _onResetCounter (event) {
     event.preventDefault()
     const counter = event.currentTarget.dataset.counter
-    this.actor.setOneFifthSanity()
-    if (counter) this.actor.resetCounter(counter)
+    await this.actor.resetDailySanity()
   }
 
   async _onAutoToggle (event) {
@@ -1831,7 +1831,17 @@ export class CoC7ActorSheet extends ActorSheet {
         if (event.currentTarget.classList.contains('attribute-value')) {
           // TODO : check why SAN only ?
           if (event.currentTarget.name === 'data.attribs.san.value') {
-            this.actor.setSan(parseInt(event.currentTarget.value))
+            const value = await this.actor.setSan(
+              parseInt(event.currentTarget.value)
+            )
+            this.render(true)
+            return
+          }
+          if (event.currentTarget.name === 'data.attribs.hp.value') {
+            const value = await this.actor.setHp(
+              parseInt(event.currentTarget.value)
+            )
+            this.render(true)
             return
           }
         }
@@ -1901,8 +1911,9 @@ export class CoC7ActorSheet extends ActorSheet {
                   value: event.currentTarget.value
                 })
               )
-              formData[event.currentTarget.name] =
-                game.i18n.format('CoC7.ErrorInvalid')
+              formData[event.currentTarget.name] = game.i18n.format(
+                'CoC7.ErrorInvalid'
+              )
             }
           }
         }
@@ -1922,8 +1933,9 @@ export class CoC7ActorSheet extends ActorSheet {
                   value: event.currentTarget.value
                 })
               )
-              formData[event.currentTarget.name] =
-                game.i18n.format('CoC7.ErrorInvalid')
+              formData[event.currentTarget.name] = game.i18n.format(
+                'CoC7.ErrorInvalid'
+              )
             }
           }
         }

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -572,14 +572,6 @@ export class CoC7ActorSheet extends ActorSheet {
         data.data.biography[0].isFirst = true
         data.data.biography[data.data.biography.length - 1].isLast = true
       }
-
-      data.data.indefiniteInsanityLevel = {}
-      data.data.indefiniteInsanityLevel.value = data.data.attribs.san.dailyLoss
-        ? data.data.attribs.san.dailyLoss
-        : 0
-      data.data.indefiniteInsanityLevel.max = Math.floor(
-        data.data.attribs.san.value / 5
-      )
     }
     data.showInventoryItems = false
     data.showInventoryBooks = false
@@ -1300,9 +1292,7 @@ export class CoC7ActorSheet extends ActorSheet {
   async _onResetCounter (event) {
     event.preventDefault()
     const counter = event.currentTarget.dataset.counter
-    const oneFifthSanity =
-      ' / ' + Math.floor(this.actor.data.data.attribs.san.value / 5)
-    this.actor.setOneFifthSanity(oneFifthSanity)
+    this.actor.setOneFifthSanity()
     if (counter) this.actor.resetCounter(counter)
   }
 

--- a/module/actors/sheets/character.js
+++ b/module/actors/sheets/character.js
@@ -243,9 +243,15 @@ export class CoC7CharacterSheet extends CoC7ActorSheet {
         .find('.reset-archetype')
         .click(async () => await this.actor.resetArchetype())
       html.find('.open-item').click(event => this._onItemDetails(event))
-      html
-        .find('[name="data.attribs.hp.value"]')
-        .change(event => this.actor.setHealthStatusManually(event))
+      // html
+      //   .find('[name="data.attribs.hp.value"]')
+      //   .change(async event =>{
+      //     event.preventDefault()
+      //     event.stopPropagation()
+      //     let value = Number( event.currentTarget?.value)
+      //     if( !isNaN(value)) await this.actor.setHp(event)
+      //     else ui.notifications.warn('Error parsing HP value')
+      //   })
       html.find('.toggle-list-mode').click(event => {
         this.toggleSkillListMode(event)
       })

--- a/module/actors/sheets/npc-sheet.js
+++ b/module/actors/sheets/npc-sheet.js
@@ -58,11 +58,11 @@ export class CoC7NPCSheet extends CoC7ActorSheet {
   activateListeners (html) {
     super.activateListeners(html)
     html.find('.roll-san').click(this._onSanCheck.bind(this))
-    if (this.actor.isOwner) {
-      html
-        .find('[name="data.attribs.hp.value"]')
-        .change(event => this.actor.setHealthStatusManually(event))
-    }
+    // if (this.actor.isOwner) {
+    //   html
+    //     .find('[name="data.attribs.hp.value"]')
+    //     .change(event => this.actor.setHealthStatusManually(event))
+    // }
   }
 
   async _onSanCheck (event) {

--- a/module/actors/vehicle/data.js
+++ b/module/actors/vehicle/data.js
@@ -34,6 +34,10 @@ export class CoC7Vehicle extends CoCActor {
     return this.build
   }
 
+  get rawHpMax () {
+    return this.build
+  }
+
   async setHp (value) {
     if (value > this.build) value = this.build
     return await this.update({ 'data.attribs.build.current': value })
@@ -49,5 +53,17 @@ export class CoC7Vehicle extends CoCActor {
 
   get mpMax () {
     return parseInt(this.data.data.attribs?.mp?.max) || 0
+  }
+
+  get rawMpMax () {
+    return parseInt(this.data.data.attribs?.mp?.max) || 0
+  }
+
+  get sanMax () {
+    return null
+  }
+
+  get rawSanMax () {
+    return null
   }
 }

--- a/module/apps/dholehouse_importer.js
+++ b/module/apps/dholehouse_importer.js
@@ -79,7 +79,8 @@ export class CoC7DholeHouseActorImporter {
         attribs: {
           san: {
             value: parseInt(dholeHouseData.Characteristics.Sanity, 10),
-            max: parseInt(dholeHouseData.Characteristics.SanityMax, 10)
+            max: parseInt(dholeHouseData.Characteristics.SanityMax, 10),
+            dailyLimit: Math.floor(dholeHouseData.Characteristics.Sanity / 5)
           },
           hp: {
             value: parseInt(dholeHouseData.Characteristics.HitPts, 10),
@@ -110,9 +111,6 @@ export class CoC7DholeHouseActorImporter {
         biography: backstories.sections,
         description: {
           keeper: game.i18n.localize('CoC7.DholeHouseActorImporterSource')
-        },
-        indefiniteInsanityLevel: {
-          max: Math.floor(dholeHouseData.Characteristics.Sanity / 5)
         }
       },
       skills: await CoC7DholeHouseActorImporter.extractSkills(

--- a/module/chat/cards/san-check.js
+++ b/module/chat/cards/san-check.js
@@ -358,9 +358,15 @@ export class SanCheckCard extends ChatCardActor {
       this.state.intRolled = false
     }
 
-    let oneFifthSanity = this.actor.data.data.attribs.san.oneFifthSanity
-    oneFifthSanity = parseInt(oneFifthSanity.replace(/\D/g, ''))
-    if (this.actor.dailySanLoss >= oneFifthSanity) {
+    /** Removal of 1/5 sanity */
+    if( !this.data.data.attribs.san.dailyLimit){
+      if( this.data.data.attribs.san.oneFifthSanity){
+        const s = this.data.data.attribs.san.oneFifthSanity.split('/')
+        if( s[1] && !isNaN(Number(s[1]))) this.data.data.attribs.san.dailyLimit = Number(s[1])
+        else this.data.data.attribs.san.dailyLimit = 0
+      } else this.data.data.attribs.san.dailyLimit = 0
+    }
+    if (this.actor.dailySanLoss >= this.data.data.attribs.san.dailyLimit) {
       // this.actor.san/5
       this.state.insanity = true
       this.state.intRolled = true

--- a/module/chat/cards/san-check.js
+++ b/module/chat/cards/san-check.js
@@ -358,14 +358,6 @@ export class SanCheckCard extends ChatCardActor {
       this.state.intRolled = false
     }
 
-    /** Removal of 1/5 sanity */
-    if( !this.data.data.attribs.san.dailyLimit){
-      if( this.data.data.attribs.san.oneFifthSanity){
-        const s = this.data.data.attribs.san.oneFifthSanity.split('/')
-        if( s[1] && !isNaN(Number(s[1]))) this.data.data.attribs.san.dailyLimit = Number(s[1])
-        else this.data.data.attribs.san.dailyLimit = 0
-      } else this.data.data.attribs.san.dailyLimit = 0
-    }
     if (this.actor.dailySanLoss >= this.data.data.attribs.san.dailyLimit) {
       // this.actor.san/5
       this.state.insanity = true

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -486,7 +486,7 @@ export class CoC7Utilities {
             )}.</b>`
           actor.update({
             'data.attribs.san.dailyLoss': 0,
-            'data.attribs.san.oneFifthSanity': oneFifthSanity
+            'data.attribs.san.dailyLimit': Math.floor(actor.data.data.attribs.san.value / 5)
           })
         }
         const hours = 7

--- a/styles/sheets/form-applications.less
+++ b/styles/sheets/form-applications.less
@@ -6,6 +6,9 @@
   }
 
   .form-fields {
-    flex: 2
+    flex: 2;
+    .file-picker {
+      flex: 0;
+    }
   }
 }

--- a/styles/sheets/form-applications.less
+++ b/styles/sheets/form-applications.less
@@ -4,4 +4,8 @@
       min-height: 10.5rem;
     }
   }
+
+  .form-fields {
+    flex: 2
+  }
 }

--- a/templates/actors/character/summary.html
+++ b/templates/actors/character/summary.html
@@ -55,8 +55,8 @@
           </div>
           <div class="status">
             <div class="invisible">
-                <input class="locked" type="text" name="data.indefiniteInsanityLevel.value" value="{{data.indefiniteInsanityLevel.value}}" data-dtype="Number" readonly/>
-                <input class="locked" type="text" name="data.indefiniteInsanityLevel.max" value="{{data.indefiniteInsanityLevel.max}}" data-dtype="Number" readonly/>
+                <input class="locked" type="text" name="data.attribs.san.dailyLoss" value="{{data.attribs.san.dailyLoss}}" data-dtype="Number" readonly/>
+                <input class="locked" type="text" name="data.attribs.san.dailyLimit" value="{{data.attribs.san.dailyLimit}}" data-dtype="Number" readonly/>
             </div>
             <a class="condition-monitor {{#if data.conditions.tempoInsane.value}}status-on{{/if}}" title="{{localize 'CoC7.BoutOfMadness'}}{{#if actor.getTempoInsaneDurationText}}: {{actor.getTempoInsaneDurationText}}{{/if}}" data-condition="tempoInsane"><i class="game-icon game-icon-hanging-spider"></i></a>
             <a class="condition-monitor {{#if data.conditions.indefInsane.value}}status-on{{/if}}" title="{{#if data.conditions.indefInsane.value}}{{localize 'CoC7.UnderlyingInsanity'}}{{else}}{{localize 'CoC7.IndefiniteInsanity'}}{{/if}}" data-condition="indefInsane"><i class="game-icon game-icon-tentacles-skull"></i></a>

--- a/templates/actors/parts/vitals.html
+++ b/templates/actors/parts/vitals.html
@@ -54,12 +54,12 @@
             </div>
         </div>
         <div>
-            <label>{{localize 'CoC7.DailyLoss'}}: {{data.attribs.san.dailyLoss}}{{data.attribs.san.oneFifthSanity}}</label>
+            <label>{{localize 'CoC7.DailyLoss'}}: {{data.attribs.san.dailyLoss}}/{{data.attribs.san.dailyLimit}}</label>
         </div>
         <div class="status">
             <div class="invisible">
-                <input class="locked" type="text" name="data.indefiniteInsanityLevel.value" value="{{data.indefiniteInsanityLevel.value}}" data-dtype="Number" readonly/>
-                <input class="locked" type="text" name="data.indefiniteInsanityLevel.max" value="{{data.indefiniteInsanityLevel.max}}" data-dtype="Number" readonly/>
+                <input class="locked" type="text" name="data.attribs.san.dailyLoss" value="{{data.attribs.san.dailyLoss}}" data-dtype="Number" readonly/>
+                <input class="locked" type="text" name="data.attribs.san.dailyLimit" value="{{data.attribs.san.dailyLimit}}" data-dtype="Number" readonly/>
             </div>
             <a class="condition-monitor {{#if data.conditions.tempoInsane.value}}status-on{{/if}}" title="{{localize 'CoC7.BoutOfMadness'}}{{#if actor.getTempoInsaneDurationText}}: {{actor.getTempoInsaneDurationText}}{{/if}}" data-condition="tempoInsane"><i class="game-icon game-icon-hanging-spider"></i></a>
             <a class="condition-monitor {{#if data.conditions.indefInsane.value}}status-on{{/if}}" title="{{#if data.conditions.indefInsane.value}}{{localize 'CoC7.UnderlyingInsanity'}}{{else}}{{localize 'CoC7.IndefiniteInsanity'}}{{/if}}" data-condition="indefInsane"><i class="game-icon game-icon-tentacles-skull"></i></a>


### PR DESCRIPTION
Correct the sanity for effects

## Description.

This allows sanity effect to be implemented.
This removes the need in actors for
- data.attribs.san.oneFifthSanity 
- data.indefiniteInsanityLevel
Both of the are replaced with : 
- data.attribs.san.dailyLimit
Actual limit is still stored in : 
- data.attribs.san.dailyLoss

## Motivation and Context.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->

## Screenshots.

<!-- If appropriate. -->

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
