### PR TITLE
Show special property of weapons on combat chat cards

### DIFF
--- a/templates/chat/combat/melee-initiator.html
+++ b/templates/chat/combat/melee-initiator.html
@@ -14,6 +14,10 @@
 
     <div class="card-content">
       {{{item.system.description.value}}}
+      {{#if this.item.system.properties.spcl}}
+        <span class="tag">{{localize 'CoC7.WeaponSpecial'}}</span>
+        {{{this.item.system.description.special}}}
+      {{/if}}
       {{#if rolled}}
         <div class="flex0 advantage-selection">
           {{#if advantage}}<span class="tag" title="{{localize 'CoC7.Advantage'}}">{{localize 'CoC7.Advantage'}}</span>{{/if}}

--- a/templates/chat/combat/range-initiator.html
+++ b/templates/chat/combat/range-initiator.html
@@ -10,6 +10,11 @@
 
     <div class="card-content">
       {{{item.system.description.value}}}
+      {{#if this.item.system.properties.spcl}}
+        <span class="tag">{{localize 'CoC7.WeaponSpecial'}}</span>
+        {{{this.item.system.description.special}}}
+      {{/if}}
+
     </div>
 
     {{#if rolled}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

The content of the special property of weapons is now displayed on the initiator combat chard cards.

<!--- Describe your changes in details. -->

## Motivation and Context.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->
Fixes #1286 

## Screenshots.

<!-- If appropriate. -->

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ X ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
