### PR TITLE
Addeed missing SAN Loss localization placeholder entries. fixes #1587

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -608,6 +608,8 @@
   "CoC7.IntCheck": "Intelligence check",
   "CoC7.NoSanLoss": "No SAN loss",
   "CoC7.SANLoss": "Sanity Loss",
+  "CoC7.SANLossPass": "Pass",
+  "CoC7.SANLossFail": "Fail",
   "CoC7.SanityCheckPerformed": "You were exposed to a traumatic event.",
   "CoC7.InvoluntaryActionPerformed": "You lost self-control for a moment.",
   "CoC7.SanityLost": "Sanity points lost",

--- a/lang/es.json
+++ b/lang/es.json
@@ -584,6 +584,8 @@
   "CoC7.IntCheck": "Tirada de INT",
   "CoC7.NoSanLoss": "Sin pérdida de COR",
   "CoC7.SANLoss": "Pérdida de COR",
+  "CoC7.SANLossPass": "Pasada",
+  "CoC7.SANLossFail": "Fallada",
   "CoC7.SanityCheckPerformed": "Has experimentado un evento traumático",
   "CoC7.InvoluntaryActionPerformed": "Pierdes el autocontrol durante unos instantes",
   "CoC7.SanityLost": "Puntos de COR perdidos",

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -230,13 +230,13 @@
             <div class="san-check flexrow" style="flex: 8; font-size: 12px;" draggable="true" data-context-menu="san-loss-roll" data-target-type="san-check">
               <label class="roll-san rollable" style="text-align: right;" title="{{ localize 'CoC7.SanRollHint'}}">{{ localize "CoC7.SANLoss" }} :</label>
               {{#if data.system.flags.locked}}
-                <span class="san-value pass flex1" style="line-height: 22px;padding-left: 2px; text-align: right;" placeholder="pass">{{data.system.special.sanLoss.checkPassed}}</span>
+                <span class="san-value pass flex1" style="line-height: 22px;padding-left: 2px; text-align: right;" placeholder="{{ localize 'CoC7.SANLossPass' }}">{{data.system.special.sanLoss.checkPassed}}</span>
                 <span class="flex0" style="line-height: 22px;">/</span>
-                <span class="san-value failed flex1" style="line-height: 22px;padding-left: 2px;" placeholder="fail">{{data.system.special.sanLoss.checkFailled}}</span>
+                <span class="san-value failed flex1" style="line-height: 22px;padding-left: 2px;" placeholder="{{ localize 'CoC7.SANLossFail' }}">{{data.system.special.sanLoss.checkFailled}}</span>
               {{else}}
-                <input class="san-value flex1" style="text-align: right;" type="text" name="system.special.sanLoss.checkPassed" value="{{data.system.special.sanLoss.checkPassed}}" data-dtype="String" placeholder="pass">
+                <input class="san-value flex1" style="text-align: right;" type="text" name="system.special.sanLoss.checkPassed" value="{{data.system.special.sanLoss.checkPassed}}" data-dtype="String" placeholder="{{ localize 'CoC7.SANLossPass' }}">
                 <span class="flex0" style="line-height: 22px;">/</span>
-                <input class="san-value flex1" type="text" name="system.special.sanLoss.checkFailled" value="{{data.system.special.sanLoss.checkFailled}}" data-dtype="String" placeholder="fail">
+                <input class="san-value flex1" type="text" name="system.special.sanLoss.checkFailled" value="{{data.system.special.sanLoss.checkFailled}}" data-dtype="String" placeholder="{{ localize 'CoC7.SANLossFail' }}">
               {{/if}}
             </div>
             <div class="flex1"></div>


### PR DESCRIPTION
## Description.

Addeed missing SAN Loss localization placeholder entries
Fixes #1587 

## Motivation and Context.

The placeholder text was harcoded

## Types of Changes.

- [x ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
