### PR TITLE
Update extreme damage calculation

### DIFF
--- a/module/chat/cards/damage.js
+++ b/module/chat/cards/damage.js
@@ -252,7 +252,7 @@ export class DamageCard extends InteractiveChatCard {
       let rollString
       if (this.critical) {
         if (this.impale) {
-          rollString = formula + '+' + maxDamage
+          rollString = this.weapon?.system?.range[range]?.damage + '+' + maxDamage
           return rollString
         } else {
           return maxDamage

--- a/module/chat/combat/melee-resolution.js
+++ b/module/chat/combat/melee-resolution.js
@@ -221,7 +221,7 @@ export class CoC7MeleeResoltion {
     }
 
     if (this.winner) {
-      if (this.winner.roll.successLevel >= CoC7Check.successLevel.extreme) {
+      if (this.winner.roll.successLevel >= CoC7Check.successLevel.extreme && this.winner.roll.side == 'initiator') {
         this.winner.roll.criticalDamage = true
       } else {
         this.winner.roll.criticalDamage = false

--- a/module/chat/damagecards.js
+++ b/module/chat/damagecards.js
@@ -39,7 +39,7 @@ export class CoC7DamageRoll extends ChatCardActor {
     this.roll = null
     if (this.critical) {
       if (this.weapon.impale) {
-        this.rollString = this.rollString + '+' + this.maxDamage
+        this.rollString = this.weapon.system.range[range].damage + '+' + this.maxDamage
         this.roll = new Roll(this.rollString)
         await this.roll.roll({ async: true })
         this.result = Math.floor(this.roll.total)

--- a/module/chat/rangecombat.js
+++ b/module/chat/rangecombat.js
@@ -734,6 +734,7 @@ export class CoC7RangeInitiator {
       if (volleySize > 0) {
         let damageFormula = String(h.shot.damage)
         if (!damageFormula || damageFormula === '') damageFormula = '0'
+        const damageWithoutDB = damageFormula
         if (this.item.system.properties.addb) {
           damageFormula = damageFormula + '+' + this.actor.db
         }
@@ -743,7 +744,7 @@ export class CoC7RangeInitiator {
         const damageDie = CoC7Damage.getMainDie(damageFormula)
         const maxDamage = new Roll(damageFormula)[(!foundry.utils.isNewerVersion(game.version, '12') ? 'evaluate' : 'evaluateSync')/* // FoundryVTT v11 */]({ maximize: true }).total
         const criticalDamageFormula = this.weapon.impale
-          ? `${damageFormula} + ${maxDamage}`
+          ? `${damageWithoutDB} + ${maxDamage}`
           : `${maxDamage}`
         const criticalDamageDie = CoC7Damage.getMainDie(criticalDamageFormula)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description.
The code have been changed to follow the rules on page 103 of Keeper Rulebook.
- No damage bonus roll is made for penetration.
- No extreme damage is applied when fighting back.

<!--- Describe your changes in details. -->


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->
<!-- If appropriate. -->


