### PR TITLE
Use Mythos Hardened flag in Sanity workflow

### DIFF
--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -1944,7 +1944,7 @@ export class CoCActor extends Actor {
     const sanityLossEvent = this.getReasonSanLoss(sanReason)
     if (!sanityLossEvent.immunity) {
       await this.setSan(this.san - sanLoss)
-      this.setReasonSanLoss(sanReason, sanLoss)
+      if (sanLoss > 0) this.setReasonSanLoss(sanReason, sanLoss)
       return sanLoss
     }
     return 0

--- a/module/chat/cards/san-check.js
+++ b/module/chat/cards/san-check.js
@@ -243,7 +243,12 @@ export class SanCheckCard extends ChatCardActor {
     this.state.involuntaryActionPerformed = this.sanCheck.passed
     this.state.sanLossRolled = true
     this.state.ignoreSanCheck = true
-    this.sanLoss = this.sanLossFormula
+    this.preHardenedSanLoss = this.originalSanLoss = this.sanLossFormula
+    this.sanLoss = this.applyMythosHardened(this.preHardenedSanLoss)
+  }
+
+  applyMythosHardened(sanLoss) {
+    return this.actor.mythosHardened ? Math.ceil(sanLoss / 2) : sanLoss;
   }
 
   async rollSan () {
@@ -266,25 +271,30 @@ export class SanCheckCard extends ChatCardActor {
       this.state.sanLossApplied = true
       this.state.intRolled = true
       this.state.insanity = false
-      this.sanLoss = 0
+      this.preHardenedSanLoss = 0
+      this.originalSanLoss = 0;
     } else if (typeof this.sanLossFormula === 'number') {
       this.state.sanLossRolled = true
+      this.originalSanLoss = this.sanLossFormula
       if (this.sanData.sanReason) {
-        this.sanLoss = this.actor.maxLossToSanReason(
+        const max = this.actor.maxLossToSanReason(
           this.sanData.sanReason,
-          this.sanLossFormula
+          this.sanData.sanMax
         )
-        if (this.sanLoss < this.sanLossFormula) {
+        this.preHardenedSanLoss = this.originalSanLoss
+        if (this.preHardenedSanLoss > max) {
+          this.preHardenedSanLoss = max
           this.state.limitedLossToCreature = true
         }
       } else {
-        this.sanLoss = this.sanLossFormula
+        this.preHardenedSanLoss = this.originalSanLoss
       }
     } else if (this.sanCheck.isFumble) {
       this.state.sanLossRolled = true
-      this.sanLoss = this.actor.maxLossToSanReason(
+      this.originalSanLoss = new Roll(this.sanData.sanMax)[(!foundry.utils.isNewerVersion(game.version, '12') ? 'evaluate' : 'evaluateSync')/* // FoundryVTT v11 */]({ maximize: true }).total
+      this.preHardenedSanLoss = this.actor.maxLossToSanReason(
         this.sanData.sanReason,
-        this.sanData.sanMax
+        this.originalSanLoss
       )
     } else if (this.sanData.sanReason) {
       const min = new Roll(this.sanLossFormula)[(!foundry.utils.isNewerVersion(game.version, '12') ? 'evaluate' : 'evaluateSync')/* // FoundryVTT v11 */]({ minimize: true }).total
@@ -294,10 +304,12 @@ export class SanCheckCard extends ChatCardActor {
       )
       if (min >= max) {
         this.state.sanLossRolled = true
-        this.sanLoss = max
+        this.preHardenedSanLoss = this.originalSanLoss = this.max
         this.state.limitedLossToCreature = true
       }
     }
+
+    this.sanLoss = this.applyMythosHardened(this.preHardenedSanLoss)
   }
 
   async rollSanLoss () {
@@ -316,7 +328,9 @@ export class SanCheckCard extends ChatCardActor {
       this.state.limitedLossToCreature = true
     }
 
-    this.sanLoss = Math.min(this.sanLossRoll.total, max)
+    this.originalSanLoss = this.sanLossRoll.total
+    this.preHardenedSanLoss = Math.min(this.originalSanLoss, max)
+    this.sanLoss = this.applyMythosHardened(this.preHardenedSanLoss)
     this.state.sanLossRolled = true
   }
 

--- a/module/items/spell/data.js
+++ b/module/items/spell/data.js
@@ -96,7 +96,7 @@ export class CoC7Spell extends CoC7Item {
         break
       case 'sanity':
         characteristicName = game.i18n.localize('CoC7.SanityPoints')
-        this.grantSanityLoss(loss)
+        loss = await this.grantSanityLoss(loss)
         break
       case 'magicPoints':
         characteristicName = game.i18n.localize('CoC7.MagicPoints')
@@ -141,7 +141,8 @@ export class CoC7Spell extends CoC7Item {
       const sanityCheck = SanCheckCard.getFromCard(html)
       await sanityCheck.bypassRollSan()
       await sanityCheck.rollSanLoss()
-      sanityCheck.updateChatCard()
+      await sanityCheck.updateChatCard()
+      return sanityCheck.sanLoss
     }
   }
 

--- a/templates/chat/cards/san-check.html
+++ b/templates/chat/cards/san-check.html
@@ -77,9 +77,19 @@
         {{#if state.sanLossRolled}}
           {{#if state.sanLossApplied}}
             {{#if state.actorLostSan}}
-              <div class='info'>{{ localize 'CoC7.SanityLost' }}: {{#if __inlineSanLossRoll}}{{{__inlineSanLossRoll}}}{{else}}{{sanLoss}}{{/if}}</div>
+              <div class='info'>
+                {{ localize 'CoC7.SanityLost' }}: 
+                {{#if __inlineSanLossRoll}}
+                  {{{__inlineSanLossRoll}}}
+                {{else}}
+                  {{originalSanLoss}}
+                {{/if}}                
+              </div>
               {{#if state.limitedLossToCreature}}
-                <div class='info'>{{ localize 'CoC7.GrowingAccustomedToAwfulness' }}: {{sanLoss}}</div>
+                <div class='info'>{{ localize 'CoC7.GrowingAccustomedToAwfulness' }}: {{preHardenedSanLoss}}</div>
+              {{/if}}
+              {{#if actor.mythosHardened}}
+                <div class='info'>{{ localize 'CoC7.BackgroundFlagsMythosHardened' }}: {{preHardenedSanLoss}} / 2 = {{sanLoss}}</div>
               {{/if}}
             {{else}}
               {{#if state.immuneAlreadyInBout}}
@@ -205,6 +215,10 @@
 
     {{#if actor.hasTempoInsane}}
       <div class="status">{{ localize 'CoC7.BoutActive'}}</div>
+    {{/if}}
+
+    {{#if actor.mythosHardened}}
+      <div class="status">{{ localize 'CoC7.BackgroundFlagsMythosHardened'}}</div>
     {{/if}}
 
     {{#if sanData.sanReason}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description.

Use Mythos Hardened flag to calculate sanity loss in Sanity workflow.

## Motivation and Context.

Mythos Hardened flag, although set on PC sheet is not taken into account when sanity loss is calculated in Sanity workflow. This requires to manually track and adjust lost sanity for Mythos Hardened investigators.

Fixes #1411 

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
