### PR TITLE
Add Pulp rule to ignore age, minor fixes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -991,6 +991,8 @@
   "CoC7.Settings.PulpRules.FasterRecovery.Hint": "Natural healing is increased to two hit points per day",
   "CoC7.Settings.PulpRules.IgnoreMajorWounds.Name": "Ignore Major Wounds",
   "CoC7.Settings.PulpRules.IgnoreMajorWounds.Hint": "",
+  "CoC7.Settings.PulpRules.IgnoreAgePenalties.Name": "Ignore Age Penalties",
+  "CoC7.Settings.PulpRules.IgnoreAgePenalties.Hint": "Do not alter movement rate based on age. When creating an investigator improvements and characteristic deductions are made",
   "CoC7.Settings.DholeUpload.Directory.Name": "The Dhole's House image upload directory",
   "CoC7.Settings.DholeUpload.Directory.Hint": "Upload path for The Dhole's House avatars, relative to the Foundry/Data directory.",
   "CoC7.Settings.WorldEra.Name": "Era for the world",

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -2212,7 +2212,7 @@ export class CoCActor extends Actor {
       } else {
         MOV = 7
       }
-      if (this.system.type !== 'creature') {
+      if (this.system.type !== 'creature' && !game.settings.get('CoC7', 'pulpRuleIgnoreAgePenalties')) {
         if (!isNaN(parseInt(this.system.infos.age))) {
           MOV =
             parseInt(this.system.infos.age) >= 40

--- a/module/scripts/game-rules.js
+++ b/module/scripts/game-rules.js
@@ -85,6 +85,14 @@ const SETTINGS = {
     default: false,
     type: Boolean
   },
+  pulpRuleIgnoreAgePenalties: {
+    name: 'CoC7.Settings.PulpRules.IgnoreAgePenalties.Name',
+    hint: 'CoC7.Settings.PulpRules.IgnoreAgePenalties.Hint',
+    scope: 'world',
+    config: false,
+    default: false,
+    type: Boolean
+  },
   opposedRollTieBreaker: {
     name: 'SETTINGS.OpposedRollTieBreaker',
     hint: 'SETTINGS.OpposedRollTieBreakerHint',

--- a/templates/actors/character-sheet-v2.html
+++ b/templates/actors/character-sheet-v2.html
@@ -191,7 +191,7 @@
         <a data-tab="background">
           <div class="tab-name"><span>{{localize 'CoC7.Background'}}</span></div>
         </a>
-        <a class="keeper-only-tab" data-tab="effects" title="{{localize 'CoC7.GmNotes'}}">
+        <a class="keeper-only-tab" data-tab="effects" title="{{localize 'CoC7.Effects'}}">
           <div class="tab-name"><span><i class="game-icon game-icon-aura"></i></span></div>
         </a>
         {{#if isKeeper}}

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -324,7 +324,7 @@
                 {{#if data.system.flags.locked}}
                   <div style="flex: 0 0 25px;height: fit-content;padding: 0 2px;text-align: center;">{{data.system.special.attacksPerRound}}</div>
                 {{else}}
-                  <input style="flex: 0 0 25px;height: fit-content;padding: 0 2px;text-align: center;" type="text" name="system.special.attacksPerRound" value="{{data.special.attacksPerRound}}" data-dtype="Number">
+                  <input style="flex: 0 0 25px;height: fit-content;padding: 0 2px;text-align: center;" type="text" name="system.special.attacksPerRound" value="{{data.system.special.attacksPerRound}}" data-dtype="Number">
                 {{/if}}
               </div>
             </div>

--- a/templates/items/skill-sheet.html
+++ b/templates/items/skill-sheet.html
@@ -45,7 +45,7 @@
 
   <nav style="flex: 0 0 24px;margin-bottom: 4px;font-family: 'Modesto Condensed', 'Palatino Linotype', serif;font-size: 16px;font-weight: 700;" class="sheet-navigation tabs" data-group="primary">
     <a style="line-height: 24px;" class="item active" data-tab="description">{{ localize "CoC7.Description" }}</a>
-    <a class="keeper-only-tab" data-tab="effects" title="{{localize 'CoC7.GmNotes'}}">
+    <a class="keeper-only-tab" data-tab="effects" title="{{localize 'CoC7.Effects'}}">
       <div class="tab-name"><span><i class="game-icon game-icon-aura"></i></span></div>
     </a>
     {{#if isKeeper}}

--- a/templates/system/rule-settings.html
+++ b/templates/system/rule-settings.html
@@ -83,6 +83,13 @@
     </div>
     <p class="notes">{{localize 'CoC7.Settings.PulpRules.IgnoreMajorWounds.Hint'}}</p>
   </div>
+  <div class="form-group">
+    <label>{{localize 'CoC7.Settings.PulpRules.IgnoreAgePenalties.Name'}}</label>
+    <div class="form-fields" style="flex: 1;">
+      <input type="checkbox" {{checked pulpRuleIgnoreAgePenalties.value}} name="pulpRuleIgnoreAgePenalties" class="pulpRulesSelect">
+    </div>
+    <p class="notes">{{localize 'CoC7.Settings.PulpRules.IgnoreAgePenalties.Hint'}}</p>
+  </div>
 
   <h2>{{localize 'CoC7.Settings.HouseRules.Title'}}</h2>
   <div class="form-group">


### PR DESCRIPTION
## Description.
Add pulp rule to ignore age when calculating movement speed
Fix localization keys for effects on skill and character sheets fixes #1292
Fix display variable for attacks per round on npc/creature sheet fixes #1294

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
