### PR TITLE
Update tour to support Foundry VTT 10.278 updated settings UI

### DIFF
--- a/module/apps/coc7-tour.js
+++ b/module/apps/coc7-tour.js
@@ -12,7 +12,7 @@ if (typeof Tour !== 'undefined') {
 
         const observer = new MutationObserver((mutations, observer) => {
           document.querySelectorAll(selector).forEach((el) => {
-            resolve(el)
+            resolve()
             observer.disconnect()
           })
         })

--- a/module/tours/enable-variant-rules-en.js
+++ b/module/tours/enable-variant-rules-en.js
@@ -25,14 +25,14 @@ export class EnableVariantRulesEn extends CoC7Tour {
         },
         {
           id: 'goto-system-settings',
-          selector: '[data-tab="system"]',
+          selector: '[data-category="system"]',
           title: 'COC7.Tour.GotoSystemSettingsTitle',
           content: 'COC7.Tour.GotoSystemSettingsContent',
           action: 'click'
         },
         {
           id: 'goto-game-rules',
-          selector: '[data-key="CoC7.gameRules"]',
+          selector: '[data-category="system"] [data-key="CoC7.gameRules"]',
           title: 'COC7.Tour.GotoGameRulesTitle',
           content: 'COC7.Tour.GotoGameRulesContent',
           action: 'click'
@@ -42,12 +42,6 @@ export class EnableVariantRulesEn extends CoC7Tour {
           selector: '#rules-settings [name=submit]',
           title: 'COC7.Tour.SaveGameRulesTitle',
           content: 'COC7.Tour.SaveGameRulesContent'
-        },
-        {
-          id: 'save-system-settings-rules',
-          selector: '#client-settings [name=submit]',
-          title: 'COC7.Tour.SaveSystemSettingsTitle',
-          content: 'COC7.Tour.SaveSystemSettingsContent'
         }
       ],
       localization: {
@@ -60,10 +54,17 @@ export class EnableVariantRulesEn extends CoC7Tour {
         'COC7.Tour.GotoGameRulesTitle': 'Configure Variant/Optional Rules',
         'COC7.Tour.GotoGameRulesContent': 'Click on the Configure Variant/Optional Rules button',
         'COC7.Tour.SaveGameRulesTitle': 'Save rule changes',
-        'COC7.Tour.SaveGameRulesContent': 'Once you have made your changes click on the Save Changes button',
-        'COC7.Tour.SaveSystemSettingsTitle': 'Save system settings',
-        'COC7.Tour.SaveSystemSettingsContent': 'Finally click on the Save Changes button'
+        'COC7.Tour.SaveGameRulesContent': 'Once you have made your changes click on the Save Changes button'
       }
     }, config))
+  }
+
+  async _preStep () {
+    await super._preStep()
+
+    if (this.currentStep.id === 'goto-game-rules') {
+      await this.waitForElement('.category-filter.system.active')
+      await this.waitForElement(this.currentStep.selector)
+    }
   }
 }

--- a/module/tours/enable-variant-rules-fr.js
+++ b/module/tours/enable-variant-rules-fr.js
@@ -15,9 +15,7 @@ export class EnableVariantRulesFr extends EnableVariantRulesEn {
         'COC7.Tour.GotoGameRulesTitle': 'Configurer les variantes/règles optionnelles',
         'COC7.Tour.GotoGameRulesContent': 'Clickez sur le boutton "Configurer les variantes/règles optionnelles"',
         'COC7.Tour.SaveGameRulesTitle': 'Sauvegarder les modifications',
-        'COC7.Tour.SaveGameRulesContent': 'Apres avoir choisis les options cliquez sur le bouton "Sauvegarder les modifications"',
-        'COC7.Tour.SaveSystemSettingsTitle': 'Saugarder',
-        'COC7.Tour.SaveSystemSettingsContent': 'Cliquez sur "Sauvegarer" !'
+        'COC7.Tour.SaveGameRulesContent': 'Apres avoir choisis les options cliquez sur le bouton "Sauvegarder les modifications"'
       }
     })
   }


### PR DESCRIPTION
## Description.
FoundryVTT 10.278 updated the Configure Settings UI, this pull request updates the tour to works with this version instead.
The tour will no longer work with older versions of v10.

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to change).
