### PR TITLE
Add behavior when NPC created

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1176,6 +1176,12 @@
   "SETTINGS.AdviseAllPlayer": "Notify all players",
   "SETTINGS.OneBlockBackStory": "One block backstory",
   "SETTINGS.OneBlockBackStoryHint": "Turn backstory to one editor block, but you can format/add links.",
+  "SETTINGS.TokenDropMode": "When creating NPC :",
+  "SETTINGS.TokenDropModeHint": "Define the default behavior when an NPC with rollable characteristics or skills is dropped on a scene.",
+  "SETTINGS.TokenDropModeAsk": "Ask what to do",
+  "SETTINGS.TokenDropModeRoll": "Roll what you can",
+  "SETTINGS.TokenDropModeAverage": "Average rolls",
+  "SETTINGS.TokenDropModeIgnore": "Do nothing",
   "SETTINGS.EnableStatusIcons": "Enable status icons",
   "SETTINGS.EnableStatusIconsHint": "Set if combat and sanity effects icons are shown in tokens.",
   "SETTINGS.ShowExperimentalFeatures": "Show Experimental Features",
@@ -1299,6 +1305,9 @@
   "CoC7.TokenCreationRoll.Prompt": "This token has rollables characteristics or skills.<br>What do you want to do ?",
   "CoC7.TokenCreationRoll.ButtonRoll": "Roll all",
   "CoC7.TokenCreationRoll.ButtonAverage": "Average all",
+  "CoC7.TokenCreationRoll.Rolled": "{name} characteristics and skills rolled",
+  "CoC7.TokenCreationRoll.Averaged": "{name} characteristics and skills averaged",
+  
 
   "CoC7.RealRollDecaderPlaceholderName": "10's"
 }

--- a/module/hooks/create-token.js
+++ b/module/hooks/create-token.js
@@ -1,6 +1,8 @@
 /* global Hooks, Dialog, game */
 export function listen () {
-  Hooks.on('createToken', async (tokenDocument, options, actorId) => {
+  Hooks.on('createToken', async (tokenDocument, options, craetorId) => {
+    // Only token creator can roll
+    if( game.user.id !== craetorId) return
     // Set token icon correctly
     if (
       tokenDocument.texture.src === 'icons/svg/mystery-man.svg' &&
@@ -10,24 +12,51 @@ export function listen () {
 
     // If there is something to roll ask if we should roll it
     if (tokenDocument._object.actor.type !== 'character' && (tokenDocument._object.actor.hasRollableCharacteristics || tokenDocument._object.actor.hosRollableSkills)) {
-      new Dialog(
-        {
-          title: game.i18n.localize('CoC7.TokenCreationRoll.Title'),
-          content: game.i18n.localize('CoC7.TokenCreationRoll.Prompt'),
-          buttons: {
-            roll: {
-              label: game.i18n.localize('CoC7.TokenCreationRoll.ButtonRoll'),
-              callback: async () => await tokenDocument._object.actor.rollCharacteristicsValue()
-            },
-            average: {
-              label: game.i18n.localize('CoC7.TokenCreationRoll.ButtonAverage'),
-              callback: async () => await tokenDocument._object.actor.averageCharacteristicsValue()
-            },
-            skip: {
-              label: game.i18n.localize('CoC7.Migrate.ButtonSkip')
-            }
-          }
-        }).render(true)
+      switch (game.settings.get('CoC7', 'tokenDropMode')) {
+        case 'ask':
+          new Dialog(
+            {
+              title: game.i18n.localize('CoC7.TokenCreationRoll.Title'),
+              content: game.i18n.localize('CoC7.TokenCreationRoll.Prompt'),
+              buttons: {
+                roll: {
+                  label: game.i18n.localize('CoC7.TokenCreationRoll.ButtonRoll'),
+                  callback: async () => { 
+                    await tokenDocument._object.actor.rollCharacteristicsValue()
+                    ui.notifications.info(game.i18n.format('CoC7.TokenCreationRoll.Rolled', { name: tokenDocument.object.actor.name} ))
+                    tokenDocument._object.actor.locked = true
+                  }
+                },
+                average: {
+                  label: game.i18n.localize('CoC7.TokenCreationRoll.ButtonAverage'),
+                  callback: async () => {
+                    await tokenDocument._object.actor.averageCharacteristicsValue()
+                    ui.notifications.info(game.i18n.format('CoC7.TokenCreationRoll.Averaged', { name: tokenDocument.object.actor.name} ))
+                    tokenDocument._object.actor.locked = true
+                  }
+                },
+                skip: {
+                  label: game.i18n.localize('CoC7.Migrate.ButtonSkip')
+                }
+              }
+            }).render(true)
+          break;
+        
+        case 'roll':
+          tokenDocument._object.actor.rollCharacteristicsValue()
+          ui.notifications.info(game.i18n.format('CoC7.TokenCreationRoll.Rolled', { name: tokenDocument.object.actor.name} ))
+          tokenDocument._object.actor.locked = true
+          break;
+
+        case 'average':
+          tokenDocument._object.actor.averageCharacteristicsValue()
+          ui.notifications.info(game.i18n.format('CoC7.TokenCreationRoll.Averaged', { name: tokenDocument.object.actor.name} ))
+          tokenDocument._object.actor.locked = true
+          break;
+  
+        case 'ignore':
+          break;
+      } 
     }
   })
 }

--- a/module/scripts/register-settings.js
+++ b/module/scripts/register-settings.js
@@ -231,7 +231,21 @@ export function registerSettings () {
     default: false,
     type: Boolean
   })
-
+  /** Default behavior when NPC is created on a scene */
+  game.settings.register('CoC7', 'tokenDropMode', {
+    name: 'SETTINGS.TokenDropMode',
+    hint: 'SETTINGS.TokenDropModeHint',
+    scope: 'world',
+    config: true,
+    default: 'ask',
+    type: String,
+    choices: {
+      ask: 'SETTINGS.TokenDropModeAsk',
+      roll: 'SETTINGS.TokenDropModeRoll',
+      average: 'SETTINGS.TokenDropModeAverage',
+      ignore: 'SETTINGS.TokenDropModeIgnore'
+    }
+  })
   /**
    * Game Artwork Settings
    */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->


## Description.

<!--- Describe your changes in details. -->
Add a setting under 'Scene Settings' to define the behavior when a NPC/Monster with "rollable" characteristics or skills is created
- By default, the system will ask what to do.
- Options are : ask, roll, average and do nothing

Fix a bug where a player was shown the choice dialog when a NPC was created. Now only the user creating the NPC will be asked.



## Motivation and Context.
Resolves #1500

## Screenshots.

<!-- If appropriate. -->

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
