### PR TITLE
Enables canvas drop

### DIFF
--- a/module/apps/canvas.js
+++ b/module/apps/canvas.js
@@ -1,9 +1,10 @@
 /* global game */
+import { CoC7Utilities } from '../utilities.js'
 import { CoC7Link } from './coc7-link.js'
 
 export class CoC7Canvas {
   static get COC7_TYPES_SUPPORTED () {
-    return ['CoC7Link']
+    return ['CoC7Link', 'locator']
   }
 
   static async onDropSomething (canvas, data) {
@@ -41,24 +42,27 @@ export class CoC7Canvas {
           }
           break
 
-        // This does not appear to be called in FoundryVTT v10, remove if not needed
-        // COC7_TYPES_SUPPORTED chase has been removed because of this
-        // default:
-        //   if (data.docUuid && data.callBack) {
-        //     const doc = CoC7Utilities.SfromUuid(data.docUuid)
-        //     if (
-        //       doc[data.callBack] &&
-        //       typeof doc[data.callBack] === 'function'
-        //     ) {
-        //       try {
-        //         data.scene = canvas.scene.uuid
-        //         doc[data.callBack](data)
-        //       } catch (error) {
-        //         console.warn(error.message)
-        //       }
-        //     }
-        //   }
-        //   break
+        // Handles generic canva drop.
+        // dataTransfer must include :
+        // - docUuid : the Uuid of the document to call
+        // - callBack : the name of the function to call in the document.
+        // Used to select location for chase
+        default:
+          if (data.docUuid && data.callBack) {
+            const doc = CoC7Utilities.SfromUuid(data.docUuid)
+            if (
+              doc[data.callBack] &&
+              typeof doc[data.callBack] === 'function'
+            ) {
+              try {
+                data.scene = canvas.scene.uuid
+                doc[data.callBack](data)
+              } catch (error) {
+                console.warn(error.message)
+              }
+            }
+          }
+          break
       }
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

Re-enables canva drops (used in chase location)

<!--- Describe your changes in details. -->

Handles generic canva drop.  Any item dropped on canva will be checked for a dataTransfer item.
If one is present, this will try to invoque the callback function on the parent doc.
dataTransfer must include :
- docUuid : the Uuid of the document to call
- callBack : the name of the function to call in the document.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->

## Screenshots.

<!-- If appropriate. -->

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
