### PR TITLE
Fix defaulting selects

### DIFF
--- a/module/apps/coc7-content-link-dialog.js
+++ b/module/apps/coc7-content-link-dialog.js
@@ -228,9 +228,20 @@ export class CoC7ContentLinkDialog extends FormApplication {
       switch (target.name) {
         case 'type':
           this.object.link.setValue('check', target.value)
+          if (target.value === CoC7Link.CHECK_TYPE.CHECK) {
+            this.object.link.setValue('linkType', CoC7Link.LINK_TYPE.SKILL)
+            this.object.link.setValue('name', '')
+          }
           break
         case 'check':
           this.object.link.setValue('linkType', target.value)
+          if (target.value === CoC7Link.LINK_TYPE.CHARACTERISTIC) {
+            this.object.link.setValue('name', CoCActor.getCharacteristicDefinition()[0].key)
+          } else if (target.value === CoC7Link.LINK_TYPE.ATTRIBUTE) {
+            this.object.link.setValue('name', 'lck')
+          } else {
+            this.object.link.setValue('name', '')
+          }
           break
         case 'attributeKey':
         case 'characteristicKey':


### PR DESCRIPTION
## Description.
When defaulting checks for characteristics / attributes set the name to a default to prevent links not working for all selects until the select box is changed

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
