### PR TITLE
Allow to hide spell casts

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -135,6 +135,7 @@
   "CoC7.Initiative": "Initiative",
 
   "CoC7.Cast": "Cast",
+  "CoC7.CastHidden": "Cast Hidden",
   "CoC7.SanityCost": "Sanity Cost",
   "CoC7.PowerCost": "Power Cost",
   "CoC7.HitPointsCost": "Hit Points Cost",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -135,6 +135,7 @@
   "CoC7.Initiative": "Inicjatywa",
 
   "CoC7.Cast": "Rzuć",
+  "CoC7.CastHidden": "Rzuć ukryty",
   "CoC7.SanityCost": "Koszt Poczytalności",
   "CoC7.PowerCost": "Koszt Mocy",
   "CoC7.HitPointsCost": "Koszt PW",

--- a/module/items/spell/data.js
+++ b/module/items/spell/data.js
@@ -1,4 +1,4 @@
-/* global ChatMessage, CONST, Dialog, foundry, game, Roll, renderTemplate, ui */
+/* global ChatMessage, Dialog, foundry, game, Roll, renderTemplate, ui */
 import { CoC7Utilities } from '../../utilities.js'
 import { CoC7Item } from '../item.js'
 import { SanCheckCard } from '../../chat/cards/san-check.js'

--- a/module/items/spell/data.js
+++ b/module/items/spell/data.js
@@ -1,4 +1,4 @@
-/* global ChatMessage, Dialog, foundry, game, Roll, renderTemplate, ui */
+/* global ChatMessage, CONST, Dialog, foundry, game, Roll, renderTemplate, ui */
 import { CoC7Utilities } from '../../utilities.js'
 import { CoC7Item } from '../item.js'
 import { SanCheckCard } from '../../chat/cards/san-check.js'
@@ -12,7 +12,7 @@ export class CoC7Spell extends CoC7Item {
     this.context = context
   }
 
-  async cast () {
+  async cast (priv) {
     if (!this.isOwned) {
       /** This is not owned by any Actor */
       return ui.notifications.error(game.i18n.localize('CoC7.NotOwned'))
@@ -67,20 +67,24 @@ export class CoC7Spell extends CoC7Item {
     }
     for (const [key, value] of Object.entries(costs)) {
       if (!value || Number(value) === 0) continue
-      losses.push(await this.resolveLosses(key, value))
+      losses.push(await this.resolveLosses(key, value, priv))
     }
     const template = 'systems/CoC7/templates/items/spell/chat.html'
     const description = this.system.description.value
     const html = await renderTemplate(template, { description, losses })
-    return await ChatMessage.create({
+    let chatData = {
       user: game.user.id,
       speaker: ChatMessage.getSpeaker({ actor: this.actor }),
       flavor: this.name,
       content: html
-    })
+    }
+    if (priv) {
+      chatData = ChatMessage.applyRollMode(chatData, 'gmroll')
+    }
+    return await ChatMessage.create(chatData)
   }
 
-  async resolveLosses (characteristic, value) {
+  async resolveLosses (characteristic, value, priv) {
     let characteristicName
     let loss
     if (CoC7Utilities.isFormula(value)) {
@@ -96,7 +100,7 @@ export class CoC7Spell extends CoC7Item {
         break
       case 'sanity':
         characteristicName = game.i18n.localize('CoC7.SanityPoints')
-        this.grantSanityLoss(loss)
+        this.grantSanityLoss(loss, priv)
         break
       case 'magicPoints':
         characteristicName = game.i18n.localize('CoC7.MagicPoints')
@@ -113,17 +117,21 @@ export class CoC7Spell extends CoC7Item {
   }
 
   /** Bypass the Sanity check and just roll the damage */
-  async grantSanityLoss (value) {
+  async grantSanityLoss (value, priv) {
     const template = SanCheckCard.template
     let html = await renderTemplate(template, {})
-    const message = await ChatMessage.create({
+    let chatData = {
       user: game.user.id,
       speaker: ChatMessage.getSpeaker({ actor: this.actor }),
       flavor: game.i18n.format('CoC7.CastingSpell', {
         spell: this.name
       }),
       content: html
-    })
+    }
+    if (priv) {
+      chatData = ChatMessage.applyRollMode(chatData, 'gmroll')
+    }
+    const message = await ChatMessage.create(chatData)
     const card = await message.getHTML()
     if (typeof card.length !== 'undefined' && card.length === 1) {
       const sanityLoss = value

--- a/module/items/spell/sheet.js
+++ b/module/items/spell/sheet.js
@@ -56,7 +56,11 @@ export class CoC7SpellSheet extends ItemSheet {
     html.find('.option').click(event => this.modifyType(event))
     html.find('#cast-spell').click(event => {
       event.preventDefault()
-      this.item.cast()
+      this.item.cast(false)
+    })
+    html.find('#cast-spell-hidden').click(event => {
+      event.preventDefault()
+      this.item.cast(true)
     })
   }
 

--- a/styles/sheets/spell.less
+++ b/styles/sheets/spell.less
@@ -117,12 +117,13 @@
           max-width: fit-content;
         }
 
-        #cast-spell {
+        .cast-button {
           align-items: center;
           background: rgba(0, 0, 0, 0.05);
           border: 0.065rem solid var(--main-sheet-front-color);
           border-radius: 0.25rem;
           padding: 0.3rem;
+          margin-bottom: 0.5rem;
 
           &:focus,
           &:hover {

--- a/templates/items/spell/main.html
+++ b/templates/items/spell/main.html
@@ -21,11 +21,18 @@
     <div class="aside">
       {{#if (and hasOwner (or isKeeper isOwner))}}
         <div class="flexrow">
-          <span id="cast-spell">
+          <span id="cast-spell" class="cast-button">
             <label>
               {{localize "CoC7.Cast"}}
             </label>
           </span>
+          {{#if isKeeper}}
+            <span id="cast-spell-hidden" class="cast-button">
+              <label>
+                {{localize "CoC7.CastHidden"}}
+              </label>
+            </span>
+          {{/if}}
         </div>
       {{/if}}
     </div>


### PR DESCRIPTION
## Description.

Add option for GM to cast spells as hidden. For GM there's additional button added on spell sheet: 'Cast Hidden'.

## Motivation and Context.

Chat messages about NPC or monsters spell casts are visible to all players. It's often not desired, as showing all the information about spell (description, costs) might give players information that they should not have.

This PR introduces additional cast mode for GM in which all information about spell being casted is shown to GM only.

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
