### PR TITLE
Fix CoC ID filters

### DIFF
--- a/module/scripts/coc-id.js
+++ b/module/scripts/coc-id.js
@@ -355,7 +355,7 @@ export class CoCID {
       const docCoCID = doc.getFlag('CoC7', 'cocidFlag')?.id
       if (docCoCID) {
         const currentDoc = bestMatchDocuments.get(docCoCID)
-        if (currentDoc === undefined) {
+        if (typeof currentDoc === 'undefined') {
           bestMatchDocuments.set(docCoCID, doc)
           continue
         }
@@ -404,14 +404,14 @@ export class CoCID {
         const key = docCoCID + '/' + docEras + '/' + (isNaN(docPriority) ? Number.MIN_SAFE_INTEGER : docPriority)
 
         const currentDoc = bestMatchDocuments.get(key)
-        if (currentDoc === undefined) {
+        if (typeof currentDoc === 'undefined') {
           bestMatchDocuments.set(key, doc)
           continue
         }
 
         const docLang = doc.getFlag('CoC7', 'cocidFlag')?.lang ?? 'en'
-        const currentLang = currentDoc?.getFlag('CoC7', 'cocidFlag')?.lang ?? 'en'
-        if (currentLang === 'en' && currentLang !== docLang) {
+        const existingLang = currentDoc?.getFlag('CoC7', 'cocidFlag')?.lang ?? 'en'
+        if (existingLang === 'en' && existingLang !== docLang) {
           bestMatchDocuments.set(key, doc)
         }
       }

--- a/module/scripts/coc-id.js
+++ b/module/scripts/coc-id.js
@@ -351,24 +351,34 @@ export class CoCID {
    */
   static filterBestCoCID (documents) {
     const bestMatchDocuments = new Map()
-
     for (const doc of documents) {
       const docCoCID = doc.getFlag('CoC7', 'cocidFlag')?.id
       if (docCoCID) {
-        const currentExists = bestMatchDocuments.get(docCoCID)
+        const currentDoc = bestMatchDocuments.get(docCoCID)
+        if (currentDoc === undefined) {
+          bestMatchDocuments.set(docCoCID, doc)
+          continue
+        }
+
         // Prefer pack === '' if possible
         const docPack = (doc.pack ?? '')
-        const existingPack = (currentExists?.pack ?? '')
-        const preferWorld = (typeof currentExists === 'undefined' || (docPack === '' && existingPack !== '') || (docPack !== '' && existingPack !== ''))
+        const existingPack = (currentDoc?.pack ?? '')
+        const preferWorld = docPack === '' || existingPack !== ''
+        if (!preferWorld) {
+          continue
+        }
+
         // Prefer highest priority
         let docPriority = parseInt(doc.getFlag('CoC7', 'cocidFlag')?.priority ?? Number.MIN_SAFE_INTEGER, 10)
-        docPriority = (isNaN(docPriority) ? Number.MIN_SAFE_INTEGER : docPriority)
-        let existingPriority = parseInt(currentExists?.priority ?? Number.MIN_SAFE_INTEGER, 10)
-        existingPriority = (isNaN(existingPriority) ? Number.MIN_SAFE_INTEGER : existingPriority)
-        const preferPriority = (typeof currentExists === 'undefined' || docPriority >= existingPriority)
-        if (preferWorld && preferPriority) {
-          bestMatchDocuments.set(docCoCID, doc)
+        docPriority = isNaN(docPriority) ? Number.MIN_SAFE_INTEGER : docPriority
+        let existingPriority = parseInt(currentDoc.getFlag('CoC7', 'cocidFlag')?.priority ?? Number.MIN_SAFE_INTEGER, 10)
+        existingPriority = isNaN(existingPriority) ? Number.MIN_SAFE_INTEGER : existingPriority
+        const preferPriority = docPriority >= existingPriority
+        if (!preferPriority) {
+          continue
         }
+
+        bestMatchDocuments.set(docCoCID, doc)
       }
     }
     return [...bestMatchDocuments.values()]
@@ -389,12 +399,19 @@ export class CoCID {
       const docCoCID = doc.getFlag('CoC7', 'cocidFlag')?.id
       if (docCoCID) {
         const docEras = Object.entries(doc.getFlag('CoC7', 'cocidFlag')?.eras ?? {}).filter(e => e[1]).map(e => e[0]).sort().join('/')
-        const docPriority = parseInt(doc.getFlag('CoC7', 'cocidFlag')?.priority ?? Number.MIN_SAFE_INTEGER, 10)
+        let docPriority = parseInt(doc.getFlag('CoC7', 'cocidFlag')?.priority ?? Number.MIN_SAFE_INTEGER, 10)
+        docPriority = isNaN(docPriority) ? Number.MIN_SAFE_INTEGER : docPriority
         const key = docCoCID + '/' + docEras + '/' + (isNaN(docPriority) ? Number.MIN_SAFE_INTEGER : docPriority)
-        const currentExists = bestMatchDocuments.get(key)
+
+        const currentDoc = bestMatchDocuments.get(key)
+        if (currentDoc === undefined) {
+          bestMatchDocuments.set(key, doc)
+          continue
+        }
+
         const docLang = doc.getFlag('CoC7', 'cocidFlag')?.lang ?? 'en'
-        const existingLang = currentExists?.getFlag('CoC7', 'cocidFlag')?.lang ?? 'en'
-        if (typeof currentExists === 'undefined' || (existingLang === 'en' && existingLang !== docLang)) {
+        const currentLang = currentDoc?.getFlag('CoC7', 'cocidFlag')?.lang ?? 'en'
+        if (currentLang === 'en' && currentLang !== docLang) {
           bestMatchDocuments.set(key, doc)
         }
       }


### PR DESCRIPTION
## Description.

Using localized resources is impossible due to improper CoC ID filtering.

Error this time seems to be rooted in `filterBestCoCID` as it incorrectly gets Priority for currently mapped document.
(Missing `.getFlag('CoC7', 'cocidFlag')`)

Addtionally small fix around preferWorld which now should allow entries with higher priority to be utilized if they are also a better match for PreferWorld.

## Motivation and Context.

Allows to translate compendiums in **a working** way.
Some resources are being removed from index by: `CoCID.filterBestCoCID (documents)`
which causes the game to be partially localized.

## Types of Changes.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
