### PR TITLE
Fix setting HP is limited by Sanity max not HP max

### DIFF
--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -3429,8 +3429,8 @@ export class CoCActor extends Actor {
 
   async setHp (value) {
     if (value < 0) value = 0
-    if (value > this.system.attribs.san.max) {
-      value = this.system.attribs.san.max
+    if (value > this.system.attribs.hp.max) {
+      value = this.system.attribs.hp.max
     }
     const healthBefore = this.hp
     let damageTaken


### PR DESCRIPTION
Fix setting HP value was limited by Sanity max not no HP max

Fixes #1314

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
