### PR TITLE
Fix max skill count for Occupation Skills in Investigator Wizard

### DIFF
--- a/module/apps/investigator-wizard.js
+++ b/module/apps/investigator-wizard.js
@@ -623,7 +623,7 @@ export class CoC7InvestigatorWizard extends FormApplication {
             })
           }
         }
-        sheetData.max = sheetData.default + sheetData.object.personal + Object.values(sheetData.object.occupationGroups).reduce((s, v) => s + v, 0)
+        sheetData.max = parseInt(sheetData.default, 10) + parseInt(sheetData.object.personal, 10) + Object.values(sheetData.object.occupationGroups).reduce((s, v) => s + parseInt(v, 10), 0)
         sheetData.skillItems.sort(CoC7Utilities.sortByNameKey)
         if (sheetData.selected === sheetData.max) {
           sheetData.canNext = true


### PR DESCRIPTION
## Description.
Sometimes number are being processed as string, fix for occupation max count.

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
