### PR TITLE
Try to add a local skill before creating a new one, improve localization

### DIFF
--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -1090,13 +1090,23 @@ export class CoCActor extends Actor {
             if (secondSkill) {
               let skill = this.getSkillsByName(secondSkill)[0]
               if (!skill) {
-                const name = mainSkill.match(/\(([^)]+)\)/)
-                  ? mainSkill.match(/\(([^)]+)\)/)[1]
-                  : mainSkill
-                skill = await this.createWeaponSkill(
-                  name,
-                  !!data.system.properties?.rngd
-                )
+                const name = secondSkill.match(/\(([^)]+)\)/)
+                  ? secondSkill.match(/\(([^)]+)\)/)[1]
+                  : secondSkill
+                const existing = game.items.find(
+                    item => item.type === 'skill' &&
+                    (item.name.toLocaleLowerCase() === name.toLocaleLowerCase() || item.system.skillName?.toLocaleLowerCase() === name.toLocaleLowerCase())
+                  )
+                if (typeof existing !== 'undefined') {
+                   await this.addItems([existing])
+                   skill = await this.getSkillsByName(secondSkill)[0]
+                  //skill = existing.toObject()
+                } else {
+                  skill = await this.createWeaponSkill(
+                    name,
+                    !!data.system.properties?.rngd
+                  )
+                }
               }
               if (skill) data.system.skill.alternativ.id = skill.id
             } // TODO : Else : selectionner le skill dans la liste ou en créer un nouveau.

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -1066,10 +1066,22 @@ export class CoCActor extends Actor {
                 const name = mainSkill.match(/\(([^)]+)\)/)
                   ? mainSkill.match(/\(([^)]+)\)/)[1]
                   : mainSkill
-                skill = await this.createWeaponSkill(
-                  name,
-                  !!data.system.properties?.rngd
-                )
+                // try to use an already defined skill
+                // TODO: search on the compendiums
+                const existing = game.items.find(
+                    item => item.type === 'skill' &&
+                    (item.name.toLocaleLowerCase() === name.toLocaleLowerCase() || item.system.skillName?.toLocaleLowerCase() === name.toLocaleLowerCase())
+                  )
+                if (typeof existing !== 'undefined') {
+                   await this.addItems([existing])
+                   skill = await this.getSkillsByName(mainSkill)[0]
+                  //skill = existing.toObject()
+                } else {
+                  skill = await this.createWeaponSkill(
+                    name,
+                    !!data.system.properties?.rngd
+                  )
+                }
               }
               if (skill) data.system.skill.main.id = skill.id
             } // TODO : Else : selectionner le skill dans la liste ou en créer un nouveau.

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -870,7 +870,7 @@ export class CoC7Utilities {
     { combat = null, source = '', fallbackAny = false } = {}
   ) {
     let existing = null
-    name = name.toLowerCase()
+    name = name.toLocaleLowerCase()
     for (let o = 0, oM = source.length; o < oM; o++) {
       switch (source.substring(o, o + 1)) {
         case 'i':


### PR DESCRIPTION
Try to add a local skill before creating a new one, improve localization

## Description.

When dragging a weapon to the character sheet, if the main skill it's not already on the character sheet it creates a new one. With this change it will try to find the skill on the  `game.items` before creating a new one. 

The change also fixed a bug with the secondary skill, when it didn't exist was using again the main skill.

Another minor change is to use `toLocaleLowerecase()` instead of `toLowercase()` on `guessItem`

## Motivation and Context.

If a skill it's already deffined it makes sense to use it instead of create a different one.

This could be improved by looking also on the compendiums. 

## Types of Changes.

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
