### PR TITLE
Fix Reset - change to targeted character

### DIFF
--- a/module/utilities.js
+++ b/module/utilities.js
@@ -376,8 +376,9 @@ export class CoC7Utilities {
     const playerTokenIds = users
       .map(u => u.character?.id)
       .filter(id => id !== undefined)
-    const selectedPlayerIds = canvas.tokens.controlled.map(token => {
-      return token.actor.id
+    let selectedPlayerIds = []
+    game.user.targets.forEach(target => {
+        selectedPlayerIds.push(target.actor.id)
     })
 
     // Build checkbox list for all active players


### PR DESCRIPTION
## Description.

Change the rest target form canvas.tokens.controlled to game.user.targets

## Motivation and Context.

FVTT has change the behaviour. When  GM select the KP tool, the selected token would unselected. 

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
