### PR TITLE
Organize system compendia on its own folder

### DIFF
--- a/system.json
+++ b/system.json
@@ -23,6 +23,14 @@
     "lib/game-icons/game-icons.css",
     "coc7g.css"
   ],
+  "packFolders": [
+    {
+      "name": "Call of Cthulhu 7",
+      "sorting": "a",
+      "color": "#3a3b71",
+      "packs": ["skills", "items", "examples", "roll-requests", "sanity-tables-examples", "system-doc"]
+    }
+  ],
   "packs": [
     {
       "label": "Skills",


### PR DESCRIPTION
## Description.

Added packfolders to organize system compendia on its own folder - different modules might have different folders and compendia might be better organized in folders