### PR TITLE
Added icon swap and message localization improvements

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1300,5 +1300,11 @@
   "CoC7.TokenCreationRoll.ButtonRoll": "Roll all",
   "CoC7.TokenCreationRoll.ButtonAverage": "Average all",
 
-  "CoC7.RealRollDecaderPlaceholderName": "10's"
+  "CoC7.RealRollDecaderPlaceholderName": "10's",
+
+  "CoC7.Temporary": "Temporary",
+  "CoC7.Passive": "Passive",
+  "CoC7.Inactive": "Inactive",
+  "CoC7.Suppressed": "Suppressed",
+  "CoC7.Unavailable": "Unavailable"
 }

--- a/module/active-effect.js
+++ b/module/active-effect.js
@@ -92,24 +92,24 @@ export default class CoC7ActiveEffect extends ActiveEffect {
     const categories = {
       temporary: {
         type: 'temporary',
-        label: game.i18n.localize('Temporary'),
+        label: game.i18n.localize('CoC7.Temporary'),
         effects: []
       },
       passive: {
         type: 'passive',
-        label: game.i18n.localize('Passive'),
+        label: game.i18n.localize('CoC7.Passive'),
         effects: []
       },
       inactive: {
         type: 'inactive',
-        label: game.i18n.localize('Inactive'),
+        label: game.i18n.localize('CoC7.Inactive'),
         effects: []
       },
       suppressed: {
         type: 'suppressed',
-        label: game.i18n.localize('Suppressed'),
+        label: game.i18n.localize('CoC7.Suppressed'),
         effects: [],
-        info: [game.i18n.localize('Unavailable')]
+        info: [game.i18n.localize('CoC7.Unavailable')]
       }
     }
 

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -216,7 +216,7 @@
 
         <div class="condition-monitors flexrow">
           {{#if isDying}}
-            <a class='dying-check' style="text-align: center;font-size: 20px;" title="Check if you'll die immediately"><i class="fas fa-dice-d20"></i></a>
+            <a class='dying-check' style="text-align: center;font-size: 20px;" title="{{localize 'CoC7.DyingCheck'}}"><i class="fas fa-dice-d20"></i></a>
           {{else}}
             <a class="condition-monitor {{#if data.system.conditions.prone.value}}status-on{{/if}}" title="{{localize 'CoC7.Prone'}}" data-condition='prone'> <i class="game-icon game-icon-falling"></i></a>
             <a class="condition-monitor {{#if data.system.conditions.unconscious.value}}status-on{{/if}}" title="{{localize 'CoC7.Unconsious'}}" data-condition="unconscious"> <i class="game-icon game-icon-knocked-out-stars"></i></a>

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -262,9 +262,9 @@
                 <a class="lock" style="flex: 0 0 16px;" title="{{localize 'CoC7.LockActor'}}" data-locked="false"> <i class="fas fa-lock-open"></i></a>
                 {{#if allowFormula}}
                   {{#if displayFormula}}
-                    <a class="formula" style="flex: 0 0 16px;" title="{{localize 'CoC7.NpcCharacteristicsFormula'}}" data-locked="true"> <i class="fas fa-square-root-alt"></i></a>
+                    <a class="formula" style="flex: 0 0 16px;" title="{{localize 'CoC7.NpcCharacteristicsValues'}}" data-locked="true"> <i class="fas fa-user-edit"></i></a>
                   {{else}}
-                    <a class="formula" style="flex: 0 0 16px;" title="{{localize 'CoC7.NpcCharacteristicsValues'}}" data-locked="false"> <i class="fas fa-user-edit"></i></a>
+                    <a class="formula" style="flex: 0 0 16px;" title="{{localize 'CoC7.NpcCharacteristicsFormula'}}" data-locked="false"> <i class="fas fa-square-root-alt"></i></a>
                   {{/if}}
                 {{/if}}
               {{/if}}

--- a/templates/chat/combat/melee-target.html
+++ b/templates/chat/combat/melee-target.html
@@ -45,7 +45,7 @@
 
     {{#unless (or rolled notResponding)}}
       <div class="flexrow advantage-selection">
-        <span class="flex1 toggle-switch advantage {{#unless rolled}}simple-flag{{/unless}} {{#if advantage}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.BonusDieAssailantRestrained'}}" style="text-align:center" data-flag="advantage" data-selected={{advantage}}>{{localize 'CoC7.Advantage'}}</span>
+        <span class="flex1 toggle-switch advantage {{#unless rolled}}simple-flag{{/unless}} {{#if advantage}}switched-on{{/if}} gm-select-only" title="{{localize ' CoC7.BonusDieAssailantReason'}}" style="text-align:center" data-flag="advantage" data-selected={{advantage}}>{{localize 'CoC7.Advantage'}}</span>
         <span class="flex1 toggle-switch disadvantage {{#unless rolled}}simple-flag{{/unless}} {{#if disadvantage}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.PenaltyDieSelfReason'}}" style="text-align:center" data-flag="disadvantage" data-selected={{disadvantage}}>{{localize 'CoC7.Disadvantage'}}</span>
       </div>
     {{/unless}}

--- a/templates/chat/combat/melee-target.html
+++ b/templates/chat/combat/melee-target.html
@@ -45,7 +45,7 @@
 
     {{#unless (or rolled notResponding)}}
       <div class="flexrow advantage-selection">
-        <span class="flex1 toggle-switch advantage {{#unless rolled}}simple-flag{{/unless}} {{#if advantage}}switched-on{{/if}} gm-select-only" title="{{localize ' CoC7.BonusDieAssailantReason'}}" style="text-align:center" data-flag="advantage" data-selected={{advantage}}>{{localize 'CoC7.Advantage'}}</span>
+        <span class="flex1 toggle-switch advantage {{#unless rolled}}simple-flag{{/unless}} {{#if advantage}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.BonusDieAssailantReason'}}" style="text-align:center" data-flag="advantage" data-selected={{advantage}}>{{localize 'CoC7.Advantage'}}</span>
         <span class="flex1 toggle-switch disadvantage {{#unless rolled}}simple-flag{{/unless}} {{#if disadvantage}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.PenaltyDieSelfReason'}}" style="text-align:center" data-flag="disadvantage" data-selected={{disadvantage}}>{{localize 'CoC7.Disadvantage'}}</span>
       </div>
     {{/unless}}

--- a/templates/chat/combat/range-initiator.html
+++ b/templates/chat/combat/range-initiator.html
@@ -86,7 +86,7 @@
             <span class="{{#if trgt.extremeRange}}tag{{else}}invisible{{/if}}" title="{{localize 'CoC7.rangeCombatCard.ExtremeRange'}}">{{localize 'CoC7.rangeCombatCard.ExtremeRange'}}</span>
             <span class="{{#if trgt.outOfRange}}tag{{else}}invisible{{/if}}" title="{{localize 'CoC7.rangeCombatCard.OutOfRange'}}">{{localize 'CoC7.rangeCombatCard.OutOfRange'}}</span>
             <span class="{{#if trgt.cover}}tag{{else}}invisible{{/if}}" title="{{localize 'CoC7.rangeCombatCard.CoverTitle'}}">{{localize 'CoC7.rangeCombatCard.Cover'}}</span>
-            <span class="{{#if trgt.surprised}}tag{{else}}invisible{{/if}}" title="{{localize 'CoC7.TitleSurprised'}}">{{localize 'CoC7.combatCard.surprised'}}</span>
+            <span class="{{#if trgt.surprised}}tag{{else}}invisible{{/if}}" title="{{localize 'CoC7.rangeCombatCard.SurprisedTargetTitle'}}">{{localize 'CoC7.combatCard.surprised'}}</span>
             <span class="{{#if trgt.pointBlankRange}}tag{{else}}invisible{{/if}}" title="{{localize 'CoC7.rangeCombatCard.PointBlankRangeTitle'}}">{{localize 'CoC7.rangeCombatCard.PointBlankRange'}}</span>
             <span class="{{#if trgt.big}}tag{{else}}invisible{{/if}}" title="{{localize 'CoC7.rangeCombatCard.BigTargetTitle'}}">{{localize 'CoC7.rangeCombatCard.BigTarget'}}</span>
             <span class="{{#if trgt.small}}tag{{else}}invisible{{/if}}" title="{{localize 'CoC7.rangeCombatCard.SmallTargetTitle'}}">{{localize 'CoC7.combatCard.SmallTarget'}}</span>
@@ -101,7 +101,7 @@
 
             <div class="flexrow bonus-selection">
               <span class="flex1 toggle-switch cover target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.cover}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.rangeCombatCard.CoverTitle'}}" style="text-align:center" data-flag="cover" data-selected={{trgt.cover}}>{{localize 'CoC7.rangeCombatCard.Cover'}}</span>
-              <span class="flex1 toggle-switch surprised target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.surprised}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.TitleSurprised'}}" style="text-align:center" data-flag="surprised" data-selected={{trgt.surprised}}>{{localize 'CoC7.combatCard.surprised'}}</span>
+              <span class="flex1 toggle-switch surprised target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.surprised}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.rangeCombatCard.SurprisedTargetTitle'}}" style="text-align:center" data-flag="surprised" data-selected={{trgt.surprised}}>{{localize 'CoC7.combatCard.surprised'}}</span>
               <span class="flex1 toggle-switch pointBlankRange target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.pointBlankRange}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.rangeCombatCard.PointBlankRangeTitle'}}" style="text-align:center" data-flag="point-blank-range" data-selected={{trgt.pointBlankRange}}>{{localize 'CoC7.rangeCombatCard.PointBlankRange'}}</span>
             </div>
 

--- a/templates/items/skill-sheet.html
+++ b/templates/items/skill-sheet.html
@@ -4,15 +4,15 @@
       <div class="item-name" style="display: flex; flex-direction: row; height: 24px;">
         <input type="hidden" name="name" value="{{item.name}}" />
         {{#if isSpecialized}}
-          <input class="item-class" style="flex: 1;" type="text" name="system.skillName" value="{{data.system.skillName}}" placeholder="name" />
+          <input class="item-class" style="flex: 1;" type="text" name="system.skillName" value="{{data.system.skillName}}" placeholder="{{localize 'CoC7.Name'}}" />
           <span style="line-height: 22px;padding-right: 3px;">/</span>
           {{#if canModifySpec}}
-            <input class="item-subclass" style="flex: 1;" type="text" name="system.specialization" value="{{data.system.specialization}}" placeholder="specialization" />
+            <input class="item-subclass" style="flex: 1;" type="text" name="system.specialization" value="{{data.system.specialization}}" placeholder="{{localize 'CoC7.SkillSpecial'}}" />
           {{else}}
             <div class="item-subclass" style="flex: 1;line-height: 22px;">{{data.system.specialization}}</div>
           {{/if}}
         {{else}}
-          <input class="item-class" style="flex: 1;" type="text" name="system.skillName" value="{{data.system.skillName}}" placeholder="name" />
+          <input class="item-class" style="flex: 1;" type="text" name="system.skillName" value="{{data.system.skillName}}" placeholder="{{localize 'CoC7.Name'}}" />
         {{/if}}
         {{#if hadNonCharacterOwner}}
           <label>{{localize 'CoC7.Value'}}</label>


### PR DESCRIPTION
## Description.

Swapped icons for 'Show Values' and 'Show Formula' in NPC sheet, as it becomes confusing if you're already viewing the formulas, having the button labeled 'Formulas' when it leads to editing fixed values. Additionally, added localization for the message "Check if you'll die immediately."

## Motivation and Context.

This change is necessary to improve user experience and clarity within the interface. It addresses the confusion that arises when the button labeled 'Formulas' actually leads to editing fixed values, which is contradictory when users are already viewing the formulas.

## Types of Changes.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).