### PR TITLE
Dice so nice - Don't play dice sound twice

### DIFF
--- a/module/check.js
+++ b/module/check.js
@@ -789,7 +789,7 @@ export class CoC7Check {
     this.dice =
       options.roll ||
       (await CoC7Dice.roll(this.diceModifier, this.rollMode, this.isBlind))
-    if (!options.silent) {
+    if (!options.silent && game.dice3d === undefined) {
       AudioHelper.play({ src: CONFIG.sounds.dice }, true)
     }
 

--- a/module/check.js
+++ b/module/check.js
@@ -789,7 +789,7 @@ export class CoC7Check {
     this.dice =
       options.roll ||
       (await CoC7Dice.roll(this.diceModifier, this.rollMode, this.isBlind))
-    if (!options.silent && game.dice3d === undefined) {
+    if (!options.silent && !game.modules.get('dice-so-nice')?.active) {
       AudioHelper.play({ src: CONFIG.sounds.dice }, true)
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description.

<!--- Describe your changes in details. -->

Currently, two dice sounds will play when dice so nice is enabled. One when the player tries to perform a roll, and one when the dice so nice dice start rolling. Detect if dice so nice is enabled, and if it is, disable the regular dice rolling sound.

Breaking change for current users that have dice so nice enabled. Now it will just play the dice so nice dice sounds. Maybe it should be put in the game settings configuration.

## Motivation and Context.

Slightly annoying to hear 2 separate dice sounds.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->

## Screenshots.

<!-- If appropriate. -->

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to change).
