### PR TITLE
Fix links not working for skill/attrib checks

### DIFF
--- a/module/apps/coc7-link.js
+++ b/module/apps/coc7-link.js
@@ -414,10 +414,10 @@ export class CoC7Link {
             options
           )
         }
-        if (['skill'].includes(options.type.toLowerCase())) {
+        if (['skill'].includes(options.linkType.toLowerCase())) {
           return actor.skillCheck(options, shiftKey, options)
         }
-        if (['attributes', 'attribute', 'attrib', 'attribs'].includes(options.type.toLowerCase())) {
+        if (['attributes', 'attribute', 'attrib', 'attribs'].includes(options.linkType.toLowerCase())) {
           return actor.attributeCheck(options.name, shiftKey, options)
         }
         break


### PR DESCRIPTION
## Description.

When deciding which path to take when a link is clicked, the wrong attribute was being checked. This changes the logic to the same as for characteristic checks.

## Motivation and Context.
When a skill or attribute roll request is clicked on, nothing happens. This fixes the check so that the existing logic is called.

## Types of Changes.

- [x] Bug fix (non-breaking change which fixes an issue).
