### PR TITLE
1289: Fixed issue with item value being taken from another item

### DIFF
--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -94,12 +94,8 @@ export class CoCActor extends Actor {
     if (['character', 'npc', 'creature'].includes(this.type)) {
       this.system.skills = {}
       for (const i of this.items) {
-        if (i.type === 'skill') {
-          this.system.skills[`${i.system.skillName}`] = {
-            value: i.rawValue
-          }
-          this.system.skills[`${i.id}`] = { value: i.rawValue }
-        }
+        if (i.type !== 'skill') continue
+        this.system.skills[`${i.itemIdentifier}`] = { value: i.rawValue }
       }
 
       /**

--- a/module/items/skill/data.js
+++ b/module/items/skill/data.js
@@ -83,6 +83,15 @@ export class CoC7Skill extends CoC7Item {
   }
 
   /**
+  * Unique identifier should be used to store and obtain item to assess item uniqueness.
+  * For old items without id, fallback of skillName may still be used
+  * but if skill name is not unique it will cause problems.
+  */
+  get itemIdentifier () {
+    return this.id || this.system.skillName
+  }
+
+  /**
    * This is the value of the skill score unaffected by active effects
    */
   get rawValue () {
@@ -116,8 +125,7 @@ export class CoC7Skill extends CoC7Item {
    * This is the skill's value after active effects have been applied
    */
   get value () {
-    const value = this.parent?.system.skills?.[`${this.system.skillName}`]
-      ?.value
+    const value = this.parent?.system.skills?.[`${this.itemIdentifier}`]?.value
     return value || this.rawValue
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Motivation and Context

The goal of this change was to fix a problem described in #1289 - skills in the Character sheet had different values when the sheet was in a `locked` vs `unlocked` state. That was happening for specialised skills named "Any", for example, "Pilot (Any)" or "Art/Craft (Any)".

## Root cause
This problem is caused by the fact that we don't fully support skills with non-unique names.
Skills as items are stored in `this.system.skills` object, and there are two keys used to identify them:

- `skillName`
- `id`

And they live next to each other in the same object, `this.system.skills`.

In some cases, `skillName` is used to obtain a skill, in some cases it's `id`.
As a result, if two skills with the same name exist, their `rawValue` will be displayed correctly, while `value` will be taken from the `this.system.skills` by `skillName`, thus picking the last object that was saved with that non-unique key name, causing the problem.

## Types of Changes
I feel `id` is a new thing and I don't know if using only this property (which would be best) won't break old systems...
So I added a method which, for a given item, should either store it using `id` or, if `id` does not exists, as `skillName`.
It's also used for obtaining the item the same way.
- [ ] Fixes #1289 

## Tests Done
* Adding a skill and rolling it
* Editing a skill and rolling it
* Adding occupation to a character and rolling these skills
* Doing battle roles and dodge rolls
* Doing creature rolls

## Screenshots


