### PR TITLE
1304: Made multiplication active effect working with floating numbers

### DIFF
--- a/module/active-effect.js
+++ b/module/active-effect.js
@@ -257,7 +257,7 @@ export default class CoC7ActiveEffect extends ActiveEffect {
 }
 
 function parse (str) {
-  const regEx = /^[+\-*/)(\d]+$/
+  const regEx = /^[+\-*/)(\d.]+$/
   if (!regEx.exec(str)) return NaN
   try {
     return new Roll(str).evaluate({ async: false }).total


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Motivation and Context
Originated from #1304 discussion.

Often `multiplication` action of `ActiveEffect` will be used with floating numbers, to decrease or increase stats - for example - modify STR like this: `50 * 0.8 = 40`, which could be a side-effect of a spell, curse, or custom item of any kind.
In the current implementation of parse regex, floating numbers were excluded, so using `multiplication` was difficult when the number was not round.


## Screenshots
Notice **50** as STR current value.

<img width="672" alt="image" src="https://user-images.githubusercontent.com/8782549/222215316-0aa01400-9bf7-4dbc-b55e-9f7a820caeef.png">

Now, with `ActiveEffect` of `multiplication` with `0.7` set, the STR is reduced as expected.

<img width="662" alt="image" src="https://user-images.githubusercontent.com/8782549/222215221-c8a68884-7028-4ec6-ac89-5a2a2d0ac25d.png">


## Types of Changes
- [x] Fixes #1304 

## Testing done
  - [x] `multiplication` works as expected, confirmed with screenshots
  - [x] `addition` works still as expected
  - [x] I tested with https://regexr.com/ if a similar list of expected inputs are caught by new regex
