### PR TITLE
Fix greedy for effects lazy for others regex

### DIFF
--- a/module/apps/parser.js
+++ b/module/apps/parser.js
@@ -246,7 +246,7 @@ export class CoC7Parser {
     text = TextEditor._getTextNodes(html)
     // Alternative regex : '@(coc7).([^\[]+)\[([^\]]+)\](?:{([^}]+)})?'
     // Before active effect :       '@(coc7).(.*?)\\[([^\\]]+)\\]' + '(?:{([^}]+)})?',
-    const rgx = new RegExp('@(coc7).(.*?)\\[(.*)\\]' + '(?:{([^}]+)})?', 'gi')
+    const rgx = new RegExp('@(coc7).(effect)\\[(.*)\\]' + '(?:{([^}]+)})?', 'gi')
     TextEditor._replaceTextContent(text, rgx, CoC7Parser._createLink)
 
     const html2 = document.createElement('div')

--- a/module/apps/parser.js
+++ b/module/apps/parser.js
@@ -246,9 +246,16 @@ export class CoC7Parser {
     text = TextEditor._getTextNodes(html)
     // Alternative regex : '@(coc7).([^\[]+)\[([^\]]+)\](?:{([^}]+)})?'
     // Before active effect :       '@(coc7).(.*?)\\[([^\\]]+)\\]' + '(?:{([^}]+)})?',
-    const rgx = new RegExp('@(coc7).(.*?)\\[(.*?)\\]' + '(?:{([^}]+)})?', 'gi')
+    const rgx = new RegExp('@(coc7).(.*?)\\[(.*)\\]' + '(?:{([^}]+)})?', 'gi')
     TextEditor._replaceTextContent(text, rgx, CoC7Parser._createLink)
-    return html.innerHTML
+
+    const html2 = document.createElement('div')
+    html2.innerHTML = html.innerHTML
+    text = TextEditor._getTextNodes(html2)
+
+    const rgx2 = new RegExp('@(coc7).(.*?)\\[(.*?)\\]' + '(?:{([^}]+)})?', 'gi')
+    TextEditor._replaceTextContent(text, rgx2, CoC7Parser._createLink)
+    return html2.innerHTML
   }
 
   static bindEventsHandler (html) {


### PR DESCRIPTION
Fix effect parsing

## Description.

To parse effects the end of json string needs to be parsed as greedy.
Text will get parsed a first time with greedy to clear all effects, then a second time with lazy to clear others.

## Motivation and Context.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->

## Screenshots.

<!-- If appropriate. -->

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
