### PR TITLE
Change default font for sheetV2 to one more readable on iOS devices

### DIFF
--- a/styles/system/constants.less
+++ b/styles/system/constants.less
@@ -32,7 +32,7 @@
 // }
 
 .defaultFont {
-  font-family: customSheetFont, 'Bradley Hand', cursive;
+  font-family: customSheetFont, 'Noto Sans';
 }
 
 .chatFont {

--- a/system.json
+++ b/system.json
@@ -19,6 +19,7 @@
   ],
   "templateVersion": 1,
   "styles": [
+    "https://fonts.googleapis.com/css?family=Noto%20Sans",
     "lib/game-icons/game-icons.css",
     "coc7g.css"
   ],


### PR DESCRIPTION
## Description.
The default font for cursive on iOS devices is hard to read.  #1473

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
