### PR TITLE
Investigator Wizard: Support multiple text roll values / add armor Item type

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -12,6 +12,7 @@
   "CoC7.ActorIsSyntheticActor": "Actor is a synthetic actor (instance of an actor)",
 
   "CoC7.Entities.Archetype": "Archetype",
+  "CoC7.Entities.Armor": "Armor",
   "CoC7.Entities.Book": "Book",
   "CoC7.Entities.Chase": "Chase",
   "CoC7.Entities.Item": "Item",
@@ -491,6 +492,7 @@
   "CoC7.AddBook": "Add book",
   "CoC7.NewSpellName": "new spell",
   "CoC7.AddSpell": "Add spell",
+  "CoC7.AddArmor": "Add armor",
 
   "CoC7.AddWeapon": "Add weapon",
   "CoC7.NewWeaponName": "new weapon",

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -469,6 +469,7 @@ export class CoC7ActorSheet extends ActorSheet {
     sheetData.showInventoryTalents = false
     sheetData.showInventoryStatuses = false
     sheetData.showInventoryWeapons = false
+    sheetData.showInventoryArmor = false
 
     sheetData.hasConditions =
       this.actor.effects.size > 0 ||

--- a/module/actors/sheets/character.js
+++ b/module/actors/sheets/character.js
@@ -204,6 +204,9 @@ export class CoC7CharacterSheet extends CoC7ActorSheet {
     sheetData.showInventoryStatuses =
       Object.prototype.hasOwnProperty.call(sheetData.itemsByType, 'status') ||
       !sheetData.data.system.flags.locked
+    sheetData.showInventoryArmor =
+      Object.prototype.hasOwnProperty.call(sheetData.itemsByType, 'armor') ||
+      !sheetData.data.system.flags.locked
 
     sheetData.hasInventory =
     sheetData.showInventoryItems ||
@@ -211,7 +214,8 @@ export class CoC7CharacterSheet extends CoC7ActorSheet {
       sheetData.showInventorySpells ||
       sheetData.showInventoryTalents ||
       sheetData.showInventoryStatuses ||
-      sheetData.showInventoryWeapons
+      sheetData.showInventoryWeapons ||
+      sheetData.showInventoryArmor
 
     sheetData.enrichedBackstory = await TextEditor.enrichHTML(
       sheetData.data.system.backstory,

--- a/module/actors/sheets/container.js
+++ b/module/actors/sheets/container.js
@@ -97,13 +97,17 @@ export class CoC7ContainerSheet extends ActorSheet {
     sheetData.showInventoryWeapons =
       Object.prototype.hasOwnProperty.call(sheetData.itemsByType, 'weapon') ||
       !sheetData.data.system.flags.locked
+    sheetData.showInventoryArmor =
+      Object.prototype.hasOwnProperty.call(sheetData.itemsByType, 'armor') ||
+      !sheetData.data.system.flags.locked
 
     sheetData.hasInventory =
       sheetData.showInventoryItems ||
       sheetData.showInventoryBooks ||
       sheetData.showInventorySpells ||
       sheetData.showInventoryTalents ||
-      sheetData.showInventoryWeapons
+      sheetData.showInventoryWeapons ||
+      sheetData.showInventoryArmor
 
     sheetData.enrichedDescriptionValue = await TextEditor.enrichHTML(
       sheetData.data.system.description.value,

--- a/module/actors/sheets/npc-sheet.js
+++ b/module/actors/sheets/npc-sheet.js
@@ -43,6 +43,11 @@ export class CoC7NPCSheet extends CoC7ActorSheet {
     sheetData.showInventoryStatuses =
       Object.prototype.hasOwnProperty.call(sheetData.itemsByType, 'status') ||
       !sheetData.data.system.flags.locked
+
+    sheetData.showInventoryArmor =
+      Object.prototype.hasOwnProperty.call(sheetData.itemsByType, 'armor') ||
+      !sheetData.data.system.flags.locked
+
     sheetData.showInventoryWeapons = false
     sheetData.hasInventory =
       sheetData.showInventoryItems ||
@@ -50,7 +55,8 @@ export class CoC7NPCSheet extends CoC7ActorSheet {
       sheetData.showInventorySpells ||
       sheetData.showInventoryTalents ||
       sheetData.showInventoryStatuses ||
-      sheetData.showInventoryWeapons
+      sheetData.showInventoryWeapons ||
+      sheetData.showInventoryArmor
 
     sheetData.enrichedBiographyPersonalDescription = await TextEditor.enrichHTML(
       sheetData.data.system.biography.personalDescription?.value,

--- a/module/apps/investigator-wizard.js
+++ b/module/apps/investigator-wizard.js
@@ -1276,9 +1276,11 @@ export class CoC7InvestigatorWizard extends FormApplication {
     if (typeof this.object.bioSections[index] !== 'undefined') {
       const rolltable = await game.system.api.cocid.fromCoCID(key)
       if (rolltable.length === 1) {
-        const tableResult = await rolltable[0].roll()
-        if (tableResult.results[0].type === CONST.TABLE_RESULT_TYPES.TEXT) {
-          this.object.bioSections[index].value = (this.object.bioSections[index].value + '\n' + tableResult.results[0].text.trim()).trim()
+        const tableResults = await rolltable[0].roll()
+        for (const tableResult of tableResults.results) {
+          if (tableResult.type === CONST.TABLE_RESULT_TYPES.TEXT) {
+            this.object.bioSections[index].value = (this.object.bioSections[index].value + '\n' + tableResult.text.trim()).trim()
+          }
         }
       }
     }

--- a/module/items/sheets/armor.js
+++ b/module/items/sheets/armor.js
@@ -1,0 +1,56 @@
+/* global foundry game ItemSheet TextEditor */
+import { addCoCIDSheetHeaderButton } from '../../scripts/coc-id-button.js'
+import CoC7ActiveEffect from '../../active-effect.js'
+
+export class CoC7ArmorSheet extends ItemSheet {
+  static get defaultOptions () {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ['coc7', 'sheet', 'armor'],
+      template: 'systems/CoC7/templates/items/armor.hbs',
+      width: 520,
+      height: 480,
+      dragDrop: [{ dragSelector: '.item' }],
+      scrollY: ['.tab.description'],
+      tabs: [
+        {
+          navSelector: '.sheet-navigation',
+          contentSelector: '.sheet-body',
+          initial: 'description'
+        }
+      ]
+    })
+  }
+
+  _getHeaderButtons () {
+    const headerButtons = super._getHeaderButtons()
+    addCoCIDSheetHeaderButton(headerButtons, this)
+    return headerButtons
+  }
+
+  async getData () {
+    const sheetData = super.getData()
+
+    sheetData.enrichedDescriptionValue = await TextEditor.enrichHTML(
+      sheetData.data.system.description.value,
+      {
+        async: true,
+        secrets: sheetData.editable
+      }
+    )
+
+    sheetData.effects = CoC7ActiveEffect.prepareActiveEffectCategories(
+      this.item.effects
+    )
+
+    sheetData.isKeeper = game.user.isGM
+    return sheetData
+  }
+
+  activateListeners (html) {
+    super.activateListeners(html)
+
+    html
+      .find('.effect-control')
+      .click(ev => CoC7ActiveEffect.onManageActiveEffect(ev, this.item))
+  }
+}

--- a/module/scripts/register-sheets.js
+++ b/module/scripts/register-sheets.js
@@ -1,5 +1,6 @@
 /* global Actors, ActorSheet, Items, ItemSheet, Journal, JournalSheet, MacroConfig, Macros, PlaylistConfig, Playlists, RollTables, RollTableConfig, Scenes, SceneConfig */
 import { CoC7ArchetypeSheet } from '../items/sheets/archetype.js'
+import { CoC7ArmorSheet } from '../items/sheets/armor.js'
 import { CoC7BookSheet } from '../items/book/sheet.js'
 import { CoC7CharacterSheet } from '../actors/sheets/character.js'
 import { CoC7CharacterSheetV3 } from '../actors/sheets/character-v3.js'
@@ -92,6 +93,10 @@ export function registerSheets () {
   })
   Items.registerSheet('CoC7', CoC7ChaseSheet, {
     types: ['chase'],
+    makeDefault: true
+  })
+  Items.registerSheet('CoC7', CoC7ArmorSheet, {
+    types: ['armor'],
     makeDefault: true
   })
   Items.registerSheet('CoC7', CoC7ItemSheet, { types: ['item'] })

--- a/styles/sheets/form-applications.less
+++ b/styles/sheets/form-applications.less
@@ -129,16 +129,22 @@ div.investigator-wizard {
       }
     }
 
-    div.form-group.status {
-      border: 1px solid #000;
+    div.form-group {
+      &.status {
+        border: 1px solid #000;
 
-      i.fa-solid.fa-circle-check,
-      i.fa-solid.fa-circle-xmark {
-        margin: 0 0.5rem;
+        i.fa-solid.fa-circle-check,
+        i.fa-solid.fa-circle-xmark {
+          margin: 0 0.5rem;
+        }
+
+        i.fa-solid.fa-circle-xmark {
+          color: red;
+        }
       }
 
-      i.fa-solid.fa-circle-xmark {
-        color: red;
+      textarea.backstory-text {
+        height: 6rem;
       }
     }
   }

--- a/styles/sheets/items.less
+++ b/styles/sheets/items.less
@@ -630,7 +630,8 @@
 .coc7.sheet.spell,
 .coc7.sheet.talent,
 .coc7.sheet.status,
-.coc7.sheet.archetype {
+.coc7.sheet.archetype,
+.coc7.sheet.armor {
   .sheet-header {
     img.profile {
       border: 1px groove;

--- a/template.json
+++ b/template.json
@@ -377,7 +377,8 @@
       "spell",
       "talent",
       "status",
-      "chase"
+      "chase",
+      "armor"
     ],
     "item": {
       "description": {
@@ -804,6 +805,12 @@
       "started": false,
       "vehicle": false,
       "participants": []
+    },
+    "armor": {
+      "description": {
+        "value": "",
+        "keeper": ""
+      }
     }
   }
 }

--- a/templates/actors/parts/actor-inventory-items.html
+++ b/templates/actors/parts/actor-inventory-items.html
@@ -132,6 +132,33 @@
         </ol>
       </div>
     {{/if}}
+    {{#if showInventoryArmor}}
+      <div class="inventory-section">
+        <ol class="item-list">
+          <li class="flexrow inventory-header">
+            <div class="item-name flexrow">
+              <h3>{{localize 'CoC7.Armor'}}</h3>
+              {{#unless data.system.flags.locked}}
+                <div style='flex:initial;'>
+                  <div class="add-item button" title="{{localize 'CoC7.AddArmor'}}" data-type="armor">{{localize 'CoC7.AddArmor'}}</div>
+                </div>
+              {{/unless}}
+            </div>
+          </li>
+          {{#each itemsByType.armor as |item id|}}
+            <li class="item flexrow" data-item-id="{{item._id}}">
+              <div class="item-image" style="background-image: url({{item.img}})"></div>
+              <h4 class="item-name show-detail">{{item.name}}</h4>
+              <div class="item-controls">
+                <a class="item-control item-trade" title="{{localize 'CoC7.TradeItem'}}"><i class="game-icon game-icon-trade"></i></a>
+                <a class="item-control item-edit" title="{{localize 'CoC7.EditItem'}}"><i class="fas fa-edit"></i></a>
+                <a class="item-control item-delete" title="{{localize 'CoC7.DeleteItem'}}"><i class="fas fa-trash"></i></a>
+              </div>
+            </li>
+          {{/each}}
+        </ol>
+      </div>
+    {{/if}}
     {{#if showInventoryStatuses}}
       <div class="inventory-section">
         <ol class="item-list">

--- a/templates/actors/parts/actor-possessions-v3.hbs
+++ b/templates/actors/parts/actor-possessions-v3.hbs
@@ -113,6 +113,29 @@
           {{/each}}
         </ol>
       {{/if}}
+      {{#if showInventoryArmor}}
+        <div class="section-header flexrow">
+          <h3>{{localize 'CoC7.Armor'}}</h3>
+          {{#unless data.system.flags.locked}}
+            <div class="header-buttons">
+              <a class="add-item" data-type="armor" title='{{localize "CoC7.AddArmor"}}'><i class="fas fa-plus"></i></a>
+            </div>
+          {{/unless}}
+        </div>
+        <ol class="item-list">
+          {{#each itemsByType.armor as |item id|}}
+            <li class="item flexrow" data-item-id="{{item._id}}">
+              <div class="item-image" style="background-image: url({{item.img}})"></div>
+              <h4 class="item-name show-detail">{{item.name}}</h4>
+              <div class="item-controls">
+                <a class="item-control item-trade" title="{{localize 'CoC7.TradeItem'}}"><i class="game-icon game-icon-trade"></i></a>
+                <a class="item-control item-edit" title="{{localize 'CoC7.EditItem'}}"><i class="fas fa-edit"></i></a>
+                <a class="item-control item-delete" title="{{localize 'CoC7.DeleteItem'}}"><i class="fas fa-trash"></i></a>
+              </div>
+            </li>
+          {{/each}}
+        </ol>
+      {{/if}}
       {{#if showInventoryStatuses}}
         <div class="section-header flexrow">
           <h3>{{localize 'CoC7.Status'}}</h3>

--- a/templates/items/armor.hbs
+++ b/templates/items/armor.hbs
@@ -1,0 +1,38 @@
+<form class="{{cssClass}} flexcol" autocomplete="off">
+  <header class="sheet-header flexrow" style="flex: 0 0 64px;padding-bottom: 2px;">
+    <div class="header-details flexrow">
+      <h1 class="name" style="height: 48px;">
+        <input name="name" type="text" value="{{item.name}}" placeholder="{{ localize 'CoC7.Name' }}" />
+      </h1>
+    </div>
+    <img class="profile" src="{{item.img}}" data-edit="img" title="{{item.name}}" height="64" width="64" />
+  </header>
+
+  {{!-- Item Sheet Navigation --}}
+  <nav style="flex: 0 0 24px;margin-bottom: 4px;font-family: 'Modesto Condensed', 'Palatino Linotype', serif;font-size: 16px;font-weight: 700;" class="sheet-navigation tabs" data-group="primary">
+    <a style="line-height: 24px;" class="item active" data-tab="description">{{ localize "CoC7.Description" }}</a>
+    <a class="keeper-only-tab" data-tab="effects" title="{{localize 'CoC7.Effects'}}">
+      <div class="tab-name"><span><i class="game-icon game-icon-aura"></i></span></div>
+    </a>
+    {{#if isKeeper}}
+      <a style="line-height: 24px;" class="item keeper-only-tab" data-tab="keeper" title="{{localize 'CoC7.GmNotes'}}"><i class="game-icon game-icon-tentacles-skull"></i></a>
+    {{/if}}
+  </nav>
+
+  {{!-- Item Sheet Body --}}
+  <section style="overflow: hidden;flex: 1;" class="sheet-body">
+    <div class="tab flexrow active" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="description">
+      {{editor enrichedDescriptionValue target="system.description.value" engine="prosemirror" button=true owner=owner editable=editable}}
+    </div>
+
+    <div class="tab coc7" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="effects">
+      {{> "systems/CoC7/templates/common/active-effects.hbs"}}
+    </div>
+
+    {{#if isKeeper}}
+      <div class="tab keeper" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+        {{editor enrichedDescriptionKeeper target="system.description.keeper" engine="prosemirror" button=true owner=owner editable=editable}}
+      </div>
+    {{/if}}
+  </section>
+</form>


### PR DESCRIPTION
## Description.
Allow multiple backstory roll text results at once
Add armor type item for use with active effects

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
