### PR TITLE
Change RegExp to only support two nested square brackets

### DIFF
--- a/module/apps/coc7-parser.js
+++ b/module/apps/coc7-parser.js
@@ -9,7 +9,7 @@ export class CoC7Parser {
     let text = []
 
     text = TextEditor._getTextNodes(html)
-    const rgx = new RegExp('@(coc7)\\.' + '([^\\]]+?)' + '\\[((?:[^\\]\\[]+|\\[(?:[^\\]\\[]+|\\[[^\\]\\[]*\\])*\\])*)\\]' + '(?:{([^}]+)})?', 'gi')
+    const rgx = new RegExp('@(coc7)\\.' + '(check|effect|item|sanloss)' + '\\[([^\\[\\]]*(?:\\[[^\\[\\]]*(?:\\[[^\\[\\]]*\\])*[^\\[\\]]*\\])*[^\\[\\]]*)\\]' + '(?:{([^}]+)})?', 'gi')
     TextEditor._replaceTextContent(text, rgx, CoC7Link._createLink)
     return html.innerHTML
   }


### PR DESCRIPTION
## Description.
Freeze with 100% CPU due to invalid RegExp #1316

Use RegExp from https://regexr.com/7amue by @kakaroto to only support two nested square brackets

## Still to resolve
https:// and http:// icons break due to FoundryVTT replacing them with links and matching too much contents before hooks have access to the html

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
