### PR TITLE
Maintain token link when switching between investigator summarized and maximized sheet

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1188,6 +1188,8 @@
   "SETTINGS.ChaseShowTokenMovementHint": "Show movement on the grid when a token is moved to the next location.",
   "SETTINGS.UseContextMenus": "Use context menus",
   "SETTINGS.UseContextMenusHint": "[EXPERIMENTAL] Use context menus for rolls instead of key combination.",
+  "SETTINGS.SceneDistanceNotCalcualtedNoError": "Don't show error for ranged distance",
+  "SETTINGS.SceneDistanceNotCalcualtedNoErrorHint": "When starting a ranged combat if playing theatre of the mind do not show the unable to calculate distance message.",
 
   "CoC7.getTheExample": "Copy Example",
   "CoC7.Copied": "Copied the Example Text to Clipboard",

--- a/module/actors/sheets/character.js
+++ b/module/actors/sheets/character.js
@@ -1,4 +1,4 @@
-/* global $, duplicate, expandObject, FontFace, game, mergeObject, TextEditor, ui */
+/* global $, duplicate, expandObject, FontFace, foundry, game, mergeObject, TextEditor, ui */
 import { COC7 } from '../../config.js'
 import { CoCActor } from '../actor.js'
 import { CoC7ActorSheet } from './base.js'
@@ -35,15 +35,17 @@ export class CoC7CharacterSheet extends CoC7ActorSheet {
 
   async toggleSheetMode (event) {
     this.summarized = !this.summarized
+    let options = foundry.utils.duplicate(CoC7CharacterSheet.defaultOptions)
+    if (this.summarized) {
+      options = foundry.utils.mergeObject(options, {
+        classes: ['coc7', 'actor', 'character', 'summarized'],
+        height: 200,
+        resizable: false,
+        width: 700
+      })
+    }
+    options.token = this.options.token
     await this.close()
-    const options = this.summarized
-      ? {
-          classes: ['coc7', 'actor', 'character', 'summarized'],
-          height: 200,
-          resizable: false,
-          width: 700
-        }
-      : CoC7CharacterSheet.defaultOptions
     await this.render(true, options)
   }
 

--- a/module/chat/helper.js
+++ b/module/chat/helper.js
@@ -319,7 +319,7 @@ export class chatHelper {
           distance.value * distance.value + elevation * elevation
         )
       }
-    } else {
+    } else if (!game.settings.get('CoC7', 'distanceTheatreOfTheMind')) {
       ui.notifications.warn(
         game.i18n.localize('CoC7.MessageDistanceCalculationFailure')
       )

--- a/module/scripts/register-settings.js
+++ b/module/scripts/register-settings.js
@@ -223,6 +223,14 @@ export function registerSettings () {
     default: true,
     type: Boolean
   })
+  game.settings.register('CoC7', 'distanceTheatreOfTheMind', {
+    name: 'SETTINGS.SceneDistanceNotCalcualtedNoError',
+    hint: 'SETTINGS.SceneDistanceNotCalcualtedNoErrorHint',
+    scope: 'world',
+    config: true,
+    default: false,
+    type: Boolean
+  })
 
   /**
    * Game Artwork Settings


### PR DESCRIPTION
## Description.
* Maintain token link when switching between investigator summarized and maximized sheet, fixes #1426
* Add setting to not display unable to calculate token distances if playing without tokens

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
