### PR TITLE
1305: NPC/Creature sheet fallback to base value in skills, if there is no user defined value to override it

### DIFF
--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -279,7 +279,7 @@ export class CoC7ActorSheet extends ActorSheet {
 
             // Assume fallback values, useful for initial setup of skills
             item.system.rawValue = rawValue || value || base
-            item.system.value = value || base      
+            item.system.value = value || base
           
           } else {
             const skill = this.actor.items.get(item._id)

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -273,9 +273,14 @@ export class CoC7ActorSheet extends ActorSheet {
                 })
               }
             }
+
             const skill = this.actor.items.get(item._id)
-            item.system.rawValue = skill.rawValue
-            item.system.value = skill.value
+            const { base, rawValue, value } = skill.system
+
+            // Assume fallback values, useful for initial setup of skills
+            item.system.rawValue = rawValue || value || base
+            item.system.value = value || base      
+          
           } else {
             const skill = this.actor.items.get(item._id)
             item.system.base = await skill.asyncBase()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description.

NPC/Creature sheet works differently than Character sheet right now.
In Character sheet, we can add new skills with ➕ and new skill will immediately use `base` value as it's starting point.
If player will improve the skill, the changes is stored as `experience` improvement.
There is no such thing for NPC/Creature sheet.

Maybe we could simplify it for the future, but for now a simple fallback mechanism should be best 80/20.

## Motivation and Context.

This problem annoyed me for some time as a Keeper. I created issue with context:
https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/issues/1305

## Testing done
- [x] Issue 1305 was fixed
- [x] Modification of values is still possible and respected
- [x] Correct value is displayed in both locked state and unlocked state of the sheet

## Screenshots.
Now the base value immediately populates the value. You can override it if you want, but by default, it will make process shorter.
<img width="851" alt="Screenshot 2023-02-26 at 21 53 27" src="https://user-images.githubusercontent.com/8782549/221433663-30a64524-9c5b-487f-812b-c006a2610d9f.png">

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
