### PR TITLE
Switch to Standard coding convention to match suggested VS Code extension

### DIFF
--- a/.github/ABANDONED.md
+++ b/.github/ABANDONED.md
@@ -10,8 +10,8 @@ Thank you for being interested in making Call of Cthulhu 7th Edition for Foundry
 
 [es.json](#esjson)
 
-## cn.json
 
+## cn.json
 ```
 "CoC7.ActorIsTokenHint": "Actor is a token",
 "CoC7.ActorDataLinked": "Actor data are linked",
@@ -238,9 +238,7 @@ Thank you for being interested in making Call of Cthulhu 7th Edition for Foundry
 "CoC7.EffectNew": "New effect",
 "CoC7.EffectAppliedCantOverride": "An active effect is applies. You can't modify [{name}]. Deactivate the corresponding effect to modify this value."
 ```
-
 ## cs.json
-
 ```
 "CoC7.Entities.Character": "Character",
 "CoC7.Entities.Container": "Container",
@@ -652,9 +650,7 @@ Thank you for being interested in making Call of Cthulhu 7th Edition for Foundry
 "CoC7.EffectNew": "New effect",
 "CoC7.EffectAppliedCantOverride": "An active effect is applies. You can't modify [{name}]. Deactivate the corresponding effect to modify this value."
 ```
-
 ## de.json
-
 ```
 "CoC7.ActorIsTokenHint": "Actor is a token",
 "CoC7.ActorDataLinked": "Actor data are linked",
@@ -911,9 +907,7 @@ Thank you for being interested in making Call of Cthulhu 7th Edition for Foundry
 "CoC7.EffectNew": "New effect",
 "CoC7.EffectAppliedCantOverride": "An active effect is applies. You can't modify [{name}]. Deactivate the corresponding effect to modify this value."
 ```
-
 ## es.json
-
 ```
 "CoC7.ActorIsTokenHint": "Actor is a token",
 "CoC7.ActorDataLinked": "Actor data are linked",

--- a/.github/TRANSLATIONS.md
+++ b/.github/TRANSLATIONS.md
@@ -6,991 +6,597 @@ The **it** translation is currently up to date
 
 The following translations have been abandoned **cn**, **cs**, **de**, **es**, [are you able to help?](./ABANDONED.md)
 
-| Key                                                                                   |    fr    |    ja    |    ko    |    pl    |  pt-BR   |    sv    |  zh-TW   |
-| :------------------------------------------------------------------------------------ | :------: | :------: | :------: | :------: | :------: | :------: | :------: |
-| **Remaining**:                                                                        | **192**  | **194**  | **193**  | **194**  | **192**  | **192**  | **192**  |
-| [CoC7.ABarrier](#coc7abarrier)                                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.AHazard](#coc7ahazard)                                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ActionCost](#coc7actioncost)                                                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ActionCostOnFail](#coc7actioncostonfail)                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Actions](#coc7actions)                                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ActorDataLinked](#coc7actordatalinked)                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ActorDataNotLinked](#coc7actordatanotlinked)                                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ActorImported](#coc7actorimported)                                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ActorImporterUploadError](#coc7actorimporteruploaderror)                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ActorIsSyntheticActor](#coc7actorissyntheticactor)                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ActorIsTokenHint](#coc7actoristokenhint)                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Add](#coc7add)                                                                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.AddActorToChase](#coc7addactortochase)                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.AddBonusDie](#coc7addbonusdie)                                                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.AddParticipant](#coc7addparticipant)                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.AdjustedMovement](#coc7adjustedmovement)                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.AlreadyEncountered](#coc7alreadyencountered)                                    | &#9989;  | &#x274C; | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#9989;  |
-| [CoC7.AlreadyEncounteredInformation](#coc7alreadyencounteredinformation)              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ArmorIgnored](#coc7armorignored)                                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.AskDamageRoll](#coc7askdamageroll)                                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.AskIntentions](#coc7askintentions)                                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.AskRoll](#coc7askroll)                                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Assist](#coc7assist)                                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.AttemptBreakDown](#coc7attemptbreakdown)                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.AttemptNegotiateObstacle](#coc7attemptnegotiateobstacle)                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Barrier](#coc7barrier)                                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.BeingCautious](#coc7beingcautious)                                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.BeingVeryCautious](#coc7beingverycautious)                                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.BonusDieAssailantReason](#coc7bonusdieassailantreason)                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.BreakDown](#coc7breakdown)                                                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Breakable](#coc7breakable)                                                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Cautious](#coc7cautious)                                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.CautiousApproach](#coc7cautiousapproach)                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Chase.AdjustedMovementShort](#coc7chaseadjustedmovementshort)                   | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Chase.ChasersMax](#coc7chasechasersmax)                                         | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Chase.ChasersMin](#coc7chasechasersmin)                                         | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Chase.CheckName](#coc7chasecheckname)                                           | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Chase.InitiativeShort](#coc7chaseinitiativeshort)                               | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Chase.PreysMax](#coc7chasepreysmax)                                             | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Chase.PreysMin](#coc7chasepreysmin)                                             | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ChaseSetup](#coc7chasesetup)                                                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.CheckFailed](#coc7checkfailed)                                                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.CheckMemoryRepressed](#coc7checkmemoryrepressed)                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.CheckName](#coc7checkname)                                                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.CheckPassed](#coc7checkpassed)                                                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.CleanSkillList](#coc7cleanskilllist)                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.CleanSkillListHint](#coc7cleanskilllisthint)                                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ClearAllConditions](#coc7clearallconditions)                                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ConfirmCut2Chase](#coc7confirmcut2chase)                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ConfirmCut2ChaseHint](#coc7confirmcut2chasehint)                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ConfirmNextChaseRound](#coc7confirmnextchaseround)                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ConfirmNextChaseRoundHint](#coc7confirmnextchaseroundhint)                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ConfirmResetChase](#coc7confirmresetchase)                                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ConfirmResetChaseHint](#coc7confirmresetchasehint)                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ConfirmRestartChase](#coc7confirmrestartchase)                                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ConfirmRestartChaseHint](#coc7confirmrestartchasehint)                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ConsumeBonusDice](#coc7consumebonusdice)                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Create](#coc7create)                                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.CutToTheChase](#coc7cuttothechase)                                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Damage](#coc7damage)                                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.DamageDealTo](#coc7damagedealto)                                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.DamageDealt](#coc7damagedealt)                                                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.DamageOnFail](#coc7damageonfail)                                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.DecreaseMovementAction](#coc7decreasemovementaction)                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.DefinitelyInsane](#coc7definitelyinsane)                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Delete](#coc7delete)                                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.DholeHouseActorImporter](#coc7dholehouseactorimporter)                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.DholeHouseActorImporterSource](#coc7dholehouseactorimportersource)              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.DholeHouseActorImporterSummary](#coc7dholehouseactorimportersummary)            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.DholeHouseImportingName](#coc7dholehouseimportingname)                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.DholeHouseInvalidActor](#coc7dholehouseinvalidactor)                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.DholeHousePickYourJSONFile](#coc7dholehousepickyourjsonfile)                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Disable](#coc7disable)                                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.DoesNotMeetMinimumReqToBeAdded](#coc7doesnotmeetminimumreqtobeadded)            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.DontMoveToLocation](#coc7dontmovetolocation)                                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.DragOnCanvas](#coc7dragoncanvas)                                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Duration](#coc7duration)                                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Edit](#coc7edit)                                                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.EffectAppliedCantOverride](#coc7effectappliedcantoverride)                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.EffectNew](#coc7effectnew)                                                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Enable](#coc7enable)                                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ErrorActorHasNoWeaponNamed](#coc7erroractorhasnoweaponnamed)                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ErrorActorHasTooManyWeaponsNamed](#coc7erroractorhastoomanyweaponsnamed)        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ErrorBeneficiaryAtMaxBonus](#coc7errorbeneficiaryatmaxbonus)                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ErrorEmptyLocationsList](#coc7erroremptylocationslist)                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ErrorEvaluatingDamage](#coc7errorevaluatingdamage)                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ErrorNoTokensSelected](#coc7errornotokensselected)                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ErrorParticipantAtMaxBonus](#coc7errorparticipantatmaxbonus)                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ErrorTokenNotOnScene](#coc7errortokennotonscene)                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ErrorUnableToParseArmorFormula](#coc7errorunabletoparsearmorformula)            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ErrorUnableToParseFormula](#coc7errorunabletoparseformula)                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ErrorUnableToParseSkillFormula](#coc7errorunabletoparseskillformula)            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ErrorUnexpectedSkillsText](#coc7errorunexpectedskillstext)                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ErrorUnexpectedWeaponText](#coc7errorunexpectedweapontext)                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.FINISH](#coc7finish)                                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.FacingObstacle](#coc7facingobstacle)                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.FileUploadError](#coc7fileuploaderror)                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.German](#coc7german)                                                            | &#9989;  | &#9989;  | &#9989;  | &#x274C; | &#9989;  | &#9989;  | &#9989;  |
-| [CoC7.GotLucky](#coc7gotlucky)                                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Hazard](#coc7hazard)                                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.IncludeEscapees](#coc7includeescapees)                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.IncludeLatecomers](#coc7includelatecomers)                                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.IncreaseMovementAction](#coc7increasemovementaction)                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Initialize](#coc7initialize)                                                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Initiative](#coc7initiative)                                                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.InsertLocation](#coc7insertlocation)                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.LocationCoordinate](#coc7locationcoordinate)                                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.LocationInit](#coc7locationinit)                                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.LocationNotEmpty](#coc7locationnotempty)                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Locations](#coc7locations)                                                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.LuckNotEnough](#coc7lucknotenough)                                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.MakeActive](#coc7makeactive)                                                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.MaxPossibleSanLoss](#coc7maxpossiblesanloss)                                    | &#9989;  | &#x274C; | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#9989;  |
-| [CoC7.MessageRollingCharacteristic](#coc7messagerollingcharacteristic)                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Migrate.ErrorActor](#coc7migrateerroractor)                                     | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Migrate.ErrorDocumentPack](#coc7migrateerrordocumentpack)                       | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Migrate.ErrorItem](#coc7migrateerroritem)                                       | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Migrate.ErrorMacro](#coc7migrateerrormacro)                                     | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Migrate.ErrorScene](#coc7migrateerrorscene)                                     | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Migrate.ErrorTable](#coc7migrateerrortable)                                     | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.MoveBackward](#coc7movebackward)                                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.MoveForward](#coc7moveforward)                                                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.MoveToLocation](#coc7movetolocation)                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.MovementAction](#coc7movementaction)                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.NeedMin2Participants](#coc7needmin2participants)                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.NeedRecalculate](#coc7needrecalculate)                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.NeedToRecalculate](#coc7needtorecalculate)                                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Negotiate](#coc7negotiate)                                                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.NextRound](#coc7nextround)                                                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.NoDamageDealt](#coc7nodamagedealt)                                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.NoValidCheck](#coc7novalidcheck)                                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.NoValidSkill](#coc7novalidskill)                                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.NotAllHaveSpeedRoll](#coc7notallhavespeedroll)                                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.NothingToRoll](#coc7nothingtoroll)                                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Obstacle](#coc7obstacle)                                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ObstacleDamage](#coc7obstacledamage)                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ObstacleFail](#coc7obstaclefail)                                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ObstacleFumble](#coc7obstaclefumble)                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ObstacleHasHitPoint](#coc7obstaclehashitpoint)                                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ObstacleName](#coc7obstaclename)                                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ObstaclePassed](#coc7obstaclepassed)                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.OpenObstacleResolutionCard](#coc7openobstacleresolutioncard)                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.OverrideCalc](#coc7overridecalc)                                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ParticipantAlreadyProcessed](#coc7participantalreadyprocessed)                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ParticipantDataMissing](#coc7participantdatamissing)                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ParticipantDropHint](#coc7participantdrophint)                                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ParticipantNotEnoughMovement](#coc7participantnotenoughmovement)                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ParticipantNotFound](#coc7participantnotfound)                                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ParticipantUuidNotFound](#coc7participantuuidnotfound)                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.ParticipantsList](#coc7participantslist)                                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.PenaltyDice](#coc7penaltydice)                                                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.PenaltyDieSelfReason](#coc7penaltydieselfreason)                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.PickDirectory](#coc7pickdirectory)                                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.PlayerMovesToLocation](#coc7playermovestolocation)                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Polish](#coc7polish)                                                            | &#9989;  | &#9989;  | &#9989;  | &#x274C; | &#9989;  | &#9989;  | &#9989;  |
-| [CoC7.ReflectObstacleChanges](#coc7reflectobstaclechanges)                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Remove](#coc7remove)                                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.RemoveBonusDie](#coc7removebonusdie)                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.RemoveLocation](#coc7removelocation)                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.RemoveObstacle](#coc7removeobstacle)                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Reset](#coc7reset)                                                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Restart](#coc7restart)                                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.RollDifficultyCriticalTitle](#coc7rolldifficultycriticaltitle)                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.RollDifficultyExtremeTitle](#coc7rolldifficultyextremetitle)                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.RollDifficultyHardTitle](#coc7rolldifficultyhardtitle)                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.RollDifficultyRegularTitle](#coc7rolldifficultyregulartitle)                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Sane](#coc7sane)                                                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.SelectNewSkill](#coc7selectnewskill)                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Settings.DholeUpload.Directory.Hint](#coc7settingsdholeuploaddirectoryhint)     | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Settings.DholeUpload.Directory.Name](#coc7settingsdholeuploaddirectoryname)     | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.SkillXpGainDisabled](#coc7skillxpgaindisabled)                                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.SomethingInTheWay](#coc7somethingintheway)                                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.SpeedCheck](#coc7speedcheck)                                                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.StartingIndex](#coc7startingindex)                                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.StartingRange](#coc7startingrange)                                              | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.TextFieldInvalidJSON](#coc7textfieldinvalidjson)                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.TooFast](#coc7toofast)                                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.TooSlow](#coc7tooslow)                                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.TryToBreak](#coc7trytobreak)                                                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.TryToGetPastBarriers](#coc7trytogetpastbarriers)                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.TryToNegotiateHazard](#coc7trytonegotiatehazard)                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.UnableToUploadDholeImage](#coc7unabletouploaddholeimage)                        | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.UnarmedWeaponName](#coc7unarmedweaponname)                                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.Update](#coc7update)                                                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.UpgradeSuccessWithLuck](#coc7upgradesuccesswithluck)                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.VehicleChase](#coc7vehiclechase)                                                | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.WaitForPlayerInput](#coc7waitforplayerinput)                                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.WeaponSkillMain](#coc7weaponskillmain)                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.YouLostTime](#coc7youlosttime)                                                  | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.YouTakeNoDamage](#coc7youtakenodamage)                                          | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.YouTakeSomeDamage](#coc7youtakesomedamage)                                      | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.combatCard.automaticSuccess](#coc7combatcardautomaticsuccess)                   | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [CoC7.rangeCombatCard.SurprisedTargetTitle](#coc7rangecombatcardsurprisedtargettitle) | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [SETTINGS.ChaseShowTokenMovement](#settingschaseshowtokenmovement)                    | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [SETTINGS.ChaseShowTokenMovementHint](#settingschaseshowtokenmovementhint)            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-| [SETTINGS.DefaultDifficulty](#settingsdefaultdifficulty)                              | &#9989;  | &#9989;  | &#x274C; | &#9989;  | &#9989;  | &#9989;  | &#9989;  |
-| [SETTINGS.TitleChaseSettings](#settingstitlechasesettings)                            | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; | &#x274C; |
-
+|Key|fr|ja|ko|pl|pt-BR|sv|zh-TW|
+|:---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+|**Remaining**:|**192**|**194**|**193**|**194**|**192**|**192**|**192**|
+|[CoC7.ABarrier](#coc7abarrier)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.AHazard](#coc7ahazard)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ActionCost](#coc7actioncost)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ActionCostOnFail](#coc7actioncostonfail)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Actions](#coc7actions)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ActorDataLinked](#coc7actordatalinked)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ActorDataNotLinked](#coc7actordatanotlinked)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ActorImported](#coc7actorimported)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ActorImporterUploadError](#coc7actorimporteruploaderror)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ActorIsSyntheticActor](#coc7actorissyntheticactor)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ActorIsTokenHint](#coc7actoristokenhint)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Add](#coc7add)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.AddActorToChase](#coc7addactortochase)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.AddBonusDie](#coc7addbonusdie)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.AddParticipant](#coc7addparticipant)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.AdjustedMovement](#coc7adjustedmovement)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.AlreadyEncountered](#coc7alreadyencountered)|&#9989;|&#x274C;|&#9989;|&#9989;|&#9989;|&#9989;|&#9989;|
+|[CoC7.AlreadyEncounteredInformation](#coc7alreadyencounteredinformation)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ArmorIgnored](#coc7armorignored)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.AskDamageRoll](#coc7askdamageroll)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.AskIntentions](#coc7askintentions)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.AskRoll](#coc7askroll)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Assist](#coc7assist)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.AttemptBreakDown](#coc7attemptbreakdown)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.AttemptNegotiateObstacle](#coc7attemptnegotiateobstacle)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Barrier](#coc7barrier)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.BeingCautious](#coc7beingcautious)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.BeingVeryCautious](#coc7beingverycautious)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.BonusDieAssailantReason](#coc7bonusdieassailantreason)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.BreakDown](#coc7breakdown)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Breakable](#coc7breakable)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Cautious](#coc7cautious)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.CautiousApproach](#coc7cautiousapproach)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Chase.AdjustedMovementShort](#coc7chaseadjustedmovementshort)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Chase.ChasersMax](#coc7chasechasersmax)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Chase.ChasersMin](#coc7chasechasersmin)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Chase.CheckName](#coc7chasecheckname)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Chase.InitiativeShort](#coc7chaseinitiativeshort)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Chase.PreysMax](#coc7chasepreysmax)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Chase.PreysMin](#coc7chasepreysmin)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ChaseSetup](#coc7chasesetup)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.CheckFailed](#coc7checkfailed)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.CheckMemoryRepressed](#coc7checkmemoryrepressed)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.CheckName](#coc7checkname)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.CheckPassed](#coc7checkpassed)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.CleanSkillList](#coc7cleanskilllist)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.CleanSkillListHint](#coc7cleanskilllisthint)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ClearAllConditions](#coc7clearallconditions)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ConfirmCut2Chase](#coc7confirmcut2chase)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ConfirmCut2ChaseHint](#coc7confirmcut2chasehint)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ConfirmNextChaseRound](#coc7confirmnextchaseround)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ConfirmNextChaseRoundHint](#coc7confirmnextchaseroundhint)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ConfirmResetChase](#coc7confirmresetchase)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ConfirmResetChaseHint](#coc7confirmresetchasehint)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ConfirmRestartChase](#coc7confirmrestartchase)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ConfirmRestartChaseHint](#coc7confirmrestartchasehint)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ConsumeBonusDice](#coc7consumebonusdice)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Create](#coc7create)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.CutToTheChase](#coc7cuttothechase)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Damage](#coc7damage)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.DamageDealTo](#coc7damagedealto)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.DamageDealt](#coc7damagedealt)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.DamageOnFail](#coc7damageonfail)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.DecreaseMovementAction](#coc7decreasemovementaction)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.DefinitelyInsane](#coc7definitelyinsane)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Delete](#coc7delete)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.DholeHouseActorImporter](#coc7dholehouseactorimporter)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.DholeHouseActorImporterSource](#coc7dholehouseactorimportersource)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.DholeHouseActorImporterSummary](#coc7dholehouseactorimportersummary)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.DholeHouseImportingName](#coc7dholehouseimportingname)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.DholeHouseInvalidActor](#coc7dholehouseinvalidactor)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.DholeHousePickYourJSONFile](#coc7dholehousepickyourjsonfile)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Disable](#coc7disable)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.DoesNotMeetMinimumReqToBeAdded](#coc7doesnotmeetminimumreqtobeadded)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.DontMoveToLocation](#coc7dontmovetolocation)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.DragOnCanvas](#coc7dragoncanvas)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Duration](#coc7duration)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Edit](#coc7edit)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.EffectAppliedCantOverride](#coc7effectappliedcantoverride)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.EffectNew](#coc7effectnew)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Enable](#coc7enable)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ErrorActorHasNoWeaponNamed](#coc7erroractorhasnoweaponnamed)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ErrorActorHasTooManyWeaponsNamed](#coc7erroractorhastoomanyweaponsnamed)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ErrorBeneficiaryAtMaxBonus](#coc7errorbeneficiaryatmaxbonus)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ErrorEmptyLocationsList](#coc7erroremptylocationslist)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ErrorEvaluatingDamage](#coc7errorevaluatingdamage)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ErrorNoTokensSelected](#coc7errornotokensselected)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ErrorParticipantAtMaxBonus](#coc7errorparticipantatmaxbonus)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ErrorTokenNotOnScene](#coc7errortokennotonscene)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ErrorUnableToParseArmorFormula](#coc7errorunabletoparsearmorformula)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ErrorUnableToParseFormula](#coc7errorunabletoparseformula)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ErrorUnableToParseSkillFormula](#coc7errorunabletoparseskillformula)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ErrorUnexpectedSkillsText](#coc7errorunexpectedskillstext)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ErrorUnexpectedWeaponText](#coc7errorunexpectedweapontext)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.FINISH](#coc7finish)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.FacingObstacle](#coc7facingobstacle)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.FileUploadError](#coc7fileuploaderror)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.German](#coc7german)|&#9989;|&#9989;|&#9989;|&#x274C;|&#9989;|&#9989;|&#9989;|
+|[CoC7.GotLucky](#coc7gotlucky)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Hazard](#coc7hazard)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.IncludeEscapees](#coc7includeescapees)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.IncludeLatecomers](#coc7includelatecomers)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.IncreaseMovementAction](#coc7increasemovementaction)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Initialize](#coc7initialize)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Initiative](#coc7initiative)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.InsertLocation](#coc7insertlocation)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.LocationCoordinate](#coc7locationcoordinate)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.LocationInit](#coc7locationinit)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.LocationNotEmpty](#coc7locationnotempty)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Locations](#coc7locations)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.LuckNotEnough](#coc7lucknotenough)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.MakeActive](#coc7makeactive)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.MaxPossibleSanLoss](#coc7maxpossiblesanloss)|&#9989;|&#x274C;|&#9989;|&#9989;|&#9989;|&#9989;|&#9989;|
+|[CoC7.MessageRollingCharacteristic](#coc7messagerollingcharacteristic)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Migrate.ErrorActor](#coc7migrateerroractor)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Migrate.ErrorDocumentPack](#coc7migrateerrordocumentpack)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Migrate.ErrorItem](#coc7migrateerroritem)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Migrate.ErrorMacro](#coc7migrateerrormacro)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Migrate.ErrorScene](#coc7migrateerrorscene)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Migrate.ErrorTable](#coc7migrateerrortable)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.MoveBackward](#coc7movebackward)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.MoveForward](#coc7moveforward)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.MoveToLocation](#coc7movetolocation)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.MovementAction](#coc7movementaction)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.NeedMin2Participants](#coc7needmin2participants)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.NeedRecalculate](#coc7needrecalculate)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.NeedToRecalculate](#coc7needtorecalculate)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Negotiate](#coc7negotiate)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.NextRound](#coc7nextround)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.NoDamageDealt](#coc7nodamagedealt)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.NoValidCheck](#coc7novalidcheck)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.NoValidSkill](#coc7novalidskill)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.NotAllHaveSpeedRoll](#coc7notallhavespeedroll)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.NothingToRoll](#coc7nothingtoroll)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Obstacle](#coc7obstacle)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ObstacleDamage](#coc7obstacledamage)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ObstacleFail](#coc7obstaclefail)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ObstacleFumble](#coc7obstaclefumble)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ObstacleHasHitPoint](#coc7obstaclehashitpoint)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ObstacleName](#coc7obstaclename)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ObstaclePassed](#coc7obstaclepassed)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.OpenObstacleResolutionCard](#coc7openobstacleresolutioncard)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.OverrideCalc](#coc7overridecalc)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ParticipantAlreadyProcessed](#coc7participantalreadyprocessed)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ParticipantDataMissing](#coc7participantdatamissing)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ParticipantDropHint](#coc7participantdrophint)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ParticipantNotEnoughMovement](#coc7participantnotenoughmovement)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ParticipantNotFound](#coc7participantnotfound)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ParticipantUuidNotFound](#coc7participantuuidnotfound)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.ParticipantsList](#coc7participantslist)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.PenaltyDice](#coc7penaltydice)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.PenaltyDieSelfReason](#coc7penaltydieselfreason)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.PickDirectory](#coc7pickdirectory)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.PlayerMovesToLocation](#coc7playermovestolocation)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Polish](#coc7polish)|&#9989;|&#9989;|&#9989;|&#x274C;|&#9989;|&#9989;|&#9989;|
+|[CoC7.ReflectObstacleChanges](#coc7reflectobstaclechanges)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Remove](#coc7remove)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.RemoveBonusDie](#coc7removebonusdie)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.RemoveLocation](#coc7removelocation)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.RemoveObstacle](#coc7removeobstacle)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Reset](#coc7reset)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Restart](#coc7restart)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.RollDifficultyCriticalTitle](#coc7rolldifficultycriticaltitle)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.RollDifficultyExtremeTitle](#coc7rolldifficultyextremetitle)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.RollDifficultyHardTitle](#coc7rolldifficultyhardtitle)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.RollDifficultyRegularTitle](#coc7rolldifficultyregulartitle)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Sane](#coc7sane)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.SelectNewSkill](#coc7selectnewskill)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Settings.DholeUpload.Directory.Hint](#coc7settingsdholeuploaddirectoryhint)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Settings.DholeUpload.Directory.Name](#coc7settingsdholeuploaddirectoryname)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.SkillXpGainDisabled](#coc7skillxpgaindisabled)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.SomethingInTheWay](#coc7somethingintheway)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.SpeedCheck](#coc7speedcheck)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.StartingIndex](#coc7startingindex)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.StartingRange](#coc7startingrange)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.TextFieldInvalidJSON](#coc7textfieldinvalidjson)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.TooFast](#coc7toofast)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.TooSlow](#coc7tooslow)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.TryToBreak](#coc7trytobreak)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.TryToGetPastBarriers](#coc7trytogetpastbarriers)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.TryToNegotiateHazard](#coc7trytonegotiatehazard)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.UnableToUploadDholeImage](#coc7unabletouploaddholeimage)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.UnarmedWeaponName](#coc7unarmedweaponname)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.Update](#coc7update)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.UpgradeSuccessWithLuck](#coc7upgradesuccesswithluck)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.VehicleChase](#coc7vehiclechase)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.WaitForPlayerInput](#coc7waitforplayerinput)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.WeaponSkillMain](#coc7weaponskillmain)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.YouLostTime](#coc7youlosttime)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.YouTakeNoDamage](#coc7youtakenodamage)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.YouTakeSomeDamage](#coc7youtakesomedamage)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.combatCard.automaticSuccess](#coc7combatcardautomaticsuccess)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[CoC7.rangeCombatCard.SurprisedTargetTitle](#coc7rangecombatcardsurprisedtargettitle)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[SETTINGS.ChaseShowTokenMovement](#settingschaseshowtokenmovement)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[SETTINGS.ChaseShowTokenMovementHint](#settingschaseshowtokenmovementhint)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
+|[SETTINGS.DefaultDifficulty](#settingsdefaultdifficulty)|&#9989;|&#9989;|&#x274C;|&#9989;|&#9989;|&#9989;|&#9989;|
+|[SETTINGS.TitleChaseSettings](#settingstitlechasesettings)|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|&#x274C;|
 ##### CoC7.ABarrier
-
-` "CoC7.ABarrier": "a barrier",`
-
+```  "CoC7.ABarrier": "a barrier",```
 ##### CoC7.AHazard
-
-` "CoC7.AHazard": "a hazard",`
-
+```  "CoC7.AHazard": "a hazard",```
 ##### CoC7.ActionCost
-
-` "CoC7.ActionCost": "Action cost",`
-
+```  "CoC7.ActionCost": "Action cost",```
 ##### CoC7.ActionCostOnFail
-
-` "CoC7.ActionCostOnFail": "Toggle action penalty on fail.",`
-
+```  "CoC7.ActionCostOnFail": "Toggle action penalty on fail.",```
 ##### CoC7.Actions
-
-` "CoC7.Actions": "actions:",`
-
+```  "CoC7.Actions": "actions:",```
 ##### CoC7.ActorDataLinked
-
-` "CoC7.ActorDataLinked": "Actor data are linked",`
-
+```  "CoC7.ActorDataLinked": "Actor data are linked",```
 ##### CoC7.ActorDataNotLinked
-
-` "CoC7.ActorDataNotLinked": "Actor data are NOT linked",`
-
+```  "CoC7.ActorDataNotLinked": "Actor data are NOT linked",```
 ##### CoC7.ActorImported
-
-` "CoC7.ActorImported": "New {actorType} imported: {actorName}",`
-
+```  "CoC7.ActorImported": "New {actorType} imported: {actorName}",```
 ##### CoC7.ActorImporterUploadError
-
-` "CoC7.ActorImporterUploadError": "Import stopped, unable to write image",`
-
+```  "CoC7.ActorImporterUploadError": "Import stopped, unable to write image",```
 ##### CoC7.ActorIsSyntheticActor
-
-` "CoC7.ActorIsSyntheticActor": "Actor is a synthetic actor (instance of an actor)",`
-
+```  "CoC7.ActorIsSyntheticActor": "Actor is a synthetic actor (instance of an actor)",```
 ##### CoC7.ActorIsTokenHint
-
-` "CoC7.ActorIsTokenHint": "Actor is a token",`
-
+```  "CoC7.ActorIsTokenHint": "Actor is a token",```
 ##### CoC7.Add
-
-` "CoC7.Add": "Add",`
-
+```  "CoC7.Add": "Add",```
 ##### CoC7.AddActorToChase
-
-` "CoC7.AddActorToChase": "Add an actor to the chase",`
-
+```  "CoC7.AddActorToChase": "Add an actor to the chase",```
 ##### CoC7.AddBonusDie
-
-` "CoC7.AddBonusDie": "Add bonus die",`
-
+```  "CoC7.AddBonusDie": "Add bonus die",```
 ##### CoC7.AddParticipant
-
-` "CoC7.AddParticipant": "Add Participant",`
-
+```  "CoC7.AddParticipant": "Add Participant",```
 ##### CoC7.AdjustedMovement
-
-` "CoC7.AdjustedMovement": "Adjusted movement",`
-
+```  "CoC7.AdjustedMovement": "Adjusted movement",```
 ##### CoC7.AlreadyEncountered
-
-` "CoC7.AlreadyEncountered": "Already encountered",`
-
+```  "CoC7.AlreadyEncountered": "Already encountered",```
 ##### CoC7.AlreadyEncounteredInformation
-
-` "CoC7.AlreadyEncounteredInformation": "Already encountered: {reason} lost {lost}/{max}",`
-
+```  "CoC7.AlreadyEncounteredInformation": "Already encountered: {reason} lost {lost}/{max}",```
 ##### CoC7.ArmorIgnored
-
-` "CoC7.ArmorIgnored": "Armor Ignored",`
-
+```  "CoC7.ArmorIgnored": "Armor Ignored",```
 ##### CoC7.AskDamageRoll
-
-` "CoC7.AskDamageRoll": "Ask damage roll",`
-
+```  "CoC7.AskDamageRoll": "Ask damage roll",```
 ##### CoC7.AskIntentions
-
-` "CoC7.AskIntentions": "What are your intentions ?",`
-
+```  "CoC7.AskIntentions": "What are your intentions ?",```
 ##### CoC7.AskRoll
-
-` "CoC7.AskRoll": "Roll {name} ({value}%)",`
-
+```  "CoC7.AskRoll": "Roll {name} ({value}%)",```
 ##### CoC7.Assist
-
-` "CoC7.Assist": "Assist ally",`
-
+```  "CoC7.Assist": "Assist ally",```
 ##### CoC7.AttemptBreakDown
-
-` "CoC7.AttemptBreakDown": "Attempt to break down !!",`
-
+```  "CoC7.AttemptBreakDown": "Attempt to break down !!",```
 ##### CoC7.AttemptNegotiateObstacle
-
-` "CoC7.AttemptNegotiateObstacle": "Attempt to negotiate that obstacle",`
-
+```  "CoC7.AttemptNegotiateObstacle": "Attempt to negotiate that obstacle",```
 ##### CoC7.Barrier
-
-` "CoC7.Barrier": "Barrier",`
-
+```  "CoC7.Barrier": "Barrier",```
 ##### CoC7.BeingCautious
-
-` "CoC7.BeingCautious": "You elect to take a cautious approach.",`
-
+```  "CoC7.BeingCautious": "You elect to take a cautious approach.",```
 ##### CoC7.BeingVeryCautious
-
-` "CoC7.BeingVeryCautious": "You are being very cautious.",`
-
+```  "CoC7.BeingVeryCautious": "You are being very cautious.",```
 ##### CoC7.BonusDieAssailantReason
-
-` "CoC7.BonusDieAssailantReason": "Add 1 bonus die (assailant is prone, restrained...)",`
-
+```  "CoC7.BonusDieAssailantReason": "Add 1 bonus die (assailant is prone, restrained...)",```
 ##### CoC7.BreakDown
-
-` "CoC7.BreakDown": "Break Down",`
-
+```  "CoC7.BreakDown": "Break Down",```
 ##### CoC7.Breakable
-
-` "CoC7.Breakable": "Breakable",`
-
+```  "CoC7.Breakable": "Breakable",```
 ##### CoC7.Cautious
-
-` "CoC7.Cautious": "Cautious",`
-
+```  "CoC7.Cautious": "Cautious",```
 ##### CoC7.CautiousApproach
-
-` "CoC7.CautiousApproach": "Take cautious approach",`
-
+```  "CoC7.CautiousApproach": "Take cautious approach",```
 ##### CoC7.Chase.AdjustedMovementShort
-
-` "CoC7.Chase.AdjustedMovementShort": "ADJ. MOV: {value}",`
-
+```  "CoC7.Chase.AdjustedMovementShort": "ADJ. MOV: {value}",```
 ##### CoC7.Chase.ChasersMax
-
-` "CoC7.Chase.ChasersMax": "Chasers Max: {value}",`
-
+```  "CoC7.Chase.ChasersMax": "Chasers Max: {value}",```
 ##### CoC7.Chase.ChasersMin
-
-` "CoC7.Chase.ChasersMin": "Chasers Min: {value}",`
-
+```  "CoC7.Chase.ChasersMin": "Chasers Min: {value}",```
 ##### CoC7.Chase.CheckName
-
-` "CoC7.Chase.CheckName": "check name",`
-
+```  "CoC7.Chase.CheckName": "check name",```
 ##### CoC7.Chase.InitiativeShort
-
-` "CoC7.Chase.InitiativeShort": "INIT: {value}",`
-
+```  "CoC7.Chase.InitiativeShort": "INIT: {value}",```
 ##### CoC7.Chase.PreysMax
-
-` "CoC7.Chase.PreysMax": "Preys Max: {value}",`
-
+```  "CoC7.Chase.PreysMax": "Preys Max: {value}",```
 ##### CoC7.Chase.PreysMin
-
-` "CoC7.Chase.PreysMin": "Preys Min: {value}",`
-
+```  "CoC7.Chase.PreysMin": "Preys Min: {value}",```
 ##### CoC7.ChaseSetup
-
-` "CoC7.ChaseSetup": "Chase setup",`
-
+```  "CoC7.ChaseSetup": "Chase setup",```
 ##### CoC7.CheckFailed
-
-` "CoC7.CheckFailed": "Check failed",`
-
+```  "CoC7.CheckFailed": "Check failed",```
 ##### CoC7.CheckMemoryRepressed
-
-` "CoC7.CheckMemoryRepressed": "Memory repressed",`
-
+```  "CoC7.CheckMemoryRepressed": "Memory repressed",```
 ##### CoC7.CheckName
-
-` "CoC7.CheckName": "Check",`
-
+```  "CoC7.CheckName": "Check",```
 ##### CoC7.CheckPassed
-
-` "CoC7.CheckPassed": "Check passed",`
-
+```  "CoC7.CheckPassed": "Check passed",```
 ##### CoC7.CleanSkillList
-
-` "CoC7.CleanSkillList": "Clean skill list",`
-
+```  "CoC7.CleanSkillList": "Clean skill list",```
 ##### CoC7.CleanSkillListHint
-
-` "CoC7.CleanSkillListHint": "<p>This will Clean your skill list by removing specialization from skill name.</p> <p>This will avoid to display skill as : 'specialization(specialization(skill))'</p>",`
-
+```  "CoC7.CleanSkillListHint": "<p>This will Clean your skill list by removing specialization from skill name.</p> <p>This will avoid to display skill as : 'specialization(specialization(skill))'</p>",```
 ##### CoC7.ClearAllConditions
-
-` "CoC7.ClearAllConditions": "Clear All Conditions",`
-
+```  "CoC7.ClearAllConditions": "Clear All Conditions",```
 ##### CoC7.ConfirmCut2Chase
-
-` "CoC7.ConfirmCut2Chase": "Are you ready to cut to the chase ?",`
-
+```  "CoC7.ConfirmCut2Chase": "Are you ready to cut to the chase ?",```
 ##### CoC7.ConfirmCut2ChaseHint
-
-` "CoC7.ConfirmCut2ChaseHint": "This will start the chase and the first chase round.",`
-
+```  "CoC7.ConfirmCut2ChaseHint": "This will start the chase and the first chase round.",```
 ##### CoC7.ConfirmNextChaseRound
-
-` "CoC7.ConfirmNextChaseRound": "Proceed to next round ?",`
-
+```  "CoC7.ConfirmNextChaseRound": "Proceed to next round ?",```
 ##### CoC7.ConfirmNextChaseRoundHint
-
-` "CoC7.ConfirmNextChaseRoundHint": "You still have action available on some actors. Are you sure you want to proceed ?",`
-
+```  "CoC7.ConfirmNextChaseRoundHint": "You still have action available on some actors. Are you sure you want to proceed ?",```
 ##### CoC7.ConfirmResetChase
-
-` "CoC7.ConfirmResetChase": "Do you want to restet the chase ?",`
-
+```  "CoC7.ConfirmResetChase": "Do you want to restet the chase ?",```
 ##### CoC7.ConfirmResetChaseHint
-
-` "CoC7.ConfirmResetChaseHint": "This will reset your chase.All positions and obstacles will be removed.",`
-
+```  "CoC7.ConfirmResetChaseHint": "This will reset your chase.All positions and obstacles will be removed.",```
 ##### CoC7.ConfirmRestartChase
-
-` "CoC7.ConfirmRestartChase": "Do you want to restart the chase ?",`
-
+```  "CoC7.ConfirmRestartChase": "Do you want to restart the chase ?",```
 ##### CoC7.ConfirmRestartChaseHint
-
-` "CoC7.ConfirmRestartChaseHint": "This will restart your chase.\nAll position will be reseted.\nActors that did not rool a speedcheck will have to roll.",`
-
+```  "CoC7.ConfirmRestartChaseHint": "This will restart your chase.\nAll position will be reseted.\nActors that did not rool a speedcheck will have to roll.",```
 ##### CoC7.ConsumeBonusDice
-
-` "CoC7.ConsumeBonusDice": "Consume Bonus Dice",`
-
+```  "CoC7.ConsumeBonusDice": "Consume Bonus Dice",```
 ##### CoC7.Create
-
-` "CoC7.Create": "Create",`
-
+```  "CoC7.Create": "Create",```
 ##### CoC7.CutToTheChase
-
-` "CoC7.CutToTheChase": "Cut to the chase",`
-
+```  "CoC7.CutToTheChase": "Cut to the chase",```
 ##### CoC7.Damage
-
-` "CoC7.Damage": "Damage",`
-
+```  "CoC7.Damage": "Damage",```
 ##### CoC7.DamageDealTo
-
-` "CoC7.DamageDealTo": "Damage {name} {damage}HP",`
-
+```  "CoC7.DamageDealTo": "Damage {name} {damage}HP",```
 ##### CoC7.DamageDealt
-
-` "CoC7.DamageDealt": "You deal {value} damage.",`
-
+```  "CoC7.DamageDealt": "You deal {value} damage.",```
 ##### CoC7.DamageOnFail
-
-` "CoC7.DamageOnFail": "Toggle damage on fail.",`
-
+```  "CoC7.DamageOnFail": "Toggle damage on fail.",```
 ##### CoC7.DecreaseMovementAction
-
-` "CoC7.DecreaseMovementAction": "Decrease movement action",`
-
+```  "CoC7.DecreaseMovementAction": "Decrease movement action",```
 ##### CoC7.DefinitelyInsane
-
-` "CoC7.DefinitelyInsane": "Good for the asylum",`
-
+```  "CoC7.DefinitelyInsane": "Good for the asylum",```
 ##### CoC7.Delete
-
-` "CoC7.Delete": "Delete",`
-
+```  "CoC7.Delete": "Delete",```
 ##### CoC7.DholeHouseActorImporter
-
-` "CoC7.DholeHouseActorImporter": "The Dhole's House Actor Importer JSON",`
-
+```  "CoC7.DholeHouseActorImporter": "The Dhole's House Actor Importer JSON",```
 ##### CoC7.DholeHouseActorImporterSource
-
-` "CoC7.DholeHouseActorImporterSource": "Imported from The Dhole's House Actor",`
-
+```  "CoC7.DholeHouseActorImporterSource": "Imported from The Dhole's House Actor",```
 ##### CoC7.DholeHouseActorImporterSummary
-
-` "CoC7.DholeHouseActorImporterSummary": "Export your DholeHouse's character as JSON and upload it here.",`
-
+```  "CoC7.DholeHouseActorImporterSummary": "Export your DholeHouse's character as JSON and upload it here.",```
 ##### CoC7.DholeHouseImportingName
-
-` "CoC7.DholeHouseImportingName": "About to import: ",`
-
+```  "CoC7.DholeHouseImportingName": "About to import: ",```
 ##### CoC7.DholeHouseInvalidActor
-
-` "CoC7.DholeHouseInvalidActor": "The selected JSON doesn't seem to be a valid Dhole's House exported character",`
-
+```  "CoC7.DholeHouseInvalidActor": "The selected JSON doesn't seem to be a valid Dhole's House exported character",```
 ##### CoC7.DholeHousePickYourJSONFile
-
-` "CoC7.DholeHousePickYourJSONFile": "Pick the JSON file exported from The Dhole's House",`
-
+```  "CoC7.DholeHousePickYourJSONFile": "Pick the JSON file exported from The Dhole's House",```
 ##### CoC7.Disable
-
-` "CoC7.Disable": "Disable",`
-
+```  "CoC7.Disable": "Disable",```
 ##### CoC7.DoesNotMeetMinimumReqToBeAdded
-
-` "CoC7.DoesNotMeetMinimumReqToBeAdded": "Can not add participant, need at least valid movement action",`
-
+```  "CoC7.DoesNotMeetMinimumReqToBeAdded": "Can not add participant, need at least valid movement action",```
 ##### CoC7.DontMoveToLocation
-
-` "CoC7.DontMoveToLocation": "You're staying there !",`
-
+```  "CoC7.DontMoveToLocation": "You're staying there !",```
 ##### CoC7.DragOnCanvas
-
-` "CoC7.DragOnCanvas": "Drag this on canvas to set the position of this location.",`
-
+```  "CoC7.DragOnCanvas": "Drag this on canvas to set the position of this location.",```
 ##### CoC7.Duration
-
-` "CoC7.Duration": "Duration",`
-
+```  "CoC7.Duration": "Duration",```
 ##### CoC7.Edit
-
-` "CoC7.Edit": "Edit",`
-
+```  "CoC7.Edit": "Edit",```
 ##### CoC7.EffectAppliedCantOverride
-
-` "CoC7.EffectAppliedCantOverride": "An active effect is applies. You can't modify [{name}]. Deactivate the corresponding effect to modify this value.",`
-
+```  "CoC7.EffectAppliedCantOverride": "An active effect is applies. You can't modify [{name}]. Deactivate the corresponding effect to modify this value.",```
 ##### CoC7.EffectNew
-
-` "CoC7.EffectNew": "New effect",`
-
+```  "CoC7.EffectNew": "New effect",```
 ##### CoC7.Enable
-
-` "CoC7.Enable": "Enable",`
-
+```  "CoC7.Enable": "Enable",```
 ##### CoC7.ErrorActorHasNoWeaponNamed
-
-` "CoC7.ErrorActorHasNoWeaponNamed": "Actor {actorName} has no weapon named {weaponName}",`
-
+```  "CoC7.ErrorActorHasNoWeaponNamed": "Actor {actorName} has no weapon named {weaponName}",```
 ##### CoC7.ErrorActorHasTooManyWeaponsNamed
-
-`` "CoC7.ErrorActorHasTooManyWeaponsNamed": "`Actor {actorName} has more than one weapon named {weaponName}. The first found will be used`",``
-
+```  "CoC7.ErrorActorHasTooManyWeaponsNamed": "`Actor {actorName} has more than one weapon named {weaponName}. The first found will be used`",```
 ##### CoC7.ErrorBeneficiaryAtMaxBonus
-
-` "CoC7.ErrorBeneficiaryAtMaxBonus": "Beneficiary {name} already has max bonus dice",`
-
+```  "CoC7.ErrorBeneficiaryAtMaxBonus": "Beneficiary {name} already has max bonus dice",```
 ##### CoC7.ErrorEmptyLocationsList
-
-` "CoC7.ErrorEmptyLocationsList": "Empty locations list",`
-
+```  "CoC7.ErrorEmptyLocationsList": "Empty locations list",```
 ##### CoC7.ErrorEvaluatingDamage
-
-` "CoC7.ErrorEvaluatingDamage": "Error evaluating damage",`
-
+```  "CoC7.ErrorEvaluatingDamage": "Error evaluating damage",```
 ##### CoC7.ErrorNoTokensSelected
-
-` "CoC7.ErrorNoTokensSelected": "No tokens selected",`
-
+```  "CoC7.ErrorNoTokensSelected": "No tokens selected",```
 ##### CoC7.ErrorParticipantAtMaxBonus
-
-` "CoC7.ErrorParticipantAtMaxBonus": "{participantUuid} already has max bonus dice",`
-
+```  "CoC7.ErrorParticipantAtMaxBonus": "{participantUuid} already has max bonus dice",```
 ##### CoC7.ErrorTokenNotOnScene
-
-` "CoC7.ErrorTokenNotOnScene": "Token does not belongs to this location's scene",`
-
+```  "CoC7.ErrorTokenNotOnScene": "Token does not belongs to this location's scene",```
 ##### CoC7.ErrorUnableToParseArmorFormula
-
-` "CoC7.ErrorUnableToParseArmorFormula": "Unable to process armor value: {value}. Ignoring armor.",`
-
+```  "CoC7.ErrorUnableToParseArmorFormula": "Unable to process armor value: {value}. Ignoring armor.",```
 ##### CoC7.ErrorUnableToParseFormula
-
-` "CoC7.ErrorUnableToParseFormula": "{value} is not a valid formula",`
-
+```  "CoC7.ErrorUnableToParseFormula": "{value} is not a valid formula",```
 ##### CoC7.ErrorUnableToParseSkillFormula
-
-` "CoC7.ErrorUnableToParseSkillFormula": "Unable to parse formula: {value} for skill {name}",`
-
+```  "CoC7.ErrorUnableToParseSkillFormula": "Unable to parse formula: {value} for skill {name}",```
 ##### CoC7.ErrorUnexpectedSkillsText
-
-` "CoC7.ErrorUnexpectedSkillsText": "Unexpected skills text, please raise a bug report with the text you are attempting to import",`
-
+```  "CoC7.ErrorUnexpectedSkillsText": "Unexpected skills text, please raise a bug report with the text you are attempting to import",```
 ##### CoC7.ErrorUnexpectedWeaponText
-
-` "CoC7.ErrorUnexpectedWeaponText": "Unexpected weapons text, please raise a bug report with the text you are attempting to import",`
-
+```  "CoC7.ErrorUnexpectedWeaponText": "Unexpected weapons text, please raise a bug report with the text you are attempting to import",```
 ##### CoC7.FINISH
-
-` "CoC7.FINISH": "--F-I-N-I-S-H--",`
-
+```  "CoC7.FINISH": "--F-I-N-I-S-H--",```
 ##### CoC7.FacingObstacle
-
-` "CoC7.FacingObstacle": "You are facing {type}.",`
-
+```  "CoC7.FacingObstacle": "You are facing {type}.",```
 ##### CoC7.FileUploadError
-
-` "CoC7.FileUploadError": "Unable to write image, file upload error",`
-
+```  "CoC7.FileUploadError": "Unable to write image, file upload error",```
 ##### CoC7.German
-
-` "CoC7.German": "German",`
-
+```  "CoC7.German": "German",```
 ##### CoC7.GotLucky
-
-` "CoC7.GotLucky": "You got lucky, this time...",`
-
+```  "CoC7.GotLucky": "You got lucky, this time...",```
 ##### CoC7.Hazard
-
-` "CoC7.Hazard": "Hazard",`
-
+```  "CoC7.Hazard": "Hazard",```
 ##### CoC7.IncludeEscapees
-
-` "CoC7.IncludeEscapees": "Let fastest fleeing actors participate.",`
-
+```  "CoC7.IncludeEscapees": "Let fastest fleeing actors participate.",```
 ##### CoC7.IncludeLatecomers
-
-` "CoC7.IncludeLatecomers": "Let slow pursuer participate.",`
-
+```  "CoC7.IncludeLatecomers": "Let slow pursuer participate.",```
 ##### CoC7.IncreaseMovementAction
-
-` "CoC7.IncreaseMovementAction": "Increase movement action",`
-
+```  "CoC7.IncreaseMovementAction": "Increase movement action",```
 ##### CoC7.Initialize
-
-` "CoC7.Initialize": "Initialize",`
-
+```  "CoC7.Initialize": "Initialize",```
 ##### CoC7.Initiative
-
-` "CoC7.Initiative": "Initiative",`
-
+```  "CoC7.Initiative": "Initiative",```
 ##### CoC7.InsertLocation
-
-` "CoC7.InsertLocation": "Insert location",`
-
+```  "CoC7.InsertLocation": "Insert location",```
 ##### CoC7.LocationCoordinate
-
-` "CoC7.LocationCoordinate": "Location set to : {x}, {y}.\nRight click to clear.\nDrag this on canvas to change the position.",`
-
+```  "CoC7.LocationCoordinate": "Location set to : {x}, {y}.\nRight click to clear.\nDrag this on canvas to change the position.",```
 ##### CoC7.LocationInit
-
-` "CoC7.LocationInit": "You can't remove a starting location",`
-
+```  "CoC7.LocationInit": "You can't  remove a starting location",```
 ##### CoC7.LocationNotEmpty
-
-` "CoC7.LocationNotEmpty": "You can't remove a location with an actor",`
-
+```  "CoC7.LocationNotEmpty": "You can't remove a location with an actor",```
 ##### CoC7.Locations
-
-` "CoC7.Locations": "Chase locations",`
-
+```  "CoC7.Locations": "Chase locations",```
 ##### CoC7.LuckNotEnough
-
-` "CoC7.LuckNotEnough": "{name} didn't have enough luck to pass the check",`
-
+```  "CoC7.LuckNotEnough": "{name} didn't have enough luck to pass the check",```
 ##### CoC7.MakeActive
-
-` "CoC7.MakeActive": "Make Active",`
-
+```  "CoC7.MakeActive": "Make Active",```
 ##### CoC7.MaxPossibleSanLoss
-
-` "CoC7.MaxPossibleSanLoss": "Max Possible loss",`
-
+```  "CoC7.MaxPossibleSanLoss": "Max Possible loss",```
 ##### CoC7.MessageRollingCharacteristic
-
-` "CoC7.MessageRollingCharacteristic": "Rolling characteristic {label}: {formula}",`
-
+```  "CoC7.MessageRollingCharacteristic": "Rolling characteristic {label}: {formula}",```
 ##### CoC7.Migrate.ErrorActor
-
-` "CoC7.Migrate.ErrorActor": "Failed CoC7 system migration for Actor {name}: {message}",`
-
+```  "CoC7.Migrate.ErrorActor": "Failed CoC7 system migration for Actor {name}: {message}",```
 ##### CoC7.Migrate.ErrorDocumentPack
-
-` "CoC7.Migrate.ErrorDocumentPack": "Failed CoC7 system migration for document {name} in pack {collection}: {message}",`
-
+```  "CoC7.Migrate.ErrorDocumentPack": "Failed CoC7 system migration for document {name} in pack {collection}: {message}",```
 ##### CoC7.Migrate.ErrorItem
-
-` "CoC7.Migrate.ErrorItem": "Failed CoC7 system migration for Item {name}: {message}",`
-
+```  "CoC7.Migrate.ErrorItem": "Failed CoC7 system migration for Item {name}: {message}",```
 ##### CoC7.Migrate.ErrorMacro
-
-` "CoC7.Migrate.ErrorMacro": "Failed CoC7 system migration for Macro {name}: {message}",`
-
+```  "CoC7.Migrate.ErrorMacro": "Failed CoC7 system migration for Macro {name}: {message}",```
 ##### CoC7.Migrate.ErrorScene
-
-` "CoC7.Migrate.ErrorScene": "Failed CoC7 system migration for Scene {name}: {message}",`
-
+```  "CoC7.Migrate.ErrorScene": "Failed CoC7 system migration for Scene {name}: {message}",```
 ##### CoC7.Migrate.ErrorTable
-
-` "CoC7.Migrate.ErrorTable": "Failed CoC7 system migration for Table {name}: {message}",`
-
+```  "CoC7.Migrate.ErrorTable": "Failed CoC7 system migration for Table {name}: {message}",```
 ##### CoC7.MoveBackward
-
-` "CoC7.MoveBackward": "Go back",`
-
+```  "CoC7.MoveBackward": "Go back",```
 ##### CoC7.MoveForward
-
-` "CoC7.MoveForward": "Move forward",`
-
+```  "CoC7.MoveForward": "Move forward",```
 ##### CoC7.MoveToLocation
-
-` "CoC7.MoveToLocation": "You're moving to the next location.",`
-
+```  "CoC7.MoveToLocation": "You're moving to the next location.",```
 ##### CoC7.MovementAction
-
-` "CoC7.MovementAction": "Movement action",`
-
+```  "CoC7.MovementAction": "Movement action",```
 ##### CoC7.NeedMin2Participants
-
-` "CoC7.NeedMin2Participants": "You need to have a chaser and a prey to start a chase!",`
-
+```  "CoC7.NeedMin2Participants": "You need to have a chaser and a prey to start a chase!",```
 ##### CoC7.NeedRecalculate
-
-` "CoC7.NeedRecalculate": "Recalculation needed",`
-
+```  "CoC7.NeedRecalculate": "Recalculation needed",```
 ##### CoC7.NeedToRecalculate
-
-` "CoC7.NeedToRecalculate": "All participant will have their movement action recalculated",`
-
+```  "CoC7.NeedToRecalculate": "All participant will have their movement action recalculated",```
 ##### CoC7.Negotiate
-
-` "CoC7.Negotiate": "Negotiate",`
-
+```  "CoC7.Negotiate": "Negotiate",```
 ##### CoC7.NextRound
-
-` "CoC7.NextRound": "Next round",`
-
+```  "CoC7.NextRound": "Next round",```
 ##### CoC7.NoDamageDealt
-
-` "CoC7.NoDamageDealt": "No damage dealt",`
-
+```  "CoC7.NoDamageDealt": "No damage dealt",```
 ##### CoC7.NoValidCheck
-
-` "CoC7.NoValidCheck": "No valid check",`
-
+```  "CoC7.NoValidCheck": "No valid check",```
 ##### CoC7.NoValidSkill
-
-` "CoC7.NoValidSkill": "Fake skill",`
-
+```  "CoC7.NoValidSkill": "Fake skill",```
 ##### CoC7.NotAllHaveSpeedRoll
-
-` "CoC7.NotAllHaveSpeedRoll": "Some participants don't have a speed roll!",`
-
+```  "CoC7.NotAllHaveSpeedRoll": "Some participants don't have a speed roll!",```
 ##### CoC7.NothingToRoll
-
-` "CoC7.NothingToRoll": "Nothing to roll!",`
-
+```  "CoC7.NothingToRoll": "Nothing to roll!",```
 ##### CoC7.Obstacle
-
-` "CoC7.Obstacle": "Something in the way",`
-
+```  "CoC7.Obstacle": "Something in the way",```
 ##### CoC7.ObstacleDamage
-
-` "CoC7.ObstacleDamage": "Obstacle damage",`
-
+```  "CoC7.ObstacleDamage": "Obstacle damage",```
 ##### CoC7.ObstacleFail
-
-` "CoC7.ObstacleFail": "You fail.",`
-
+```  "CoC7.ObstacleFail": "You fail.",```
 ##### CoC7.ObstacleFumble
-
-` "CoC7.ObstacleFumble": "You fail misarably !",`
-
+```  "CoC7.ObstacleFumble": "You fail misarably !",```
 ##### CoC7.ObstacleHasHitPoint
-
-` "CoC7.ObstacleHasHitPoint": "Toggle location's hit points.",`
-
+```  "CoC7.ObstacleHasHitPoint": "Toggle location's hit points.",```
 ##### CoC7.ObstacleName
-
-` "CoC7.ObstacleName": "Obstacle name:",`
-
+```  "CoC7.ObstacleName": "Obstacle name:",```
 ##### CoC7.ObstaclePassed
-
-` "CoC7.ObstaclePassed": "You succeesfully found a way.",`
-
+```  "CoC7.ObstaclePassed": "You succeesfully found a way.",```
 ##### CoC7.OpenObstacleResolutionCard
-
-` "CoC7.OpenObstacleResolutionCard": "Start obstacle resolution flow card.",`
-
+```  "CoC7.OpenObstacleResolutionCard": "Start obstacle resolution flow card.",```
 ##### CoC7.OverrideCalc
-
-` "CoC7.OverrideCalc": "Override calculation",`
-
+```  "CoC7.OverrideCalc": "Override calculation",```
 ##### CoC7.ParticipantAlreadyProcessed
-
-` "CoC7.ParticipantAlreadyProcessed": "Participant was already processed.",`
-
+```  "CoC7.ParticipantAlreadyProcessed": "Participant was already processed.",```
 ##### CoC7.ParticipantDataMissing
-
-` "CoC7.ParticipantDataMissing": "Participant data missing",`
-
+```  "CoC7.ParticipantDataMissing": "Participant data missing",```
 ##### CoC7.ParticipantDropHint
-
-` "CoC7.ParticipantDropHint": "You can drop and actor on this window or directly on a chase location.",`
-
+```  "CoC7.ParticipantDropHint": "You can drop and actor on this window or directly on a chase location.",```
 ##### CoC7.ParticipantNotEnoughMovement
-
-` "CoC7.ParticipantNotEnoughMovement": "Particpant {assistantUuid} only has {actions} movement actions",`
-
+```  "CoC7.ParticipantNotEnoughMovement": "Particpant {assistantUuid} only has {actions} movement actions",```
 ##### CoC7.ParticipantNotFound
-
-` "CoC7.ParticipantNotFound": "Cannot find participant",`
-
+```  "CoC7.ParticipantNotFound": "Cannot find participant",```
 ##### CoC7.ParticipantUuidNotFound
-
-` "CoC7.ParticipantUuidNotFound": "Cannot find participant {participantUuid}",`
-
+```  "CoC7.ParticipantUuidNotFound": "Cannot find participant {participantUuid}",```
 ##### CoC7.ParticipantsList
-
-` "CoC7.ParticipantsList": "Participants list",`
-
+```  "CoC7.ParticipantsList": "Participants list",```
 ##### CoC7.PenaltyDice
-
-` "CoC7.PenaltyDice": "Penalty Dice",`
-
+```  "CoC7.PenaltyDice": "Penalty Dice",```
 ##### CoC7.PenaltyDieSelfReason
-
-` "CoC7.PenaltyDieSelfReason": "Add 1 penalty die (for being prone, restrained...)",`
-
+```  "CoC7.PenaltyDieSelfReason": "Add 1 penalty die (for being prone, restrained...)",```
 ##### CoC7.PickDirectory
-
-` "CoC7.PickDirectory": "Pick Directory",`
-
+```  "CoC7.PickDirectory": "Pick Directory",```
 ##### CoC7.PlayerMovesToLocation
-
-` "CoC7.PlayerMovesToLocation": "PLayer is moving to the next location",`
-
+```  "CoC7.PlayerMovesToLocation": "PLayer is moving to the next location",```
 ##### CoC7.Polish
-
-` "CoC7.Polish": "Polish",`
-
+```  "CoC7.Polish": "Polish",```
 ##### CoC7.ReflectObstacleChanges
-
-` "CoC7.ReflectObstacleChanges": "Reflect changes to obstacle",`
-
+```  "CoC7.ReflectObstacleChanges": "Reflect changes to obstacle",```
 ##### CoC7.Remove
-
-` "CoC7.Remove": "Remove",`
-
+```  "CoC7.Remove": "Remove",```
 ##### CoC7.RemoveBonusDie
-
-` "CoC7.RemoveBonusDie": "Remove bonus die",`
-
+```  "CoC7.RemoveBonusDie": "Remove bonus die",```
 ##### CoC7.RemoveLocation
-
-` "CoC7.RemoveLocation": "Remove location",`
-
+```  "CoC7.RemoveLocation": "Remove location",```
 ##### CoC7.RemoveObstacle
-
-` "CoC7.RemoveObstacle": "Destroy Obstacle",`
-
+```  "CoC7.RemoveObstacle": "Destroy Obstacle",```
 ##### CoC7.Reset
-
-` "CoC7.Reset": "Reset",`
-
+```  "CoC7.Reset": "Reset",```
 ##### CoC7.Restart
-
-` "CoC7.Restart": "Restart",`
-
+```  "CoC7.Restart": "Restart",```
 ##### CoC7.RollDifficultyCriticalTitle
-
-` "CoC7.RollDifficultyCriticalTitle": "Critical difficulty",`
-
+```  "CoC7.RollDifficultyCriticalTitle": "Critical difficulty",```
 ##### CoC7.RollDifficultyExtremeTitle
-
-` "CoC7.RollDifficultyExtremeTitle": "Extreme difficulty",`
-
+```  "CoC7.RollDifficultyExtremeTitle": "Extreme difficulty",```
 ##### CoC7.RollDifficultyHardTitle
-
-` "CoC7.RollDifficultyHardTitle": "Hard difficulty",`
-
+```  "CoC7.RollDifficultyHardTitle": "Hard difficulty",```
 ##### CoC7.RollDifficultyRegularTitle
-
-` "CoC7.RollDifficultyRegularTitle": "Regular difficulty",`
-
+```  "CoC7.RollDifficultyRegularTitle": "Regular difficulty",```
 ##### CoC7.Sane
-
-` "CoC7.Sane": "Sane",`
-
+```  "CoC7.Sane": "Sane",```
 ##### CoC7.SelectNewSkill
-
-` "CoC7.SelectNewSkill": "Select skill",`
-
+```  "CoC7.SelectNewSkill": "Select skill",```
 ##### CoC7.Settings.DholeUpload.Directory.Hint
-
-` "CoC7.Settings.DholeUpload.Directory.Hint": "Upload path for The Dhole's House avatars, relative to the Foundry/Data directory.",`
-
+```  "CoC7.Settings.DholeUpload.Directory.Hint": "Upload path for The Dhole's House avatars, relative to the Foundry/Data directory.",```
 ##### CoC7.Settings.DholeUpload.Directory.Name
-
-` "CoC7.Settings.DholeUpload.Directory.Name": "The Dhole's House image upload directory",`
-
+```  "CoC7.Settings.DholeUpload.Directory.Name": "The Dhole's House image upload directory",```
 ##### CoC7.SkillXpGainDisabled
-
-` "CoC7.SkillXpGainDisabled": "XP Gain disabled.",`
-
+```  "CoC7.SkillXpGainDisabled": "XP Gain disabled.",```
 ##### CoC7.SomethingInTheWay
-
-` "CoC7.SomethingInTheWay": "There is something in the way",`
-
+```  "CoC7.SomethingInTheWay": "There is something in the way",```
 ##### CoC7.SpeedCheck
-
-` "CoC7.SpeedCheck": "Speed check",`
-
+```  "CoC7.SpeedCheck": "Speed check",```
 ##### CoC7.StartingIndex
-
-` "CoC7.StartingIndex": "Starting index of fleeing actors",`
-
+```  "CoC7.StartingIndex": "Starting index of fleeing actors",```
 ##### CoC7.StartingRange
-
-` "CoC7.StartingRange": "Starting locations advance",`
-
+```  "CoC7.StartingRange": "Starting locations advance",```
 ##### CoC7.TextFieldInvalidJSON
-
-` "CoC7.TextFieldInvalidJSON": "Unable to parse the JSON, please try again",`
-
+```  "CoC7.TextFieldInvalidJSON": "Unable to parse the JSON, please try again",```
 ##### CoC7.TooFast
-
-` "CoC7.TooFast": "Too fast",`
-
+```  "CoC7.TooFast": "Too fast",```
 ##### CoC7.TooSlow
-
-` "CoC7.TooSlow": "Too slow",`
-
+```  "CoC7.TooSlow": "Too slow",```
 ##### CoC7.TryToBreak
-
-` "CoC7.TryToBreak": "You try to break down that barrier.",`
-
+```  "CoC7.TryToBreak": "You try to break down that barrier.",```
 ##### CoC7.TryToGetPastBarriers
-
-` "CoC7.TryToGetPastBarriers": "You try to get past that barrier.",`
-
+```  "CoC7.TryToGetPastBarriers": "You try to get past that barrier.",```
 ##### CoC7.TryToNegotiateHazard
-
-` "CoC7.TryToNegotiateHazard": "You try to negotiate that hazard.",`
-
+```  "CoC7.TryToNegotiateHazard": "You try to negotiate that hazard.",```
 ##### CoC7.UnableToUploadDholeImage
-
-` "CoC7.UnableToUploadDholeImage": "You do not have permission to upload images, if you import the default avatar will be used.",`
-
+```  "CoC7.UnableToUploadDholeImage": "You do not have permission to upload images, if you import the default avatar will be used.",```
 ##### CoC7.UnarmedWeaponName
-
-` "CoC7.UnarmedWeaponName": "Unarmed",`
-
+```  "CoC7.UnarmedWeaponName": "Unarmed",```
 ##### CoC7.Update
-
-` "CoC7.Update": "Update",`
-
+```  "CoC7.Update": "Update",```
 ##### CoC7.UpgradeSuccessWithLuck
-
-` "CoC7.UpgradeSuccessWithLuck": "Upgrade to {{difficultyName}} success for {{luckToSpend}} luck.",`
-
+```  "CoC7.UpgradeSuccessWithLuck": "Upgrade to {{difficultyName}} success for {{luckToSpend}} luck.",```
 ##### CoC7.VehicleChase
-
-` "CoC7.VehicleChase": "Chase can include vehicle (NOT IMPLEMENTED)",`
-
+```  "CoC7.VehicleChase": "Chase can include vehicle (NOT IMPLEMENTED)",```
 ##### CoC7.WaitForPlayerInput
-
-` "CoC7.WaitForPlayerInput": "Wait for player's input",`
-
+```  "CoC7.WaitForPlayerInput": "Wait for player's input",```
 ##### CoC7.WeaponSkillMain
-
-` "CoC7.WeaponSkillMain": "Main skill",`
-
+```  "CoC7.WeaponSkillMain": "Main skill",```
 ##### CoC7.YouLostTime
-
-` "CoC7.YouLostTime": "You lost time in your attempt.",`
-
+```  "CoC7.YouLostTime": "You lost time in your attempt.",```
 ##### CoC7.YouTakeNoDamage
-
-` "CoC7.YouTakeNoDamage": "You did not suffer any injury.",`
-
+```  "CoC7.YouTakeNoDamage": "You did not suffer any injury.",```
 ##### CoC7.YouTakeSomeDamage
-
-` "CoC7.YouTakeSomeDamage": "You take {amount} points of damage.",`
-
+```  "CoC7.YouTakeSomeDamage": "You take {amount} points of damage.",```
 ##### CoC7.combatCard.automaticSuccess
-
-` "CoC7.combatCard.automaticSuccess": "Automatic Success",`
-
+```  "CoC7.combatCard.automaticSuccess": "Automatic Success",```
 ##### CoC7.rangeCombatCard.SurprisedTargetTitle
-
-` "CoC7.rangeCombatCard.SurprisedTargetTitle": "1 bonus die for surprised target",`
-
+```  "CoC7.rangeCombatCard.SurprisedTargetTitle": "1 bonus die for surprised target",```
 ##### SETTINGS.ChaseShowTokenMovement
-
-` "SETTINGS.ChaseShowTokenMovement": "Show token movement.",`
-
+```  "SETTINGS.ChaseShowTokenMovement": "Show token movement.",```
 ##### SETTINGS.ChaseShowTokenMovementHint
-
-` "SETTINGS.ChaseShowTokenMovementHint": "Show movement on the grid when a token is moved to the next location.",`
-
+```  "SETTINGS.ChaseShowTokenMovementHint": "Show movement on the grid when a token is moved to the next location.",```
 ##### SETTINGS.DefaultDifficulty
-
-` "SETTINGS.DefaultDifficulty": "Default check difficulty",`
-
+```  "SETTINGS.DefaultDifficulty": "Default check difficulty",```
 ##### SETTINGS.TitleChaseSettings
-
-` "SETTINGS.TitleChaseSettings": "Chase Settings",`
+```  "SETTINGS.TitleChaseSettings": "Chase Settings",```

--- a/docs/en/manual.md
+++ b/docs/en/manual.md
@@ -12,14 +12,17 @@ The system automates most of the regular tasks and rules involved with running a
 
 Several parts of the actor sheets have pop up tooltips that trigger after two seconds, this delay can be changed in the settings
 
-This documentation can be reopened under Compendiums -> JournalEntry -> System manual -> Call of Cthulhu 7th Edition (Unofficial) [en]
+This documentation can be reopened under  Compendiums -> JournalEntry -> System manual -> Call of Cthulhu 7th Edition (Unofficial) [en]
+
 
 # Recent changes
 
 For a full list of changes checkout the [changelog](https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/CHANGELOG.md) on GitHub
 
+
 - [Chases](chases.md)
 - [Actor importer](actor_importer.md) - added The Dhole's House JSON support
+
 
 # Overview sections below
 
@@ -30,6 +33,7 @@ If this is your first time it is recommends you also read the following sections
 - Settings overview
 - Scene menu overview
 - [Creating your first investigator](first_investigator.md)
+
 
 # How to use the system
 
@@ -57,25 +61,28 @@ If this is your first time it is recommends you also read the following sections
 - Start Rest
 - XP Gain
 
+
 # Actor overview
 
-- _Character_ - A complete character, usually an investigator.
-- _Container_ - An inventory container.
-- _Creature_ - A more simple character, suitable for creatures.
-- _NPC_ - A more simple character, suitable for NPCs.
+- _Character_ - A complete character, usually an investigator. 
+- _Container_ - An inventory container. 
+- _Creature_ - A more simple character, suitable for creatures. 
+- _NPC_ - A more simple character, suitable for NPCs. 
+
 
 # Items overview
 
-- _Archetype_ - A set of skills and other stats that implement a Pulp Cthulhu archetype. These do not trigger automation in the system.
+- _Archetype_ - A set of skills and other stats that implement a Pulp Cthulhu archetype. These do not trigger automation in the system. 
 - _Book_ - An arcane tome that can hold spells and character improvements.
 - _Item_ - A piece of equipment.
-- _Occupation_ - A set of skills and other stats that implement a CoC occupation.
-- _Setup_ - A set of default configurations for character, creature, or NPC creation.
-- _Skill_ - A skill with a base percentage and some tags.
+- _Occupation_ - A set of skills and other stats that implement a CoC occupation. 
+- _Setup_ - A set of default configurations for character, creature, or NPC creation. 
+- _Skill_ - A skill with a base percentage and some tags. 
 - _Spell_ - A magic spell.
-- _Status_ - An phobia or mania condition.
-- _Talent_ -A special power for Pulp Cthulhu. These do not trigger automation in the system.
-- _Weapon_ - An item with weapon statistics (this includes unarmed attacks).
+- _Status_ - An phobia or mania condition. 
+- _Talent_ -A special power for Pulp Cthulhu. These do not trigger automation in the system. 
+- _Weapon_ - An item with weapon statistics (this includes unarmed attacks). 
+
 
 # Settings overview
 
@@ -93,6 +100,7 @@ Click on System Settings
 - _Weapon Settings_ - Weapon Settings
 - _Developer And Debug Settings_ - These settings can break your world when new updates are released so only use them on test worlds
 - _Roll Table Settings_ - When sanity rolls are made the system can automatically roll for a bout of madness. You can see example roll tables in the Sanity Roll Table compendiums
+
 
 # Call of Cthulhu Scene Menu
 

--- a/generate-translations.js
+++ b/generate-translations.js
@@ -1,4 +1,4 @@
-import del from './node_modules/del/index.js'
+import { deleteAsync } from 'del'
 import glob from './node_modules/glob/glob.js'
 import jsonfile from './node_modules/jsonfile/index.js'
 import write from './node_modules/write/index.js'
@@ -149,6 +149,6 @@ glob('./lang/*.json', {}, async function (er, files) {
     })
     write('./.github/ABANDONED.md', output)
   } else {
-    del('./.github/ABANDONED.md')
+    deleteAsync('./.github/ABANDONED.md')
   }
 })

--- a/module/active-effect.js
+++ b/module/active-effect.js
@@ -1,4 +1,4 @@
-/* global ActiveEffect, game */
+/* global ActiveEffect, foundry, game, Roll */
 
 export default class CoC7ActiveEffect extends ActiveEffect {
   /** @inheritdoc */
@@ -75,14 +75,15 @@ export default class CoC7ActiveEffect extends ActiveEffect {
           else update = current + String(value)
         }
         break
-      case 'number':
+      case 'number':{
         const n = Number.fromString(value)
         if (!isNaN(n)) update = current + n
+      }
         break
-      case 'Array':
+      case 'Array':{
         const at = foundry.utils.getType(current[0])
-        if (!current.length || foundry.utils.getType(value) === at)
-          update = current.concat([value])
+        if (!current.length || foundry.utils.getType(value) === at) { update = current.concat([value]) }
+      }
     }
     if (update !== null) foundry.utils.setProperty(actor.data, key, update)
     return update
@@ -227,7 +228,7 @@ export default class CoC7ActiveEffect extends ActiveEffect {
 
 function parse (str) {
   try {
-    return eval(str)
+    return new Roll(str).evaluate({ async: false }).total
   } catch (e) {
     return NaN
   }

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -1,4 +1,4 @@
-/* global Actor, CONFIG, CONST, Dialog, Die, duplicate, game, getProperty, Hooks, mergeObject, Roll, TextEditor, Token, ui */
+/* global Actor, CONFIG, CONST, Dialog, Die, duplicate, foundry, game, getProperty, Hooks, mergeObject, Roll, TextEditor, Token, ui */
 
 import { COC7 } from '../config.js'
 import { CoC7ChatMessage } from '../apps/coc7-chat-message.js'
@@ -110,10 +110,14 @@ export class CoCActor extends Actor {
     if (typeof this.data.data.attribs.san.dailyLimit === 'undefined') {
       if (this.data.data.attribs.san.oneFifthSanity) {
         const s = this.data.data.attribs.san.oneFifthSanity.split('/')
-        if (s[1] && !isNaN(Number(s[1])))
+        if (s[1] && !isNaN(Number(s[1]))) {
           this.data.data.attribs.san.dailyLimit = Number(s[1])
-        else this.data.data.attribs.san.dailyLimit = 0
-      } else this.data.data.attribs.san.dailyLimit = 0
+        } else {
+          this.data.data.attribs.san.dailyLimit = 0
+        }
+      } else {
+        this.data.data.attribs.san.dailyLimit = 0
+      }
     }
 
     // return computed values or fixed values if not auto.
@@ -171,7 +175,7 @@ export class CoCActor extends Actor {
    */
   prepareDerivedData () {
     super.prepareDerivedData()
-    //Set hpMax, mpMax, sanMax, mov, db, build. This is to allow calculation of derived value with modifed characteristics.
+    // Set hpMax, mpMax, sanMax, mov, db, build. This is to allow calculation of derived value with modifed characteristics.
     this.data.data.attribs.mov.value = this.rawMov
     this.data.data.attribs.db.value = this.rawDb
     this.data.data.attribs.build.value = this.rawBuild
@@ -185,15 +189,15 @@ export class CoCActor extends Actor {
     this.data.data.attribs.san.max = this.rawSanMax
     if (this.san === null) this.data.data.attribs.san.value = this.rawSanMax
 
-    //Apply effects to automaticaly calculated values.
+    // Apply effects to automaticaly calculated values.
     const filterMatrix = []
 
-    if( this.data.data.attribs.hp.auto) filterMatrix.push( 'data.attribs.hp.max')
-    if( this.data.data.attribs.mp.auto) filterMatrix.push( 'data.attribs.mp.max')
-    if( this.data.data.attribs.san.auto) filterMatrix.push( 'data.attribs.san.max')
-    if( this.data.data.attribs.mov.auto) filterMatrix.push( 'data.attribs.mov.value')
-    if( this.data.data.attribs.db.auto) filterMatrix.push( 'data.attribs.db.value')
-    if( this.data.data.attribs.build.auto) filterMatrix.push( 'data.attribs.build.value')
+    if (this.data.data.attribs.hp.auto) filterMatrix.push('data.attribs.hp.max')
+    if (this.data.data.attribs.mp.auto) filterMatrix.push('data.attribs.mp.max')
+    if (this.data.data.attribs.san.auto) filterMatrix.push('data.attribs.san.max')
+    if (this.data.data.attribs.mov.auto) filterMatrix.push('data.attribs.mov.value')
+    if (this.data.data.attribs.db.auto) filterMatrix.push('data.attribs.db.value')
+    if (this.data.data.attribs.build.auto) filterMatrix.push('data.attribs.build.value')
 
     const changes = this.effects.reduce((changes, e) => {
       if (e.data.disabled || e.isSuppressed) return changes
@@ -211,16 +215,13 @@ export class CoCActor extends Actor {
     const selectChanges = changes.filter(e => filterMatrix.includes(e.key))
 
     // Apply all changes
-    for (let change of selectChanges) {
+    for (const change of selectChanges) {
       change.effect.apply(this, change)
     }
 
-    if (this.hpMax && this.hpMax < this.hp)
-      this.data.data.attribs.hp.value = this.hpMax
-    if (this.mpMax && this.mpMax < this.mp)
-      this.data.data.attribs.mp.value = this.mpMax
-    if (this.sanMax && this.sanMax < this.san)
-      this.data.data.attribs.san.value = this.sanMax
+    if (this.hpMax && this.hpMax < this.hp) { this.data.data.attribs.hp.value = this.hpMax }
+    if (this.mpMax && this.mpMax < this.mp) { this.data.data.attribs.mp.value = this.mpMax }
+    if (this.sanMax && this.sanMax < this.san) { this.data.data.attribs.san.value = this.sanMax }
   }
 
   /** @override */
@@ -344,7 +345,7 @@ export class CoCActor extends Actor {
         this.data.data.characteristics
       )) {
         characteristics[key] = {
-          key: key,
+          key,
           shortName: game.i18n.localize(value.short),
           label: game.i18n.localize(value.label),
           value: value.value,
@@ -450,8 +451,8 @@ export class CoCActor extends Actor {
     if (!realTime) return result
 
     this.setCondition(COC7.status.tempoInsane, {
-      realTime: realTime,
-      duration: duration
+      realTime,
+      duration
     })
 
     // const effect = this.effects.get( effectData._id);
@@ -488,14 +489,14 @@ export class CoCActor extends Actor {
       name: skillName,
       type: 'skill',
       data: {
-        value: value,
-        skillName: skillName,
+        value,
+        skillName,
         specialization: '',
         properties: {
           special: false,
-          rarity: rarity,
-          push: push,
-          combat: combat
+          rarity,
+          push,
+          combat
         }
       }
     }
@@ -682,7 +683,7 @@ export class CoCActor extends Actor {
       name: itemName,
       type: 'item',
       data: {
-        quantity: quantity
+        quantity
       }
     }
     const created = await this.createEmbeddedDocuments('Item', [data], {
@@ -816,7 +817,7 @@ export class CoCActor extends Actor {
       ? duplicate(this.data.data.biography)
       : []
     bio.push({
-      title: title,
+      title,
       value: null
     })
     await this.update({ 'data.biography': bio })
@@ -1494,7 +1495,7 @@ export class CoCActor extends Actor {
       game.system.template.Actor.templates.characteristics.characteristics
     )) {
       characteristics.push({
-        key: key,
+        key,
         shortName: game.i18n.localize(value.short),
         label: game.i18n.localize(value.label)
       })
@@ -1515,7 +1516,7 @@ export class CoCActor extends Actor {
           key === charName.toLowerCase()
         ) {
           return {
-            key: key,
+            key,
             shortName: game.i18n.localize(value.short),
             label: game.i18n.localize(value.label),
             value: value.value
@@ -1875,8 +1876,7 @@ export class CoCActor extends Actor {
 
   async setMp (value) {
     if (value < 0) value = 0
-    if (value > parseInt(this.data.data.attribs.mp.max))
-      value = parseInt(this.data.data.attribs.mp.max)
+    if (value > parseInt(this.data.data.attribs.mp.max)) { value = parseInt(this.data.data.attribs.mp.max) }
     return await this.update({ 'data.attribs.mp.value': value })
   }
 
@@ -1985,8 +1985,7 @@ export class CoCActor extends Actor {
 
   async setSan (value) {
     if (value < 0) value = 0
-    if (value > this.data.data.attribs.san.max)
-      value = this.data.data.attribs.san.max
+    if (value > this.data.data.attribs.san.max) { value = this.data.data.attribs.san.max }
     const loss = parseInt(this.data.data.attribs.san.value) - value
 
     if (loss > 0) {
@@ -2748,7 +2747,7 @@ export class CoCActor extends Actor {
                 'CoC7.SanGained',
                 {
                   results: `${augmentSANDie.values[0]} + ${augmentSANDie.values[1]}`,
-                  sanGained: sanGained,
+                  sanGained,
                   skill: item.data.name,
                   skillValue: skillValue + augmentDie.total
                 }
@@ -2811,11 +2810,11 @@ export class CoCActor extends Actor {
       message += '</p>'
       const speaker = { actor: this }
       await chatHelper.createMessage(skillsRolled ? title : '', message, {
-        speaker: speaker
+        speaker
       })
       this.onlyRunOncePerSession = true
     }
-    return { failure: failure, success: success }
+    return { failure, success }
   }
 
   async developLuck (fastForward = false) {
@@ -2861,7 +2860,7 @@ export class CoCActor extends Actor {
     if (!fastForward) {
       message += '</p>'
       const speaker = { actor: this }
-      await chatHelper.createMessage(title, message, { speaker: speaker })
+      await chatHelper.createMessage(title, message, { speaker })
     }
   }
 
@@ -2898,7 +2897,7 @@ export class CoCActor extends Actor {
       })
     }
     const speaker = { actor: this._id }
-    await chatHelper.createMessage(title, message, { speaker: speaker })
+    await chatHelper.createMessage(title, message, { speaker })
     await skill.unflagForDevelopement()
   }
 
@@ -2974,7 +2973,7 @@ export class CoCActor extends Actor {
             custom.flags.CoC7.realTime = realTime
             custom.flags = {
               CoC7: {
-                realTime: realTime
+                realTime
               }
             }
             if (duration !== null && typeof duration !== 'undefined') {
@@ -3304,8 +3303,7 @@ export class CoCActor extends Actor {
 
   async setHp (value) {
     if (value < 0) value = 0
-    if (value > this.data.data.attribs.san.max)
-      value = this.data.data.attribs.san.max
+    if (value > this.data.data.attribs.san.max) { value = this.data.data.attribs.san.max }
     const healthBefore = this.hp
     let damageTaken
     // is healing

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -1,4 +1,4 @@
-/* global $, ActorSheet, ChatMessage, CONST, Dialog, FormData, game, getProperty, Hooks, Item, mergeObject, Roll, TextEditor, ui */
+/* global $, ActorSheet, ChatMessage, CONST, Dialog, FormData, foundry, game, getProperty, Hooks, Item, mergeObject, Roll, TextEditor, ui */
 
 import { RollDialog } from '../../apps/roll-dialog.js'
 import { CoC7ChatMessage } from '../../apps/coc7-chat-message.js'
@@ -288,7 +288,6 @@ export class CoC7ActorSheet extends ActorSheet {
             if (item.data.value) {
               // This should be part of migration or done at init !
               // Was done when skill value was changed to base + adjustement
-              const value = item.data.value
               const exp = item.data.adjustments?.experience
                 ? parseInt(item.data.adjustments.experience)
                 : 0
@@ -934,8 +933,8 @@ export class CoC7ActorSheet extends ActorSheet {
                     game.settings.get('CoC7', 'stanbyGMRolls') &&
                     sheet.actor.hasPlayerOwner
                       ? game.i18n.format('CoC7.ToolTipKeeperStandbySkill', {
-                          name: sheet.actor.name
-                        })
+                        name: sheet.actor.name
+                      })
                       : ''
                 })
             }
@@ -974,8 +973,8 @@ export class CoC7ActorSheet extends ActorSheet {
                     game.settings.get('CoC7', 'stanbyGMRolls') &&
                     sheet.actor.hasPlayerOwner
                       ? game.i18n.format('CoC7.ToolTipKeeperStandbySkill', {
-                          name: sheet.actor.name
-                        })
+                        name: sheet.actor.name
+                      })
                       : ''
                 })
             }
@@ -1017,8 +1016,8 @@ export class CoC7ActorSheet extends ActorSheet {
                         game.settings.get('CoC7', 'stanbyGMRolls') &&
                         sheet.actor.hasPlayerOwner
                           ? game.i18n.format('CoC7.ToolTipKeeperStandbySkill', {
-                              name: sheet.actor.name
-                            })
+                            name: sheet.actor.name
+                          })
                           : ''
                     })
                 }
@@ -1044,8 +1043,8 @@ export class CoC7ActorSheet extends ActorSheet {
                         (game.settings.get('CoC7', 'stanbyGMRolls') &&
                         sheet.actor.hasPlayerOwner
                           ? game.i18n.format('CoC7.ToolTipKeeperStandbySkill', {
-                              name: sheet.actor.name
-                            })
+                            name: sheet.actor.name
+                          })
                           : '')
                     })
                 }
@@ -1149,7 +1148,7 @@ export class CoC7ActorSheet extends ActorSheet {
     message.actorTo = await new Promise(resolve => {
       const dlg = new Dialog({
         title: game.i18n.localize('CoC7.MessageTitleSelectUserToGiveTo'),
-        content: content,
+        content,
         buttons: {
           confirm: {
             label: game.i18n.localize('CoC7.Validate'),
@@ -1292,7 +1291,6 @@ export class CoC7ActorSheet extends ActorSheet {
 
   async _onResetCounter (event) {
     event.preventDefault()
-    const counter = event.currentTarget.dataset.counter
     await this.actor.resetDailySanity()
   }
 
@@ -1646,7 +1644,7 @@ export class CoC7ActorSheet extends ActorSheet {
     const range = event.currentTarget.closest('.weapon-damage').dataset.range
     const damageChatCard = new DamageCard({
       fastForward: event.shiftKey,
-      range: range
+      range
     })
     damageChatCard.actorKey = this.actor.tokenKey
     damageChatCard.itemId = itemId
@@ -1662,7 +1660,7 @@ export class CoC7ActorSheet extends ActorSheet {
     const data = {
       rollType: CoC7ChatMessage.ROLL_TYPE_SKILL,
       cardType: CoC7ChatMessage.CARD_TYPE_OPPOSED,
-      event: event,
+      event,
       actor: this.actor
     }
     if (event.currentTarget.classList.contains('characteristic-label')) {
@@ -1689,7 +1687,7 @@ export class CoC7ActorSheet extends ActorSheet {
     CoC7ChatMessage.trigger({
       rollType: CoC7ChatMessage.ROLL_TYPE_CHARACTERISTIC,
       cardType: CoC7ChatMessage.CARD_TYPE_NORMAL,
-      event: event,
+      event,
       actor: this.actor
     })
   }
@@ -1724,7 +1722,7 @@ export class CoC7ActorSheet extends ActorSheet {
         event.altKey && attrib === 'san'
           ? CoC7ChatMessage.CARD_TYPE_SAN_CHECK
           : CoC7ChatMessage.CARD_TYPE_NORMAL,
-      event: event,
+      event,
       actor: this.actor
     })
   }
@@ -1740,7 +1738,7 @@ export class CoC7ActorSheet extends ActorSheet {
     CoC7ChatMessage.trigger({
       rollType: CoC7ChatMessage.ROLL_TYPE_SKILL,
       cardType: CoC7ChatMessage.CARD_TYPE_NORMAL,
-      event: event,
+      event,
       actor: this.actor
     })
   }
@@ -1777,7 +1775,7 @@ export class CoC7ActorSheet extends ActorSheet {
     const name = event?.currentTarget?.name
     if (name && overrides && overrides[name]) {
       ui.notifications.warn(
-        game.i18n.format('CoC7.EffectAppliedCantOverride', { name: name })
+        game.i18n.format('CoC7.EffectAppliedCantOverride', { name })
       )
     }
 
@@ -1831,14 +1829,14 @@ export class CoC7ActorSheet extends ActorSheet {
         if (event.currentTarget.classList.contains('attribute-value')) {
           // TODO : check why SAN only ?
           if (event.currentTarget.name === 'data.attribs.san.value') {
-            const value = await this.actor.setSan(
+            await this.actor.setSan(
               parseInt(event.currentTarget.value)
             )
             this.render(true)
             return
           }
           if (event.currentTarget.name === 'data.attribs.hp.value') {
-            const value = await this.actor.setHp(
+            await this.actor.setHp(
               parseInt(event.currentTarget.value)
             )
             this.render(true)

--- a/module/actors/sheets/character.js
+++ b/module/actors/sheets/character.js
@@ -418,11 +418,12 @@ export class CoC7CharacterSheet extends CoC7ActorSheet {
             '--other-sheet-bg',
             "url( './assets/images/void.webp')"
           )
-        } else
+        } else {
           sheet.element.css(
             '--other-sheet-bg',
             game.settings.get('CoC7', 'artWorkOtherSheetBackground')
           )
+        }
       }
 
       if (game.settings.get('CoC7', 'artworkSheetImage')) {
@@ -434,11 +435,12 @@ export class CoC7CharacterSheet extends CoC7ActorSheet {
             '--main-sheet-image',
             "url( './assets/images/void.webp')"
           )
-        } else
+        } else {
           sheet.element.css(
             '--main-sheet-image',
             game.settings.get('CoC7', 'artworkSheetImage')
           )
+        }
       }
 
       if (game.settings.get('CoC7', 'artworkFrontColor')) {

--- a/module/actors/sheets/container.js
+++ b/module/actors/sheets/container.js
@@ -186,7 +186,7 @@ export class CoC7ContainerSheet extends ActorSheet {
     content = content + '</select></form></p>'
     await Dialog.prompt({
       title: game.i18n.localize('CoC7.MessageTitleSelectUserToGiveTo'),
-      content: content,
+      content,
       callback: html => {
         const formData = new FormData(html[0].querySelector('#selectform'))
         for (const [name, value] of formData) {

--- a/module/actors/vehicle/data.js
+++ b/module/actors/vehicle/data.js
@@ -50,7 +50,7 @@ export class CoC7Vehicle extends CoCActor {
   get rawDb () {
     return this.db
   }
-  
+
   get db () {
     const db = parseInt(this.data.data.attribs.db?.value)
     return isNaN(db) ? null : db
@@ -59,7 +59,7 @@ export class CoC7Vehicle extends CoCActor {
   get rawMov () {
     return this.mov
   }
-  
+
   get mov () {
     const mov = parseInt(this.data.data.attribs.mov?.value)
     return isNaN(mov) ? null : mov

--- a/module/apps/actor-importer.js
+++ b/module/apps/actor-importer.js
@@ -173,7 +173,7 @@ export class CoC7ActorImporter {
       maxLoops--
       text = text.trim()
       if (
-        (dodge = this.check('weaponDodge', { saveKeys: false, text: text }))
+        (dodge = this.check('weaponDodge', { saveKeys: false, text }))
       ) {
         text = text.replace(dodge['-source'], '\n')
         if (typeof this.parsed.skills === 'undefined') {
@@ -187,7 +187,7 @@ export class CoC7ActorImporter {
       } else if (
         (weapon = this.check('weapon', {
           saveKeys: false,
-          text: text,
+          text,
           requiredGroup: lastPercent === false ? 'percentage' : false
         }))
       ) {
@@ -262,7 +262,7 @@ export class CoC7ActorImporter {
         const damages = damage.split('/')
         const isShotgun = damages.length === 3
         const data = {
-          name: name,
+          name,
           type: 'weapon',
           data: {
             skill: {
@@ -327,7 +327,7 @@ export class CoC7ActorImporter {
     do {
       maxLoops--
       text = text.trim()
-      skill = this.check('skill', { saveKeys: false, text: text })
+      skill = this.check('skill', { saveKeys: false, text })
       if (skill) {
         text = text.replace(skill['-source'], '\n')
         if (typeof this.parsed[key] === 'undefined') {

--- a/module/apps/char-roll-dialog.js
+++ b/module/apps/char-roll-dialog.js
@@ -99,7 +99,7 @@ export class CharacRollDialog extends Dialog {
         roll.toMessage({
           flavor: game.i18n.format('CoC7.MessageRollingCharacteristic', {
             label: this.data.data.characteristics.list[key].label,
-            formula: formula
+            formula
           })
         })
         input.value = roll.total
@@ -230,8 +230,8 @@ export class CharacRollDialog extends Dialog {
         {
           title: data.title,
           content: html,
-          data: data,
-          rolled: rolled,
+          data,
+          rolled,
           buttons: {},
           close: () => {
             if (data.validate) return resolve(true)

--- a/module/apps/char-selection-dialog.js
+++ b/module/apps/char-selection-dialog.js
@@ -25,7 +25,7 @@ export class CharacSelectDialog extends Dialog {
         {
           title: data.title,
           content: html,
-          data: data,
+          data,
           buttons: {},
           close: () => {
             if (data.selected) return resolve(data.selected)

--- a/module/apps/coc7-chat-message.js
+++ b/module/apps/coc7-chat-message.js
@@ -411,7 +411,7 @@ export class CoC7ChatMessage {
 
             SanCheckCard.create(
               config.options.actor.actorKey,
-              { sanMin: sanMin, sanMax: sanMax, sanReason: sanReason },
+              { sanMin, sanMax, sanReason },
               {
                 sanModifier: config.dialogOptions.modifier,
                 sanDifficulty: config.dialogOptions.difficulty,

--- a/module/apps/dholehouse_importer.js
+++ b/module/apps/dholehouse_importer.js
@@ -281,7 +281,7 @@ export class CoC7DholeHouseActorImporter {
             },
             range: {
               normal: {
-                damage: damage
+                damage
               }
             },
             ammo: weapon.ammo,
@@ -289,7 +289,7 @@ export class CoC7DholeHouseActorImporter {
             properties: {
               melee: skill?.data.data.properties?.fighting ?? false,
               rngd: skill?.data.data.properties?.firearm ?? false,
-              addb: addb
+              addb
             }
           }
         }

--- a/module/apps/parser.js
+++ b/module/apps/parser.js
@@ -302,7 +302,7 @@ export class CoC7Parser {
       dataset: { check: type },
       icon: null,
       blind: false,
-      name: name
+      name
     }
 
     const matches = options.matchAll(/[^,]+/gi)
@@ -353,7 +353,7 @@ export class CoC7Parser {
             !data.dataset.modifier ? '' : 'Modif'
           }`,
           {
-            difficulty: difficulty,
+            difficulty,
             modifier: data.dataset.modifier,
             name: humanName
           }
@@ -366,7 +366,7 @@ export class CoC7Parser {
             !data.dataset.modifier ? '' : 'Modif'
           }`,
           {
-            difficulty: difficulty,
+            difficulty,
             modifier: data.dataset.modifier,
             sanMin: data.dataset.sanMin,
             sanMax: data.dataset.sanMax
@@ -379,7 +379,7 @@ export class CoC7Parser {
             !data.dataset.modifier ? '' : 'Modif'
           }`,
           {
-            difficulty: difficulty,
+            difficulty,
             modifier: data.dataset.modifier,
             name: data.dataset.name
           }

--- a/module/apps/point-selection-dialog.js
+++ b/module/apps/point-selection-dialog.js
@@ -60,7 +60,7 @@ export class PointSelectDialog extends Dialog {
         {
           title: data.title,
           content: html,
-          data: data,
+          data,
           buttons: {},
           close: () => {
             if (data.resolved) return resolve(data)

--- a/module/apps/roll-dialog.js
+++ b/module/apps/roll-dialog.js
@@ -32,7 +32,7 @@ export class RollDialog {
         game.settings.get('CoC7', 'allowFlatThresholdModifier') &&
         !options.disableFlatThresholdModifier,
       difficulty: CoC7Check.difficultyLevel,
-      unknownDifficultyDefault: unknownDifficultyDefault,
+      unknownDifficultyDefault,
       hideDifficulty: options.hideDifficulty ?? false,
       options
     }

--- a/module/apps/skill-selection-dialog.js
+++ b/module/apps/skill-selection-dialog.js
@@ -35,7 +35,7 @@ export class SkillSelectDialog extends Dialog {
         {
           title: data.title,
           content: html,
-          data: data,
+          data,
           buttons: {},
           close: () => {
             if (!data.added >= data.optionsCount) return resolve(false)

--- a/module/apps/skill-spec-select-dialog.js
+++ b/module/apps/skill-spec-select-dialog.js
@@ -11,16 +11,16 @@ export class SkillSpecSelectDialog {
       'systems/CoC7/templates/apps/skill-spec-select.html',
       {
         hasSkills: skills.length > 0,
-        skills: skills,
+        skills,
         base: baseValue,
-        name: name
+        name
       }
     )
     return new Promise(resolve => {
       let formData = null
       const dlg = new Dialog({
         title: name
-          ? game.i18n.format('CoC7.SkillSelectBase', { name: name })
+          ? game.i18n.format('CoC7.SkillSelectBase', { name })
           : game.i18n.format('CoC7.SkillSpecSelectTitle', {
             specialization: specializationName
           }),

--- a/module/apps/skill-value-dialog.js
+++ b/module/apps/skill-value-dialog.js
@@ -4,12 +4,12 @@ export class SkillValueDialog {
   static async create (name = null, baseValue = null) {
     const html = await renderTemplate(
       'systems/CoC7/templates/apps/skill-value.html',
-      { base: baseValue, name: name }
+      { base: baseValue, name }
     )
     return new Promise(resolve => {
       let formData = null
       const dlg = new Dialog({
-        title: game.i18n.format('CoC7.SkillValue', { name: name }),
+        title: game.i18n.format('CoC7.SkillValue', { name }),
         content: html,
         buttons: {
           validate: {

--- a/module/chat.js
+++ b/module/chat.js
@@ -762,7 +762,7 @@ export class CoC7Chat {
                 detailedResultPlaceHolder.innerText = game.i18n.format(
                   'CoC7.RollResult.LuckSpendText',
                   {
-                    luckAmount: luckAmount,
+                    luckAmount,
                     successLevel: game.i18n.localize('CoC7.RegularDifficulty')
                   }
                 )
@@ -773,7 +773,7 @@ export class CoC7Chat {
                 detailedResultPlaceHolder.innerText = game.i18n.format(
                   'CoC7.RollResult.LuckSpendText',
                   {
-                    luckAmount: luckAmount,
+                    luckAmount,
                     successLevel: game.i18n.localize('CoC7.HardDifficulty')
                   }
                 )
@@ -784,7 +784,7 @@ export class CoC7Chat {
                 detailedResultPlaceHolder.innerText = game.i18n.format(
                   'CoC7.RollResult.LuckSpendText',
                   {
-                    luckAmount: luckAmount,
+                    luckAmount,
                     successLevel: game.i18n.localize('CoC7.ExtremeDifficulty')
                   }
                 )
@@ -795,7 +795,7 @@ export class CoC7Chat {
                 detailedResultPlaceHolder.innerText = game.i18n.format(
                   'CoC7.RollResult.LuckSpendText',
                   {
-                    luckAmount: luckAmount,
+                    luckAmount,
                     successLevel: game.i18n.localize('CoC7.CriticalDifficulty')
                   }
                 )

--- a/module/chat/card-actor.js
+++ b/module/chat/card-actor.js
@@ -147,8 +147,8 @@ export class ChatCardActor {
 
     const chatData = {
       user: user.id,
-      speaker: speaker,
-      flavor: flavor,
+      speaker,
+      flavor,
       content: message
     }
 

--- a/module/chat/cards/chase-obstacle.js
+++ b/module/chat/cards/chase-obstacle.js
@@ -89,7 +89,7 @@ export class ChaseObstacleCard extends EnhancedChatCard {
       }
       data.strings.checkRollRequest = game.i18n.format('CoC7.AskRoll', {
         name: checkName,
-        value: value
+        value
       })
       if (data.data.bonusDice !== 0) {
         if (data.data.bonusDice > 0) {
@@ -966,7 +966,7 @@ export class ChaseObstacleCard extends EnhancedChatCard {
           old: this.obstacle[key],
           new: newObstacle[key],
           name: names[key],
-          key: key
+          key
         }
         if (validate) this.data.validation[key] = true
       }

--- a/module/chat/cards/combined-roll.js
+++ b/module/chat/cards/combined-roll.js
@@ -151,14 +151,14 @@ export class CombinedCheckCard extends RollCard {
           }
         }
 
-        const roll = await CoC7Dice.combinedRoll({ pool: pool })
+        const roll = await CoC7Dice.combinedRoll({ pool })
         roll.initiator = game.user.id
 
         const data = {
           type: this.defaultConfig.type,
           action: 'assignRoll',
           fromGM: game.user.isGM,
-          roll: roll
+          roll
         }
         AudioHelper.play({ src: CONFIG.sounds.dice }, true)
         card.process(data)
@@ -176,7 +176,7 @@ export class CombinedCheckCard extends RollCard {
         const data = {
           type: this.defaultConfig.type,
           action: 'updateRoll',
-          rank: rank,
+          rank,
           fromGM: game.user.isGM,
           roll: {
             initiator: game.user.id

--- a/module/chat/cards/opposed-roll.js
+++ b/module/chat/cards/opposed-roll.js
@@ -209,7 +209,7 @@ export class OpposedCheckCard extends RollCard {
     const data = {
       type: this.config.type,
       action: 'updateRoll',
-      rank: rank,
+      rank,
       fromGM: game.user.isGM
     }
     if (!game.user.isGM) data.roll = this.rolls[rank].JSONRollData
@@ -285,7 +285,7 @@ export class OpposedCheckCard extends RollCard {
         const data = {
           type: this.defaultConfig.type,
           action: 'updateRoll',
-          rank: rank,
+          rank,
           fromGM: game.user.isGM
         }
         if (!game.user.isGM) data.roll = card.rolls[rank].JSONRollData

--- a/module/chat/cards/san-check.js
+++ b/module/chat/cards/san-check.js
@@ -449,10 +449,10 @@ export class SanCheckCard extends ChatCardActor {
       for (const t of targets) {
         if (t.actor.isToken) {
           SanCheckCard.create(t.actor.tokenKey, sanData, {
-            fastForward: fastForward
+            fastForward
           })
         } else {
-          SanCheckCard.create(t.actor.id, sanData, { fastForward: fastForward })
+          SanCheckCard.create(t.actor.id, sanData, { fastForward })
         }
       }
     } else {

--- a/module/chat/combat/melee-initiator.js
+++ b/module/chat/combat/melee-initiator.js
@@ -250,7 +250,7 @@ export class CoC7MeleeInitiator extends ChatCardActor {
         resulDetails.innerText = game.i18n.format(
           'CoC7.RollResult.LuckSpendText',
           {
-            luckAmount: luckAmount,
+            luckAmount,
             successLevel: game.i18n.localize('CoC7.RegularDifficulty')
           }
         )
@@ -261,7 +261,7 @@ export class CoC7MeleeInitiator extends ChatCardActor {
         resulDetails.innerText = game.i18n.format(
           'CoC7.RollResult.LuckSpendText',
           {
-            luckAmount: luckAmount,
+            luckAmount,
             successLevel: game.i18n.localize('CoC7.HardDifficulty')
           }
         )
@@ -273,7 +273,7 @@ export class CoC7MeleeInitiator extends ChatCardActor {
         resulDetails.innerText = game.i18n.format(
           'CoC7.RollResult.LuckSpendText',
           {
-            luckAmount: luckAmount,
+            luckAmount,
             successLevel: game.i18n.localize('CoC7.ExtremeDifficulty')
           }
         )
@@ -285,7 +285,7 @@ export class CoC7MeleeInitiator extends ChatCardActor {
         resulDetails.innerText = game.i18n.format(
           'CoC7.RollResult.LuckSpendText',
           {
-            luckAmount: luckAmount,
+            luckAmount,
             successLevel: game.i18n.localize('CoC7.CriticalDifficulty')
           }
         )

--- a/module/chat/combat/melee-target.js
+++ b/module/chat/combat/melee-target.js
@@ -196,7 +196,7 @@ export class CoC7MeleeTarget extends ChatCardActor {
             title: game.i18n.localize(
               'CoC7.MessageTitleSelectSingleUserForTarget'
             ),
-            content: content,
+            content,
             callback: html => {
               const formData = new FormData(
                 html[0].querySelector('#selectform')
@@ -433,7 +433,7 @@ export class CoC7MeleeTarget extends ChatCardActor {
         resulDetails.innerText = game.i18n.format(
           'CoC7.RollResult.LuckSpendText',
           {
-            luckAmount: luckAmount,
+            luckAmount,
             successLevel: game.i18n.localize('CoC7.RegularDifficulty')
           }
         )
@@ -444,7 +444,7 @@ export class CoC7MeleeTarget extends ChatCardActor {
         resulDetails.innerText = game.i18n.format(
           'CoC7.RollResult.LuckSpendText',
           {
-            luckAmount: luckAmount,
+            luckAmount,
             successLevel: game.i18n.localize('CoC7.HardDifficulty')
           }
         )
@@ -455,7 +455,7 @@ export class CoC7MeleeTarget extends ChatCardActor {
         resulDetails.innerText = game.i18n.format(
           'CoC7.RollResult.LuckSpendText',
           {
-            luckAmount: luckAmount,
+            luckAmount,
             successLevel: game.i18n.localize('CoC7.ExtremeDifficulty')
           }
         )
@@ -466,7 +466,7 @@ export class CoC7MeleeTarget extends ChatCardActor {
         resulDetails.innerText = game.i18n.format(
           'CoC7.RollResult.LuckSpendText',
           {
-            luckAmount: luckAmount,
+            luckAmount,
             successLevel: game.i18n.localize('CoC7.CriticalDifficulty')
           }
         )

--- a/module/chat/concheck.js
+++ b/module/chat/concheck.js
@@ -113,7 +113,7 @@ export class CoC7ConCheck {
 
     const chatData = {
       user: user.id,
-      speaker: speaker,
+      speaker,
       flavor: this.flavor,
       content: htmlElement.outerHTML
     }

--- a/module/chat/interactive-chat-card.js
+++ b/module/chat/interactive-chat-card.js
@@ -119,7 +119,7 @@ export class InteractiveChatCard {
     const button = event.currentTarget
     // button.style.display = 'none' //Avoid multiple push
     const action = button.dataset.action
-    if (this[action]) this[action]({ event: event, update: true })
+    if (this[action]) this[action]({ event, update: true })
   }
 
   /**

--- a/module/chat/rangecombat.js
+++ b/module/chat/rangecombat.js
@@ -343,8 +343,8 @@ export class CoC7RangeInitiator {
     return {
       level: difficulty,
       name: difficultyName,
-      modifier: modifier,
-      damage: damage,
+      modifier,
+      damage,
       impossible: difficulty === CoC7Check.difficultyLevel.impossible
     }
   }
@@ -785,14 +785,14 @@ export class CoC7RangeInitiator {
 
         this.damage.push({
           targetKey: h.roll.targetKey,
-          targetName: targetName,
+          targetName,
           rolls: damageRolls,
-          total: total,
-          critical: critical,
+          total,
+          critical,
           dealt: false,
           resultString: game.i18n.format('CoC7.rangeCombatDamage', {
             name: targetName,
-            total: total
+            total
           })
         })
       }

--- a/module/chat/sancheck.js
+++ b/module/chat/sancheck.js
@@ -114,13 +114,13 @@ export class CoC7SanCheck {
         const speaker = chatHelper.getSpeakerFromKey(tokenKey)
         const title = game.i18n.format('CoC7.SANCheckTitle', {
           name: speaker.alias,
-          sanMin: sanMin,
-          sanMax: sanMax
+          sanMin,
+          sanMax
         })
         chatHelper.createMessage(
           null,
           `@coc7.sanloss[sanMax:${sanMax},sanMin:${sanMin}]{${title}}`,
-          { speaker: speaker }
+          { speaker }
         )
       } else ui.notifications.error('No target selected')
     }
@@ -176,7 +176,7 @@ export class CoC7SanCheck {
 
     const chatData = {
       user: user.id,
-      speaker: speaker,
+      speaker,
       flavor: this.flavor,
       content: htmlElement.outerHTML
     }

--- a/module/check.js
+++ b/module/check.js
@@ -366,7 +366,7 @@ export class CoC7Check {
       `CoC7.LinkCheck${!difficulty ? '' : 'Diff'}${
         !this._diceModifier ? '' : 'Modif'
       }`,
-      { difficulty: difficulty, modifier: modifier, name: this.name }
+      { difficulty, modifier, name: this.name }
     )
   }
 
@@ -484,7 +484,7 @@ export class CoC7Check {
         success: true,
         cssClass: this.isCritical ? 'critical' : 'success',
         hint: successHint,
-        icons: icons
+        icons
       }
     } else {
       const icons = []
@@ -499,7 +499,7 @@ export class CoC7Check {
         success: false,
         cssClass: this.isFumble ? 'fumble' : 'failure',
         hint: failureHint,
-        icons: icons
+        icons
       }
     }
   }
@@ -653,7 +653,7 @@ export class CoC7Check {
         !this._diceModifier ? '' : 'Modif'
       }`,
       {
-        difficulty: difficulty,
+        difficulty,
         modifier: this._diceModifier,
         name: this.name
       }
@@ -1593,7 +1593,7 @@ export class CoC7Check {
 
     const chatData = {
       user: user.id,
-      speaker: speaker,
+      speaker,
       flavor: this.flavor,
       content: html,
       flags: {

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -136,7 +136,7 @@ Hooks.once('init', async function () {
       check: CoC7Utilities.checkMacro
     },
     cards: {
-      DamageCard: DamageCard
+      DamageCard
     },
     dev: {
       dice: {
@@ -248,8 +248,8 @@ Hooks.on('createActiveEffect', (data, options, userId) => {
           }
           data.parent.setCondition(COC7.status.tempoInsane, {
             forceValue: true,
-            realTime: realTime,
-            duration: duration
+            realTime,
+            duration
           })
         }
         break

--- a/module/common/chatcardlib/src/chatcardlib.js
+++ b/module/common/chatcardlib/src/chatcardlib.js
@@ -215,7 +215,7 @@ export class EnhancedChatCard {
       {
         // user: userId,
         user: game.user.id,
-        speaker: speaker,
+        speaker,
         flavor: game.i18n.localize(this.options.title),
         content: htmlCardElement.outerHTML
       },
@@ -511,7 +511,7 @@ export class EnhancedChatCard {
       if (!formUpdate) return // If the form was updated we still update the card
     }
     if (this[action]) {
-      actionUpdate = await this[action]({ event: event, updateCard: false })
+      actionUpdate = await this[action]({ event, updateCard: false })
     }
 
     if (formUpdate || actionUpdate) await this.updateChatCard()

--- a/module/dice.js
+++ b/module/dice.js
@@ -42,7 +42,7 @@ export class CoC7Dice {
         results: []
       },
       total: 0,
-      roll: roll
+      roll
     }
 
     if (rollMode) result.rollMode = rollMode
@@ -125,7 +125,7 @@ export class CoC7Dice {
         bonusDice: []
       },
       unit: 0,
-      roll: roll
+      roll
     }
     let baseSet = false
     for (const d of roll.dice) {
@@ -158,7 +158,7 @@ export class CoC7Dice {
           results: []
         },
         total: 0,
-        roll: roll
+        roll
       }
       const modif = parseInt(key, 10)
       let modifier = modif

--- a/module/items/chase/data.js
+++ b/module/items/chase/data.js
@@ -195,7 +195,7 @@ export class CoC7Chase extends CoC7Item {
     const participantsData = this.cleanParticipantList(list)
     return await this.update(
       { 'data.participants': participantsData },
-      { render: render }
+      { render }
     )
   }
 
@@ -210,7 +210,7 @@ export class CoC7Chase extends CoC7Item {
     foundry.utils.mergeObject(participants[participantIndex], update, {
       overwrite: true
     })
-    await this.updateParticipants(participants, { render: render })
+    await this.updateParticipants(participants, { render })
   }
 
   cleanParticipantList (list) {
@@ -267,7 +267,7 @@ export class CoC7Chase extends CoC7Item {
       if (assistant.currentMovementActions < 1) {
         ui.notifications.error(
           game.i18n.format('CoC7.ParticipantNotEnoughMovement', {
-            assistantUuid: assistantUuid,
+            assistantUuid,
             actions: assistant.currentMovementActions
           })
         )
@@ -283,7 +283,7 @@ export class CoC7Chase extends CoC7Item {
     )
     await this.update(
       { 'data.participants': participantsData },
-      { render: render }
+      { render }
     )
   }
 
@@ -293,7 +293,7 @@ export class CoC7Chase extends CoC7Item {
     if (!participant) {
       ui.notifications.error(
         game.i18n.format('CoC7.ParticipantUuidNotFound', {
-          participantUuid: participantUuid
+          participantUuid
         })
       )
       return undefined
@@ -312,7 +312,7 @@ export class CoC7Chase extends CoC7Item {
     )
     await this.update(
       { 'data.participants': participantsData },
-      { render: render }
+      { render }
     )
   }
 
@@ -325,7 +325,7 @@ export class CoC7Chase extends CoC7Item {
     if (!participant) {
       ui.notifications.error(
         game.i18n.format('CoC7.ParticipantUuidNotFound', {
-          participantUuid: participantUuid
+          participantUuid
         })
       )
       return undefined
@@ -340,7 +340,7 @@ export class CoC7Chase extends CoC7Item {
     if (participant.hasMaxBonusDice) {
       ui.notifications.error(
         game.i18n.format('CoC7.ErrorParticipantAtMaxBonus', {
-          participantUuid: participantUuid
+          participantUuid
         })
       )
       return
@@ -363,7 +363,7 @@ export class CoC7Chase extends CoC7Item {
     )
     await this.update(
       { 'data.participants': participantsData },
-      { render: render }
+      { render }
     )
   }
 
@@ -377,7 +377,7 @@ export class CoC7Chase extends CoC7Item {
     if (!participant) {
       ui.notifications.error(
         game.i18n.format('CoC7.ParticipantUuidNotFound', {
-          participantUuid: participantUuid
+          participantUuid
         })
       )
       return undefined
@@ -397,7 +397,7 @@ export class CoC7Chase extends CoC7Item {
     )
     await this.update(
       { 'data.participants': participantsData },
-      { render: render }
+      { render }
     )
   }
 
@@ -409,10 +409,10 @@ export class CoC7Chase extends CoC7Item {
   } = {}) {
     const activeParticipant = this.nextActiveParticipant
     const options = {
-      scrollToLocation: scrollToLocation,
-      activateLocation: activateLocation,
-      render: render,
-      html: html
+      scrollToLocation,
+      activateLocation,
+      render,
+      html
     }
     if (!activeParticipant) return this.activateParticipant(undefined, options)
     return this.activateParticipant(activeParticipant.uuid, options)
@@ -428,11 +428,11 @@ export class CoC7Chase extends CoC7Item {
     } = {}
   ) {
     const dataUpdate = this.getActivateParticipantUpdateData(participantUuid, {
-      scrollToLocation: scrollToLocation,
+      scrollToLocation,
       activeLocation: activateLocation,
-      html: html
+      html
     })
-    await this.update(dataUpdate, { render: render })
+    await this.update(dataUpdate, { render })
   }
 
   getActivateParticipantUpdateData (
@@ -458,7 +458,7 @@ export class CoC7Chase extends CoC7Item {
       if (activateLocation) {
         locationsDataUpdate = this.getActivateLocationUpdateData(
           participantLocation.uuid,
-          { scrollToLocation: scrollToLocation, html: html }
+          { scrollToLocation, html }
         )
       } else if (scrollToLocation) {
         locationsDataUpdate = {}
@@ -466,12 +466,12 @@ export class CoC7Chase extends CoC7Item {
           this.chaseTrackCurrentScrollPosition
         locationsDataUpdate['data.scroll.chaseTrack.to'] =
           this.getChaseTrackLocationScrollPosition(participantLocation.uuid, {
-            html: html
+            html
           })
       }
     } else {
       locationsDataUpdate = this.getActivateLocationUpdateData(undefined, {
-        scrollToLocation: scrollToLocation
+        scrollToLocation
       })
     }
 
@@ -489,8 +489,8 @@ export class CoC7Chase extends CoC7Item {
   ) {
     const card = new ChaseObstacleCard({
       chaseUuid: this.uuid,
-      locationUuid: locationUuid,
-      moveParticipant: moveParticipant,
+      locationUuid,
+      moveParticipant,
       forward: locationUuid !== this.activeLocation.uuid
     })
     card.toMessage()
@@ -515,7 +515,7 @@ export class CoC7Chase extends CoC7Item {
       }
     })
     await this.updateParticipants(participants, { render: false })
-    this.activateNextParticipantTurn({ render: render })
+    this.activateNextParticipantTurn({ render })
   }
 
   /** @override */
@@ -769,7 +769,7 @@ export class CoC7Chase extends CoC7Item {
     const updatedList = this.cleanLocationsList(list)
     await this.update(
       { 'data.locations.list': updatedList },
-      { render: render }
+      { render }
     )
   }
 
@@ -782,7 +782,7 @@ export class CoC7Chase extends CoC7Item {
     foundry.utils.mergeObject(locations[locationIndex], update, {
       overwrite: true
     })
-    await this.updateLocationsList(locations, { render: render })
+    await this.updateLocationsList(locations, { render })
   }
 
   cleanLocationsList (list) {
@@ -833,7 +833,7 @@ export class CoC7Chase extends CoC7Item {
     newLocation.init = locations[locationIndex].init
     newLocation.active = true
     locations.splice(newLocationIndex, 0, newLocation)
-    return await this.updateLocationsList(locations, { render: render })
+    return await this.updateLocationsList(locations, { render })
   }
 
   async removeLocation (uuid, { render = true } = {}) {
@@ -848,7 +848,7 @@ export class CoC7Chase extends CoC7Item {
       if (index < 0) index = 0
       locations[index].active = true
     }
-    return await this.updateLocationsList(locations, { render: render })
+    return await this.updateLocationsList(locations, { render })
   }
 
   async activateLocation (
@@ -856,9 +856,9 @@ export class CoC7Chase extends CoC7Item {
     { scrollToLocation = true, render = true } = {}
   ) {
     const updateData = this.getActivateLocationUpdateData(locationUuid, {
-      scrollToLocation: scrollToLocation
+      scrollToLocation
     })
-    await this.update(updateData, { render: render })
+    await this.update(updateData, { render })
   }
 
   getClearActiveLocationUpdateData ({
@@ -887,7 +887,7 @@ export class CoC7Chase extends CoC7Item {
   ) {
     if (!locationUuid) {
       return this.getClearActiveLocationUpdateData({
-        scrollToLocation: scrollToLocation
+        scrollToLocation
       })
     }
     const updateData = {}
@@ -904,7 +904,7 @@ export class CoC7Chase extends CoC7Item {
       updateData['data.scroll.chaseTrack.from'] =
         this.chaseTrackCurrentScrollPosition
       updateData['data.scroll.chaseTrack.to'] =
-        this.getChaseTrackLocationScrollPosition(locationUuid, { html: html })
+        this.getChaseTrackLocationScrollPosition(locationUuid, { html })
       // await this.setchaseTrackScroll({
       //   from: this.chaseTrackCurrentScrollPosition,
       //   to: this.chaseTrackActiveLocationScrollPosition
@@ -982,15 +982,15 @@ export class CoC7Chase extends CoC7Item {
   ) {
     const locations = foundry.utils.duplicate(this.data.data.locations.list)
     const locationIndex = locations.findIndex(l => locationUuid === l.uuid)
-    locations[locationIndex].coordinates = { x: x, y: y, scene: sceneId }
+    locations[locationIndex].coordinates = { x, y, scene: sceneId }
 
-    return await this.updateLocationsList(locations, { render: render })
+    return await this.updateLocationsList(locations, { render })
   }
 
   async clearActiveLocationCoordinates ({ render = true } = {}) {
     if (this.activeLocation) {
       return await this.clearLocationCoordinates(this.activeLocation.uuid, {
-        render: render
+        render
       })
     }
   }
@@ -1000,7 +1000,7 @@ export class CoC7Chase extends CoC7Item {
     const locationIndex = locations.findIndex(l => locationUuid === l.uuid)
     delete locations[locationIndex].coordinates
 
-    return await this.updateLocationsList(locations, { render: render })
+    return await this.updateLocationsList(locations, { render })
   }
 
   // get activeParticipantHaveActiveLocationSkill (){
@@ -1093,7 +1093,7 @@ export class CoC7Chase extends CoC7Item {
           }
         })
         await this.updateParticipants(newParticipantsData, { render: false })
-        await this.updateLocationsList(locationsData, { render: render })
+        await this.updateLocationsList(locationsData, { render })
       }
     })
   }
@@ -1171,7 +1171,7 @@ export class CoC7Chase extends CoC7Item {
       ) {
         locationsData[locationIndex].participants.push(participant.uuid)
       }
-      await this.updateLocationsList(locationsData, { render: render })
+      await this.updateLocationsList(locationsData, { render })
     }
   }
 
@@ -1268,8 +1268,8 @@ export class CoC7Chase extends CoC7Item {
 
     if (activateParticipant) {
       await this.activateParticipant(participantUuid, {
-        scrollToLocation: scrollToLocation,
-        activateLocation: activateLocation,
+        scrollToLocation,
+        activateLocation,
         render: false
       })
       modified = true
@@ -1277,7 +1277,7 @@ export class CoC7Chase extends CoC7Item {
 
     if (activateLocation && !activateParticipant) {
       await this.activateLocation(locations[destinationIndex].uuid, {
-        scrollToLocation: scrollToLocation,
+        scrollToLocation,
         render: false
       })
       modified = true
@@ -1384,8 +1384,8 @@ export class CoC7Chase extends CoC7Item {
 
           update.push({
             _id: particpantDocument.id,
-            x: x,
-            y: y
+            x,
+            y
           })
 
           // destination.participants?.forEach( pUuid =>{
@@ -1414,7 +1414,7 @@ export class CoC7Chase extends CoC7Item {
       }
     }
 
-    await this.updateLocationsList(locations, { render: render })
+    await this.updateLocationsList(locations, { render })
   }
 
   // Handle scrolling
@@ -1430,7 +1430,7 @@ export class CoC7Chase extends CoC7Item {
         'data.scroll.chaseTrack.to':
           undefined === to ? this.chaseTrackCurrentScrollPosition : to
       },
-      { render: render }
+      { render }
     )
   }
 

--- a/module/items/chase/sheet.js
+++ b/module/items/chase/sheet.js
@@ -416,7 +416,7 @@ export class CoC7ChaseSheet extends ItemSheet {
       } else {
         app.position.width = 45 * remSize
       }
-      return await app.item.activateNextParticipantTurn({ html: html }) // html is not rendered, element have size = 0
+      return await app.item.activateNextParticipantTurn({ html }) // html is not rendered, element have size = 0
       // if (end > 0) {
       //   start = 0
       // } else if (start > 0) {
@@ -850,7 +850,7 @@ export class CoC7ChaseSheet extends ItemSheet {
     } else {
       CoC7ChaseParticipantImporter.create({
         chaseUuid: this.item.uuid,
-        locationUuid: locationUuid,
+        locationUuid,
         dropData: data
       })
     }

--- a/module/items/item.js
+++ b/module/items/item.js
@@ -265,7 +265,7 @@ export class CoC7Item extends Item {
       return {
         name: skillName,
         specialization: '',
-        skillName: skillName
+        skillName
       }
     }
     const specNameRegex = new RegExp(
@@ -282,8 +282,8 @@ export class CoC7Item extends Item {
     }
     return {
       name: specialization + ' (' + skillName + ')',
-      specialization: specialization,
-      skillName: skillName
+      specialization,
+      skillName
     }
   }
 

--- a/module/items/skill/data.js
+++ b/module/items/skill/data.js
@@ -1,4 +1,4 @@
-/* global CONST, foundry */
+/* global foundry, game */
 import { CoC7Item } from '../item.js'
 
 export class CoC7Skill extends CoC7Item {

--- a/module/scripts/game-rules.js
+++ b/module/scripts/game-rules.js
@@ -107,7 +107,7 @@ function _setInitiativeOptions (rule) {
   }
   CONFIG.Combat.initiative = {
     formula: null,
-    decimals: decimals
+    decimals
   }
 }
 

--- a/module/updater.js
+++ b/module/updater.js
@@ -949,7 +949,7 @@ export class Updater {
                   effects[i] = mergeObject(effect, {
                     flags: {
                       core: {
-                        statusId: statusId
+                        statusId
                       }
                     }
                   })

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -76,9 +76,9 @@ export class CoC7Utilities {
 
       if (ask) {
         const dialogOptions = {
-          threshold: threshold,
+          threshold,
           modifier: diceModifier,
-          difficulty: difficulty,
+          difficulty,
           askValue: true
         }
         const usage = await RollDialog.create(dialogOptions)
@@ -275,7 +275,7 @@ export class CoC7Utilities {
   }
 
   static async checkMacro (threshold = undefined, event = null) {
-    await CoC7Utilities.rollDice(event, { threshold: threshold })
+    await CoC7Utilities.rollDice(event, { threshold })
   }
 
   static async createMacro (bar, data, slot) {
@@ -334,7 +334,7 @@ export class CoC7Utilities {
         name: item.name,
         type: 'script',
         img: item.img,
-        command: command
+        command
       })
     }
     game.user.assignHotbarMacro(macro, slot)
@@ -436,8 +436,6 @@ export class CoC7Utilities {
         const dailySanityLoss = actor.data.data.attribs.san.dailyLoss
         const hpValue = actor.data.data.attribs.hp.value
         const hpMax = actor.data.data.attribs.hp.max
-        const oneFifthSanity =
-          ' / ' + Math.floor(actor.data.data.attribs.san.value / 5)
         const mpValue = actor.data.data.attribs.mp.value
         const mpMax = actor.data.data.attribs.mp.max
         const pow = actor.data.data.characteristics.pow.value
@@ -930,7 +928,7 @@ export class CoC7Utilities {
         return await CoC7Utilities.guessItem(
           type,
           match[1] + 'any' + match[2],
-          { combat: combat, source: source }
+          { combat, source }
         )
       }
     }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "An unofficial implementation of Call of Cthulhu 7th Edition system for Foundry VTT.",
   "scripts": {
     "build": "webpack --mode production",
-    "format": "prettier-standard --format --changed",
-    "lint": "prettier-standard --lint --changed",
+    "format": "standard --fix",
     "watch": "webpack --mode development"
   },
   "repository": {
@@ -19,32 +18,26 @@
     "url": "https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/issues"
   },
   "homepage": "https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT#readme",
+  "type": "module",
   "devDependencies": {
-    "@babel/core": "^7.16.7",
-    "@babel/eslint-parser": "^7.16.5",
-    "@babel/preset-react": "^7.16.7",
-    "@ksmithut/prettier-standard": "git+https://github.com/ksmithut/prettier-standard.git",
-    "copy-webpack-plugin": "^9.0.1",
-    "css-loader": "^6.2.0",
-    "css-minimizer-webpack-plugin": "^3.0.2",
-    "del": "^6.0.0",
-    "eslint": "^7.32.0",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-jest": "^25.3.4",
-    "glob": "^7.1.7",
+    "copy-webpack-plugin": "^11.0.0",
+    "css-loader": "^6.7.1",
+    "css-minimizer-webpack-plugin": "^4.0.0",
+    "del": "^7.0.0",
     "jsonfile": "^6.1.0",
-    "less": "^4.1.1",
-    "less-loader": "^10.0.1",
-    "mini-css-extract-plugin": "^2.2.0",
+    "less-loader": "^11.0.0",
+    "mini-css-extract-plugin": "^2.6.1",
     "remarkable": "^2.0.1",
-    "standard": "^16.0.3",
-    "terser-webpack-plugin": "^5.1.4",
+    "standard": "^17.0.0",
     "thread-loader": "^3.0.4",
-    "webpack": "^5.50.0",
-    "webpack-cli": "^4.8.0",
-    "webpackbar": "^5.0.0-3",
+    "webpack": "^5.74.0",
+    "webpack-cli": "^4.10.0",
+    "webpackbar": "^5.0.2",
     "write": "^2.0.0"
   },
-  "type": "module",
-  "dependencies": {}
+  "standard": {
+    "ignore": [
+      "/lib/socketlib/"
+    ]
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,25 +42,25 @@ function buildDestination () {
 const optimization =
   buildMode === 'production'
     ? {
-      minimize: true,
-      minimizer: [
-        new TerserPlugin({
-          terserOptions: {
-            mangle: false
-          }
-        }),
-        new CssMinimizerPlugin()
-      ],
-      splitChunks: {
-        chunks: 'all',
-        cacheGroups: {
-          default: {
-            name: 'main',
-            test: 'module/coc7.js'
+        minimize: true,
+        minimizer: [
+          new TerserPlugin({
+            terserOptions: {
+              mangle: false
+            }
+          }),
+          new CssMinimizerPlugin()
+        ],
+        splitChunks: {
+          chunks: 'all',
+          cacheGroups: {
+            default: {
+              name: 'main',
+              test: 'module/coc7.js'
+            }
           }
         }
       }
-    }
     : undefined
 
 /**
@@ -102,7 +102,7 @@ const bundleScript = {
       }
     ]
   },
-  optimization: optimization,
+  optimization,
   output: {
     clean: true,
     path: buildDestination(),


### PR DESCRIPTION
## Description.
prettier-standard has not been updated for two years and has several listed vulnerabilities.
The version used was not compatible with the VS Code extension

Switch to https://www.npmjs.com/package/standard and https://marketplace.visualstudio.com/items?itemName=standard.vscode-standard

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
