### PR TITLE
Fixed `extractPossessions` for 1 item. Fixes #1423.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,7 @@ Happy gaming !
 
 When not specified, all changes were made by @castanhocorreia, @HavlockV, and @snap01.
 
+- Fix dholehouse importer for characters with a single item on their possesions. Fixes #1423
 - Add system manual button to Game Settings sidebar tab
 - Update to French localization, thanks to @vonv #1415
 - Update to Italian localization, thanks to @Stefano1975t #1419

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,7 +9,7 @@ Happy gaming !
 
 When not specified, all changes were made by @castanhocorreia, @HavlockV, and @snap01.
 
-- Fix dholehouse importer for characters with a single item on their possesions. Fixes #1423
+- Fix dholehouse importer for characters with a single item on their possesions. Fixes #1423, thanks to @pconcepcion #1424
 - Add system manual button to Game Settings sidebar tab
 - Update to French localization, thanks to @vonv #1415
 - Update to Italian localization, thanks to @Stefano1975t #1419

--- a/module/apps/dholehouse_importer.js
+++ b/module/apps/dholehouse_importer.js
@@ -219,6 +219,9 @@ export class CoC7DholeHouseActorImporter {
 
   static async extractPossessions (dholehousePossessions, options) {
     const items = []
+    if (!Array.isArray(dholehousePossessions) && dholehousePossessions != null) {
+      dholehousePossessions = [dholehousePossessions]
+    }
     for (const item of dholehousePossessions) {
       const existing = await CoC7Utilities.guessItem('item', item.description, {
         source: options.source


### PR DESCRIPTION
Fixed `extractPossessions` when `dholehousePossessions` is a single item instead of an array, this was preventing characters from Dholehouse to be imported when they had a single item as a possesion.



## Description.

This fixes #1423 
 
## Motivation and Context.

See #1423 

## Types of Changes.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
