### PR TITLE
Rename altered flexcol and flexrow styles

### DIFF
--- a/module/actors/sheets/character.js
+++ b/module/actors/sheets/character.js
@@ -382,7 +382,7 @@ export class CoC7CharacterSheet extends CoC7ActorSheet {
 
   async _onEditSanityLossReason (event) {
     const input = $(event.currentTarget)
-    const offset = input.closest('.flexrow').data('offset')
+    const offset = input.closest('.flexrow-coc7').data('offset')
     if (typeof this.actor.system.sanityLossEvents?.[offset]?.totalLoss !== 'undefined') {
       const sanityLossEvents = foundry.utils.duplicate(this.actor.system.sanityLossEvents)
       sanityLossEvents[offset].totalLoss = parseInt(input.val(), 10)
@@ -393,7 +393,7 @@ export class CoC7CharacterSheet extends CoC7ActorSheet {
   _onDeleteSanityLossReason (event) {
     event.preventDefault()
     const offset = $(event.currentTarget)
-      .closest('.flexrow')
+      .closest('.flexrow-coc7')
       .data('offset')
     const sanityLossEvents = this.actor.system.sanityLossEvents ?? []
     sanityLossEvents.splice(offset, 1)

--- a/module/hooks/render-coc7-journal-sheet.js
+++ b/module/hooks/render-coc7-journal-sheet.js
@@ -12,7 +12,7 @@ export default function RenderCoC7JournalSheet (application, html, data) {
         obj.find('article.journal-entry-page.text.level1')?.before('<div style="padding: 0.5em;"></div>')
       } else {
         const short = subheading.trim().length === 0
-        obj.find('article.journal-entry-page.text.level1')?.before('<div class="adventure-heading-section flexrow"><div class="bookmark' + (short ? ' short' : '') + '"><img src="systems/CoC7/assets/art/' + (short ? 'bookmarks.webp' : 'bookmark.webp') + '"></div><div class="adventure-heading"><div class="heading">' + data.title + '</div>' + (short ? '' : '<div class="subheading">' + subheading + '</div>') + '</div></div>')
+        obj.find('article.journal-entry-page.text.level1')?.before('<div class="adventure-heading-section flexrow-coc7"><div class="bookmark' + (short ? ' short' : '') + '"><img src="systems/CoC7/assets/art/' + (short ? 'bookmarks.webp' : 'bookmark.webp') + '"></div><div class="adventure-heading"><div class="heading">' + data.title + '</div>' + (short ? '' : '<div class="subheading">' + subheading + '</div>') + '</div></div>')
       }
     }
   }

--- a/module/scripts/compendium-filter.js
+++ b/module/scripts/compendium-filter.js
@@ -218,8 +218,8 @@ export function compendiumFilter () {
         .find('header.directory-header')
         .after(
           '<div class="compendiumfilter">' +
-          '<div class="header-search flexrow"><i class="fas fa-layer-group"></i><select name="coc7type' + app.appId + '" style="">' + select.join('') + '</select></div>' +
-          '<div class="header-search flexrow era_select" style="display:none"><i class="fas fa-layer-group"></i><select name="coc7era' + app.appId + '" style="">' + eras.join('') + '</select></div>' +
+          '<div class="header-search flexrow-coc7"><i class="fas fa-layer-group"></i><select name="coc7type' + app.appId + '" style="">' + select.join('') + '</select></div>' +
+          '<div class="header-search flexrow-coc7 era_select" style="display:none"><i class="fas fa-layer-group"></i><select name="coc7era' + app.appId + '" style="">' + eras.join('') + '</select></div>' +
           '</div>'
         )
       html.find('select').change(app.options.filters[0].callback.bind(app))

--- a/styles/interface/app.less
+++ b/styles/interface/app.less
@@ -173,7 +173,7 @@
   }
 }
 #bonus-roll-form {
-  div.flexrow {
+  div.flexrow-coc7 {
     margin: 2px 0;
     align-items: center;
   }

--- a/styles/sheets/book.less
+++ b/styles/sheets/book.less
@@ -35,7 +35,7 @@
       'body body body';
     padding: 0.15rem;
 
-    .flexrow {
+    .flexrow-coc7 {
       padding: 0.15rem 0;
     }
 
@@ -110,7 +110,7 @@
       grid-area: aside;
       text-align: center;
 
-      .flexrow {
+      .flexrow-coc7 {
         justify-content: center;
         margin: 0.065rem 0;
 
@@ -289,7 +289,7 @@
             justify-content: center;
             text-align: center;
 
-            .flexrow {
+            .flexrow-coc7 {
               justify-content: center;
               margin-top: -0.188rem;
 

--- a/styles/sheets/character-v3.less
+++ b/styles/sheets/character-v3.less
@@ -164,7 +164,7 @@
         .sheet-inner {
           height: calc(100% - 57px);
           margin-bottom: 5px;
-          .flexrow();
+          .flexrow-coc7();
 
           .auto-toggle:hover {
             text-shadow: 0 0 10px var(--main-sheet-interactive-color);
@@ -307,7 +307,7 @@
                 margin-bottom: 0.3rem;
 
                 .detail-wrapper {
-                  .flexrow();
+                  .flexrow-coc7();
                   align-items: center;
 
                   .detail-label {
@@ -348,7 +348,7 @@
                 border-radius: 15px;
                 overflow: hidden;
                 margin-bottom: 0.3rem;
-                .flexcol();
+                .flexcol-coc7();
 
                 &.show-part-values {
                   .characteristics-grid .char-box .char-box-values {
@@ -445,7 +445,7 @@
                   background: rgba(0, 0, 0, 0.08);
                   border-radius: 15px;
                   margin-bottom: 0.3rem;
-                  .flexcol();
+                  .flexcol-coc7();
 
                   .attribute-label {
                     color: var(--official-coc-label-color);
@@ -507,7 +507,7 @@
                 overflow: hidden;
                 font-size: 1.1rem;
                 font-family: "MODESTO CONDENSED";
-                .flexcol();
+                .flexcol-coc7();
 
                 .derived-attributes-top-line {
                   background-image: var(--investigator-sheet-red-line);
@@ -817,7 +817,7 @@
                     }
 
                     .weapon-range {
-                      .flexrow();
+                      .flexrow-coc7();
 
                       .weapon-damage {
                         text-align: center;
@@ -834,7 +834,7 @@
                     }
 
                     .weapon-controls {
-                      .flexrow();
+                      .flexrow-coc7();
 
                       a.reload-weapon {
                         vertical-align: middle;
@@ -974,7 +974,7 @@
                   }
 
                   .skill-icons {
-                    .flexrow();
+                    .flexrow-coc7();
                     flex: 0 0 2.3rem;
                     text-align: right;
 
@@ -1104,7 +1104,7 @@
                 }
 
                 .bio-section-boxes {
-                  .flexrow();
+                  .flexrow-coc7();
                   gap: 0.4rem;
 
                   .bio-section-events {

--- a/styles/sheets/chase.less
+++ b/styles/sheets/chase.less
@@ -292,7 +292,7 @@
   // background-attachment: local;
   // background-image: linear-gradient(to right, red , blue);
 
-  .flexrow {
+  .flexrow-coc7 {
     flex-wrap: nowrap;
     flex: 0 0 auto;
   }

--- a/styles/sheets/items.less
+++ b/styles/sheets/items.less
@@ -598,7 +598,7 @@
       // Item Control Buttons
       .item-controls {
         flex: 0 0 32px;
-        .flexrow();
+        .flexrow-coc7();
         justify-content: flex-end;
 
         a {
@@ -834,7 +834,7 @@
       // Item Control Buttons
       .item-controls {
         flex: 0 0 32px;
-        .flexrow();
+        .flexrow-coc7();
         justify-content: flex-end;
 
         a {

--- a/styles/sheets/occupation.less
+++ b/styles/sheets/occupation.less
@@ -39,7 +39,7 @@
     }
     .item-controls {
       flex: 0 0 32px;
-      .flexrow();
+      .flexrow-coc7();
       justify-content: flex-end;
       a {
         flex: 0 0 16px;

--- a/styles/sheets/sheet.less
+++ b/styles/sheets/sheet.less
@@ -190,7 +190,7 @@
 
     .item-controls {
       flex: 0 0 58px;
-      .flexrow();
+      .flexrow-coc7();
       justify-content: flex-end;
       height: 16px;
 

--- a/styles/sheets/sheets.less
+++ b/styles/sheets/sheets.less
@@ -73,8 +73,8 @@ html {
     display: block;
   }
 
-  .tab[data-tab].active.flexrow,
-  .tab[data-tab].active.flexcol {
+  .tab[data-tab].active.flexrow-coc7,
+  .tab[data-tab].active.flexcol-coc7 {
     display: flex;
   }
 

--- a/styles/sheets/spell.less
+++ b/styles/sheets/spell.less
@@ -34,7 +34,7 @@
       'body body body';
     padding: 0.15rem;
 
-    .flexrow {
+    .flexrow-coc7 {
       padding: 0.15rem 0;
     }
 
@@ -109,7 +109,7 @@
       grid-area: aside;
       text-align: center;
 
-      .flexrow {
+      .flexrow-coc7 {
         justify-content: center;
         margin: 0.065rem 0;
 
@@ -219,7 +219,7 @@
           grid-area: type;
           text-align: center;
 
-          .flexrow {
+          .flexrow-coc7 {
             justify-content: center;
             margin-top: -0.188rem;
 

--- a/styles/sheets/summary.less
+++ b/styles/sheets/summary.less
@@ -61,7 +61,7 @@
         max-width: fit-content;
         margin-left: 5px;
       }
-      .flexrow {
+      .flexrow-coc7 {
         margin: 0 5px;
         max-width: fit-content;
       }

--- a/styles/system/adventure-sheet.less
+++ b/styles/system/adventure-sheet.less
@@ -70,7 +70,7 @@ div.coc7-adventure-entry.sheet {
         padding:0;
       }
 
-      ul.flexrow {
+      ul.flexrow-coc7 {
         li {
           list-style-type: none;
           text-align: center;
@@ -304,7 +304,7 @@ div.coc7-adventure-entry.sheet {
       }
     }
 
-    div.flexrow.two-column {
+    div.flexrow-coc7.two-column {
       text-align: justify;
 
       div:first-child {

--- a/styles/system/coc7.less
+++ b/styles/system/coc7.less
@@ -85,7 +85,7 @@
       font-weight: bold;
     }
     .form-fields {
-      .flexrow();
+      .flexrow-coc7();
       > * {
         margin: 0 3px 0 0;
         &:last-child {

--- a/styles/system/compendiums.less
+++ b/styles/system/compendiums.less
@@ -3,7 +3,7 @@
   flex: none;
   padding-bottom: 3px;
 
-  .flexrow {
+  .flexrow-coc7 {
     align-items: center;
     margin: 0 0 3px;
 

--- a/styles/system/main.less
+++ b/styles/system/main.less
@@ -969,7 +969,7 @@
   min-width: 672px;
   min-height: 765px;
 }
-.flexrow {
+.flexrow-coc7 {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
@@ -990,7 +990,7 @@
     flex: 4;
   }
 }
-.flexcol {
+.flexcol-coc7 {
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;

--- a/styles/system/variables.less
+++ b/styles/system/variables.less
@@ -8,7 +8,7 @@
 @colorCrimson: #44191a;
 @borderGroove: 2px groove #eeede0;
 @sheetBackground: url('../assets/images/background.webp') repeat;
-.flexrow {
+.flexrow-coc7 {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
@@ -33,7 +33,7 @@
     justify-content: flex-end;
   }
 }
-.flexcol {
+.flexcol-coc7 {
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;

--- a/templates/actors/character-sheet-v2.html
+++ b/templates/actors/character-sheet-v2.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}} flexcol {{#if permissionLimited}}permission-limited{{/if}}" autocomplete="off" data-actor-id="{{actor.id}}" {{#if tokenId}}data-token-id="{{tokenId}}" {{/if}}>
+<form class="{{cssClass}} flexcol-coc7 {{#if permissionLimited}}permission-limited{{/if}}" autocomplete="off" data-actor-id="{{actor.id}}" {{#if tokenId}}data-token-id="{{tokenId}}" {{/if}}>
   {{#if showHiddenDevMenu}}
     <div class="floating-debug">
       <a class="test-trigger" title='Test Icon, if you see that and do not know why, then you should not click it'>
@@ -28,18 +28,18 @@
         </div>
 
         <div class="infos">
-          <div class="row flexrow">
+          <div class="row flexrow-coc7">
             <label>{{ localize 'CoC7.Name' }} :</label>
             <input name="name" type="text" value="{{actor.name}}" />
           </div>
           {{#if displayPlayerName}}
-            <div class="row flexrow">
+            <div class="row flexrow-coc7">
               <label>{{ localize 'CoC7.PlayerName' }} :</label>
               <input name="system.infos.playername" type="text" value="{{data.system.infos.playername}}" />
             </div>
           {{/if}}
           {{#if pulpRuleArchetype}}
-            <div class="row flexrow">
+            <div class="row flexrow-coc7">
               <label>{{ localize 'CoC7.Archetype' }} :</label>
               {{#if data.system.infos.archetypeSet}}
                 <span class="rollable open-item" data-type="archetype">{{data.system.infos.archetype}}</span>
@@ -52,12 +52,12 @@
             </div>
           {{/if}}
           {{#if pulpRuleOrganization}}
-            <div class="row flexrow">
+            <div class="row flexrow-coc7">
               <label>{{ localize 'CoC7.Organization' }} :</label>
               <input name="system.infos.organization" type="text" value="{{data.system.infos.organization}}" />
             </div>
           {{/if}}
-          <div class="row flexrow">
+          <div class="row flexrow-coc7">
             <label>{{ localize 'CoC7.Occupation' }} :</label>
             {{#if data.system.infos.occupationSet}}
               <span class="rollable open-item" data-type="occupation">{{data.system.infos.occupation}}</span>
@@ -68,17 +68,17 @@
               <input name="system.infos.occupation" type="text" value="{{data.system.infos.occupation}}" />
             {{/if}}
           </div>
-          <div class="row flexrow">
+          <div class="row flexrow-coc7">
             <label>{{ localize 'CoC7.Age' }} :</label>
             <input name="system.infos.age" type="text" value="{{data.system.infos.age}}" />
             <label>{{ localize 'CoC7.Sex' }} :</label>
             <input name="system.infos.sex" type="text" value="{{data.system.infos.sex}}" />
           </div>
-          <div class="row flexrow">
+          <div class="row flexrow-coc7">
             <label>{{ localize 'CoC7.Residence' }} :</label>
             <input name="system.infos.residence" type="text" value="{{data.system.infos.residence}}" />
           </div>
-          <div class="row flexrow">
+          <div class="row flexrow-coc7">
             <label>{{ localize 'CoC7.Birthplace' }} :</label>
             <input name="system.infos.birthplace" type="text" value="{{data.system.infos.birthplace}}" />
           </div>
@@ -262,14 +262,14 @@
                 {{#if hasConditions}}
                   <div><a class="clear_conditions button">{{localize 'CoC7.ClearAllConditions'}}</a></div>
                 {{/if}}
-                <div class="flexrow">
+                <div class="flexrow-coc7">
                   {{> "systems/CoC7/templates/actors/parts/actor-keeper-mythos-enounters.hbs"}}
-                  <div class="flexcol bio-section" style="flex: 0 0 50%;">
-                    <div class="flexrow" style="flex: initial;">
+                  <div class="flexcol-coc7 bio-section" style="flex: 0 0 50%;">
+                    <div class="flexrow-coc7" style="flex: initial;">
                       <label style="height: 1rem;margin: 0;border: 0;font-family: customSheetFont, 'Palatino Linotype', serif;font-size: .75rem;flex: 1;">{{localize 'CoC7.BackgroundFlags'}}</label>
                     </div>
                     <div class="bio-section-value" style="min-height: 80px;">
-                      <div class="flexrow">
+                      <div class="flexrow-coc7">
                         <div class="bio-section-type">{{localize 'CoC7.BackgroundFlagsMythosExperienced'}}</div>
                         <div class="item-controls">
                           <a class="item-control toggle-keeper-flags" title="{{localize 'CoC7.BackgroundFlagsMythosExperienced'}}" data-flag="mythosInsanityExperienced">
@@ -281,7 +281,7 @@
                           </a>
                         </div>
                       </div>
-                      <div class="flexrow">
+                      <div class="flexrow-coc7">
                         <div class="bio-section-type">{{localize 'CoC7.BackgroundFlagsMythosHardened'}}</div>
                         <div class="item-controls">
                           <a class="item-control toggle-keeper-flags" title="{{localize 'CoC7.BackgroundFlagsMythosHardened'}}" data-flag="mythosHardened">
@@ -320,7 +320,7 @@
                       </div>
                     {{/if}}
                     {{#each data.system.monetary.values as |value index|}}
-                      <div class="flexrow form-group item" data-index="{{index}}">
+                      <div class="flexrow-coc7 form-group item" data-index="{{index}}">
                         <input name="system.monetary.values.{{index}}.name" value="{{localize value.name}}" type="text" placeholder="{{localize 'CoC7.Name'}}">
                         <input name="system.monetary.values.{{index}}.min" value="{{value.min}}" class="cash-assets-range" type="number" placeholder="{{localize 'CoC7.MonetaryCreditRatingMin'}}">
                         <input name="system.monetary.values.{{index}}.max" value="{{value.max}}" class="cash-assets-range" type="number" placeholder="{{localize 'CoC7.MonetaryCreditRatingMax'}}">
@@ -361,11 +361,11 @@
     </div>
   {{else}}
     {{#if isSummarized}}
-      <div class="sheet-portrait flexcol">
+      <div class="sheet-portrait flexcol-coc7">
         <img src="{{actor.img}}" title="{{actor.name}}" style="flex: auto !important; height: 1px !important; border: 0; width: 100% !important;">
       </div>
     {{else}}
-      <div class="sheet-portrait flexcol">
+      <div class="sheet-portrait flexcol-coc7">
         <img class="photo" src="{{actor.img}}" title="{{actor.name}}" data-edit="img" style="object-fit: fill; max-height: 100%;" />
       </div>
     {{/if}}

--- a/templates/actors/character-sheet-v3.hbs
+++ b/templates/actors/character-sheet-v3.hbs
@@ -1,4 +1,4 @@
-<form class="{{cssClass}} flexcol" autocomplete="off">
+<form class="{{cssClass}} flexcol-coc7" autocomplete="off">
   {{#unless permissionLimited}}
     <nav class="tabs sheet-nav" data-group="primary">
       <div class="tab tab-green">
@@ -57,7 +57,7 @@
       {{/if}}
     </div>
 
-    <section class="sheet flexcol">
+    <section class="sheet flexcol-coc7">
       <div class="ornament-top"></div>
       <div class="sheet-inner">
         <section class="sheet-header">
@@ -121,7 +121,7 @@
               </div>
             </div>
             {{~> 'systems/CoC7/templates/actors/parts/actor-characteristics-v3.hbs'}}
-            <div class="secondary-attributes flexrow">
+            <div class="secondary-attributes flexrow-coc7">
               <div class="secondary-attribute attribute attr-hp{{#unless (and data.system.flags.locked data.system.attribs.hp.auto)}} manual-override{{/unless}}" data-attrib="hp">
                 <div class="attribute-label{{#unless data.system.flags.locked}} auto-toggle{{/unless}}">{{localize 'CoC7.HP'}}</div>
                 <input class="attribute-value" type="text" name="system.attribs.hp.value" value="{{data.system.attribs.hp.value}}" data-dtype="Number" />
@@ -200,7 +200,7 @@
             </div>
           </div>
         </section>
-        <div class="sheet-main flexcol">
+        <div class="sheet-main flexcol-coc7">
           <div class="tab-top-line"></div>
           <section class="sheet-body">
             <!-- Development -->
@@ -236,7 +236,7 @@
             {{#unless data.system.flags.locked}}
               <div class="tab portrait-frame" data-tab="portrait-frame">
                 <h2>Portrait Options</h2>
-                <div class="flexrow">
+                <div class="flexrow-coc7">
                   <div class="optionbox">
                     <div class="photo-frame" data-object-fit="contain">
                       <img class="sheet-photo portrait-frame" src="{{actor.img}}" style="object-fit: contain;">
@@ -248,7 +248,7 @@
                     </div>
                   </div>
                 </div>
-                <div class="flexrow">
+                <div class="flexrow-coc7">
                   <div class="optionbox">
                     <div class="photo-frame" data-object-fit="fill">
                       <img class="sheet-photo portrait-frame" src="{{actor.img}}" style="object-fit: fill;">

--- a/templates/actors/character/summary.html
+++ b/templates/actors/character/summary.html
@@ -1,7 +1,7 @@
 <form class="summarized" autocomplete="off" data-actor-id="{{actor.id}}" {{#if tokenId}}data-token-id="{{tokenId}}" {{/if}}>
   <div class="container">
-    <div class="header flexrow" style="flex-wrap: nowrap;">
-      <div class="flexrow attribute" data-attrib="lck" style="flex-wrap: nowrap;">
+    <div class="header flexrow-coc7" style="flex-wrap: nowrap;">
+      <div class="flexrow-coc7 attribute" data-attrib="lck" style="flex-wrap: nowrap;">
         <label class="attribute-label rollable">{{localize 'CoC7.Luck'}}</label>
         <div class="current-value">
           <input class="attribute-value" type="text" name="system.attribs.lck.value" value="{{data.system.attribs.lck.value}}" data-dtype="Number" />
@@ -16,7 +16,7 @@
         </div>
       </div>
 
-      <div class="flexrow" data-attrib="hp" style="flex-wrap: nowrap;">
+      <div class="flexrow-coc7" data-attrib="hp" style="flex-wrap: nowrap;">
         <label class="attribute-label">{{localize 'CoC7.HitPoints'}}</label>
         <div class="current-value">
           <input class="attribute-value" type="text" name="system.attribs.hp.value" value="{{data.system.attribs.hp.value}}" data-dtype="Number" />
@@ -43,7 +43,7 @@
         {{/if}}
       </div>
 
-      <div class="flexrow attribute" data-attrib="san" style="flex-wrap: nowrap;">
+      <div class="flexrow-coc7 attribute" data-attrib="san" style="flex-wrap: nowrap;">
         <label class="attribute-label rollable">{{localize 'CoC7.Sanity'}}</label>
         <div class="current-value">
           <input class="attribute-value" type="text" name="system.attribs.san.value" value="{{data.system.attribs.san.value}}" data-dtype="Number" />
@@ -67,7 +67,7 @@
         <a class="condition-monitor {{#if data.system.conditions.indefInsane.value}}status-on{{/if}}" title="{{#if data.system.conditions.indefInsane.value}}{{localize 'CoC7.UnderlyingInsanity'}}{{else}}{{localize 'CoC7.IndefiniteInsanity'}}{{/if}}" data-condition="indefInsane"><i class="game-icon game-icon-tentacles-skull"></i></a>
       </div>
 
-      <div class="flexrow" data-attrib="mp" style="flex-wrap: nowrap;">
+      <div class="flexrow-coc7" data-attrib="mp" style="flex-wrap: nowrap;">
         <label class="attribute-label">{{localize 'CoC7.MagicPoints'}}</label>
         <div class="current-value">
           <input class="attribute-value" type="text" name="system.attribs.mp.value" value="{{data.system.attribs.mp.value}}" data-dtype="Number" />
@@ -164,7 +164,7 @@
           {{#if weapon.system.properties.melee}}
             <li class="weapon-row item weapon {{#unless weapon.skillSet}}error{{/unless}}" data-item-id="{{weapon._id}}" title="{{#unless weapon.skillSet}}{{localize 'CoC7.NoSkill'}}{{/unless}}">
               <div class="weapon-image" style="background-image: url('{{weapon.img}}')"></div>
-              <div class="flexrow">
+              <div class="flexrow-coc7">
                 <div class="weapon-name combat {{#if weapon.skillSet}}rollable{{else}}item-edit{{/if}}">{{weapon.name}}</div>
                 {{#if weapon.system.properties.thrown}}
                   <a class="weapon-name combat alternativ-skill {{#if weapon.skillSet}}rollable{{else}}item-edit{{/if}}" title="Throw"><i class="game-icon game-icon-thrown-knife"></i></a>
@@ -181,7 +181,7 @@
           {{else}}
             <li class="weapon-row item weapon {{#unless weapon.skillSet}}error{{/unless}}" data-item-id="{{weapon._id}}" title="{{#unless weapon.skillSet}}{{localize 'CoC7.NoSkill'}}{{/unless}}">
               <div class="weapon-image" style="background-image: url('{{weapon.img}}')"></div>
-              <div class="flexrow">
+              <div class="flexrow-coc7">
                 <div class="weapon-name combat {{#if weapon.skillSet}}rollable{{else}}item-edit{{/if}}">{{weapon.name}}</div>
                 {{#if weapon.usesAlternateSkill}}
                   <a class="weapon-name combat alternativ-skill {{#if weapon.skillSet}}rollable{{else}}item-edit{{/if}}" title="{{localize 'CoC7.AutomaticFire'}}"><i class="game-icon game-icon-machine-gun-magazine"></i></a>
@@ -202,7 +202,7 @@
           {{/if}}
         {{/each}}
       </ol>
-      <div class="flexrow cash-row">
+      <div class="flexrow-coc7 cash-row">
         <label>{{localize 'CoC7.MonetarySpendingLevel'}}</label>
         {{#if data.system.flags.manualCredit}}
           <input type="text" name="system.monetary.spendingLevel" value="{{data.system.monetary.spendingLevel}}">
@@ -210,7 +210,7 @@
           <span>{{monetary.spendingLevel}}</span>
         {{/if}}
       </div>
-      <div class="flexrow cash-row">
+      <div class="flexrow-coc7 cash-row">
         <label>{{localize 'CoC7.MonetaryCash'}}</label>
         {{#if data.system.flags.manualCredit}}
           <input type="text" name="system.monetary.cash" value="{{data.system.monetary.cash}}">

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}} flexcol {{#if permissionLimited}}permission-limited{{/if}}" autocomplete="off" data-actor-id="{{actor.id}}" {{#if tokenId}}data-token-id="{{tokenId}}" {{/if}}>
+<form class="{{cssClass}} flexcol-coc7 {{#if permissionLimited}}permission-limited{{/if}}" autocomplete="off" data-actor-id="{{actor.id}}" {{#if tokenId}}data-token-id="{{tokenId}}" {{/if}}>
   <div class="token-extras">
     {{#if canDragToken}}
       <div draggable="true" class="token-drag-handle" title="{{ localize 'CoC7.ActorIsTokenHint'}}"><i class="fas fa-user-circle"></i></div>
@@ -13,46 +13,46 @@
     {{/if}}
   </div>
   {{!-- Sheet Header --}}
-  <header class="sheet-header flexrow" style="flex: 0 0 auto;padding-bottom: 10px;border-bottom: 2px groove;">
+  <header class="sheet-header flexrow-coc7" style="flex: 0 0 auto;padding-bottom: 10px;border-bottom: 2px groove;">
     {{#unless permissionLimited}}
-      <div class="flexcol">
-        <div class="infos flexrow" style="flex: 0 0 auto;display: flex;">
+      <div class="flexcol-coc7">
+        <div class="infos flexrow-coc7" style="flex: 0 0 auto;display: flex;">
           {{#if isCreature}}
-            <div class="flexrow flex1">
+            <div class="flexrow-coc7 flex1">
               <label>{{localize 'CoC7.Name'}}</label>
               <input name="name" type="text" value="{{actor.name}}" placeholder="{{localize 'CoC7.Name'}}" />
             </div>
-            <div class="flexrow flex1">
+            <div class="flexrow-coc7 flex1">
               <label>{{localize 'CoC7.Type'}}</label>
               <input name="system.infos.type" type="text" value="{{data.system.infos.type}}" />
             </div>
           {{else}}
-            <div class="flexrow flex2">
+            <div class="flexrow-coc7 flex2">
               <label>{{localize 'CoC7.Name'}}</label>
               <input name="name" type="text" value="{{actor.name}}" placeholder="{{localize 'CoC7.Name'}}" />
             </div>
-            <div class="flexrow flex2">
+            <div class="flexrow-coc7 flex2">
               <label>{{localize 'CoC7.Occupation'}}</label>
               <input name="system.infos.occupation" type="text" value="{{data.system.infos.occupation}}" />
             </div>
             {{#if pulpRuleOrganization}}
-              <div class="flexrow flex2">
+              <div class="flexrow-coc7 flex2">
                 <label>{{localize 'CoC7.Organization'}}</label>
                 <input name="system.infos.organization" type="text" value="{{data.system.infos.organization}}" />
               </div>
             {{/if}}
-            <div class="flexrow flex1">
+            <div class="flexrow-coc7 flex1">
               <label>{{localize 'CoC7.Age'}}</label>
               <input name="system.infos.age" type="text" value="{{data.system.infos.age}}" />
             </div>
           {{/if}}
         </div>
 
-        <div class="characteritics flexrow" style="flex: 0 0 auto;display: flex;">
+        <div class="characteritics flexrow-coc7" style="flex: 0 0 auto;display: flex;">
           {{#each data.system.characteristics as |characteristic key|}}
             {{#if ../data.system.flags.locked}}
               {{#if characteristic.display}}
-                <div class="flexcol char-box" style=" margin-right: 2px;" data-characteristic="{{key}}">
+                <div class="flexcol-coc7 char-box" style=" margin-right: 2px;" data-characteristic="{{key}}">
                   <div class="characteristic-label rollable" draggable="true" style="text-align: left;">
                     <label data-context-menu="skill-roll" data-target-type="characteristic">{{localize characteristic.short}}</label>
                   </div>
@@ -66,7 +66,7 @@
                 </div>
               {{/if}}
             {{else}}
-              <div class="flexcol" style=" margin-right: 2px;" data-characteristic="{{key}}">
+              <div class="flexcol-coc7" style=" margin-right: 2px;" data-characteristic="{{key}}">
                 <div class="characteristic-label rollable" draggable="true" style="text-align: left;">
                   <label>{{localize characteristic.short}}</label>
                 </div>
@@ -88,8 +88,8 @@
           {{/each}}
         </div>
 
-        <div class="attribute-list flexrow" style="display: flex;">
-          <div class="flexrow flex1 attribute" style="display: flex;" data-attrib="hp">
+        <div class="attribute-list flexrow-coc7" style="display: flex;">
+          <div class="flexrow-coc7 flex1 attribute" style="display: flex;" data-attrib="hp">
             <label class="attribute-label">{{localize 'CoC7.HP'}} :</label>
             <input class="attribute-value" type="text" name="system.attribs.hp.value" value="{{data.system.attribs.hp.value}}" data-dtype="Number" />
             <span style="flex: none;font-size: 14px;line-height:20px;">/</span>
@@ -104,7 +104,7 @@
             {{/unless}}
           </div>
           {{#if data.system.flags.locked}}
-            <div class="flexrow flex1 attribute" data-attrib="mp">
+            <div class="flexrow-coc7 flex1 attribute" data-attrib="mp">
               {{#if hasMp}}
                 <label class="attribute-label">{{localize 'CoC7.MP'}} :</label>
                 <input class="attribute-value" type="text" name="system.attribs.mp.value" value="{{data.system.attribs.mp.value}}" data-dtype="Number" />
@@ -117,7 +117,7 @@
               {{/if}}
             </div>
 
-            <div class="flexrow flex1 attribute" data-attrib="san">
+            <div class="flexrow-coc7 flex1 attribute" data-attrib="san">
               {{#if hasSan}}
                 <label class="attribute-label rollable" draggable="true" data-context-menu="san-roll" data-target-type="attribute">{{localize 'CoC7.SAN'}} :</label>
                 <input class="attribute-value" type="text" name="system.attribs.san.value" value="{{data.system.attribs.san.value}}" data-dtype="Number" />
@@ -130,14 +130,14 @@
               {{/if}}
             </div>
 
-            <div class="flexrow flex1 attribute" data-attrib="lck">
+            <div class="flexrow-coc7 flex1 attribute" data-attrib="lck">
               {{#if hasLuck}}
                 <label class="attribute-label rollable" draggable="true">{{localize 'CoC7.Luck'}} :</label>
                 <input class="attribute-value single read-only" type="text" name="system.attribs.lck.value" value="{{data.system.attribs.lck.value}}" data-dtype="Number" readonly>
               {{/if}}
             </div>
           {{else}}
-            <div class="flexrow flex1 attribute" data-attrib="mp">
+            <div class="flexrow-coc7 flex1 attribute" data-attrib="mp">
               <label class="attribute-label" draggable="true">{{localize 'CoC7.MP'}} :</label>
               <input class="attribute-value" type="text" name="system.attribs.mp.value" value="{{data.system.attribs.mp.value}}" data-dtype="Number" />
               <span style="flex: none;font-size: 14px;line-height:20px;">/</span>
@@ -149,7 +149,7 @@
               <div class="auto-toggle {{#if data.system.attribs.mp.auto}}auto-on{{else}}auto-off{{/if}}"><i class="fas fa-cogs" style="padding-top: 4px;"></i></div>
             </div>
 
-            <div class="flexrow flex1 attribute" data-attrib="san">
+            <div class="flexrow-coc7 flex1 attribute" data-attrib="san">
               <label class="attribute-label rollable">{{localize 'CoC7.SAN'}} :</label>
               <input class="attribute-value" type="text" name="system.attribs.san.value" value="{{data.system.attribs.san.value}}" data-dtype="Number" />
               <span style="flex: none;font-size: 14px;line-height:20px;">/</span>
@@ -161,15 +161,15 @@
               <div class="auto-toggle {{#if data.system.attribs.san.auto}}auto-on{{else}}auto-off{{/if}}"><i class="fas fa-cogs" style="padding-top: 4px;"></i></div>
             </div>
 
-            <div class="flexrow flex1 attribute" data-attrib="lck">
+            <div class="flexrow-coc7 flex1 attribute" data-attrib="lck">
               <label class="attribute-label rollable">{{localize 'CoC7.Luck'}} :</label>
               <input class="attribute-value single read-only" type="text" name="system.attribs.lck.value" value="{{data.system.attribs.lck.value}}" data-dtype="Number">
             </div>
           {{/if}}
         </div>
 
-        <div class="attribute-list flexrow" style="flex: none;height: 20px;">
-          <div class="flexrow flex1 attribute" data-attrib="mov">
+        <div class="attribute-list flexrow-coc7" style="flex: none;height: 20px;">
+          <div class="flexrow-coc7 flex1 attribute" data-attrib="mov">
             <label>{{localize 'CoC7.Mov'}} :</label>
 
             {{#if data.system.attribs.mov.auto}}
@@ -183,7 +183,7 @@
             {{/unless}}
 
           </div>
-          <div class="flexrow flex1 attribute" data-attrib="db" data-roll-formula="{{data.system.attribs.db.value}}">
+          <div class="flexrow-coc7 flex1 attribute" data-attrib="db" data-roll-formula="{{data.system.attribs.db.value}}">
             <label class="attribute-label rollable">{{localize 'CoC7.DB'}} :</label>
 
             {{#if data.system.attribs.db.auto}}
@@ -196,7 +196,7 @@
               <div class="auto-toggle {{#if data.system.attribs.db.auto}}auto-on{{else}}auto-off{{/if}}"><i class="fas fa-cogs" style="padding-top: 4px;"></i></div>
             {{/unless}}
           </div>
-          <div class="flexrow flex1 attribute" data-attrib="build">
+          <div class="flexrow-coc7 flex1 attribute" data-attrib="build">
             <label>{{localize 'CoC7.Build'}} :</label>
             {{#if data.system.attribs.build.auto}}
               <span class="attribute-value single" type="text" style="line-height: 22px;"> {{data.system.attribs.build.value}} </span>
@@ -208,13 +208,13 @@
               <div class="auto-toggle {{#if data.system.attribs.build.auto}}auto-on{{else}}auto-off{{/if}}"><i class="fas fa-cogs" style="padding-top: 4px;"></i></div>
             {{/unless}}
           </div>
-          <div class="flexrow flex1 attribute" data-attrib="armor">
+          <div class="flexrow-coc7 flex1 attribute" data-attrib="armor">
             <label>{{localize 'CoC7.Armor'}} :</label>
             <input class="attribute-value single {{#if data.system.flags.locked}}read-only{{/if}}" type="text" name="system.attribs.armor.value" value="{{data.system.attribs.armor.value}}" data-dtype="Number" {{#if data.system.flags.locked}}readonly{{/if}}>
           </div>
         </div>
 
-        <div class="condition-monitors flexrow">
+        <div class="condition-monitors flexrow-coc7">
           {{#if isDying}}
             <a class='dying-check' style="text-align: center;font-size: 20px;" title="{{localize 'CoC7.DyingCheck'}}"><i class="fas fa-dice-d20"></i></a>
           {{else}}
@@ -227,7 +227,7 @@
             <a class="condition-monitor {{#if data.system.conditions.indefInsane.value}}status-on{{/if}}" title="{{#if data.system.conditions.indefInsane.value}}{{localize 'CoC7.UnderlyingInsanity'}}{{else}}{{localize 'CoC7.IndefiniteInsanity'}}{{/if}}" data-condition="indefInsane"><i class="game-icon game-icon-tentacles-skull"></i></a>
             <div class="flex1"></div>
 
-            <div class="san-check flexrow" style="flex: 8; font-size: 12px;" draggable="true" data-context-menu="san-loss-roll" data-target-type="san-check">
+            <div class="san-check flexrow-coc7" style="flex: 8; font-size: 12px;" draggable="true" data-context-menu="san-loss-roll" data-target-type="san-check">
               <label class="roll-san rollable" style="text-align: right;" title="{{ localize 'CoC7.SanRollHint'}}">{{ localize "CoC7.SANLoss" }} :</label>
               {{#if data.system.flags.locked}}
                 <span class="san-value pass flex1" style="line-height: 22px;padding-left: 2px; text-align: right;" placeholder="{{localize 'CoC7.SANLossPass'}}">{{data.system.special.sanLoss.checkPassed}}</span>
@@ -241,7 +241,7 @@
             </div>
             <div class="flex1"></div>
 
-            <div class="flexrow sheet-controls" style="flex: 0 0 96px;align-content: flex-start;">
+            <div class="flexrow-coc7 sheet-controls" style="flex: 0 0 96px;align-content: flex-start;">
               {{#if allowFormula}}
                 {{#if data.system.flags.locked}}
                   <div style="flex: 0 0 32px;"></div>
@@ -294,7 +294,7 @@
       <div class="tab">
 
         <section class="sheet-section">
-          <div class="section-header flexrow" data-pannel="skills">
+          <div class="section-header flexrow-coc7" data-pannel="skills">
             <h3 class="flex1">{{localize 'CoC7.Skills'}}</h3>
             {{#unless data.system.flags.locked}}
               <div style="flex: 0 0 14px;">
@@ -308,7 +308,7 @@
         </section>
 
         <section class="sheet-section">
-          <div class="section-header flexrow" data-pannel="combat">
+          <div class="section-header flexrow-coc7" data-pannel="combat">
             <h3 class="flex1">{{localize 'CoC7.Combat'}}</h3>
             {{#unless data.system.flags.locked}}
               <div style="flex: 0 0 14px;">
@@ -317,9 +317,9 @@
             {{/unless}}
           </div>
           <div class="pannel combat expanded" style="padding-top: 1px;border-bottom: 2px groove;">
-            <div class="flexrow" style="border-bottom: 1px groove;">
-              <div class="flexrow" style="flex: 0 0 66%;flex-wrap: wrap;">&nbsp;</div>
-              <div class="flexrow" style="flex: 0 0 33%;flex-wrap: wrap;border-left: 1px groove;">
+            <div class="flexrow-coc7" style="border-bottom: 1px groove;">
+              <div class="flexrow-coc7" style="flex: 0 0 66%;flex-wrap: wrap;">&nbsp;</div>
+              <div class="flexrow-coc7" style="flex: 0 0 33%;flex-wrap: wrap;border-left: 1px groove;">
                 <h4 style="height:18px;padding: 1px 0 1px 2px;margin: 0;overflow: hidden;">{{localize 'CoC7.AttacksPerRound'}} :</h4>
                 {{#if data.system.flags.locked}}
                   <div style="flex: 0 0 25px;height: fit-content;padding: 0 2px;text-align: center;">{{data.system.special.attacksPerRound}}</div>
@@ -334,17 +334,17 @@
 
         {{#if hasInventory}}
           <section class="sheet-section">
-            <div class="section-header flexrow" data-pannel="inventory">
+            <div class="section-header flexrow-coc7" data-pannel="inventory">
               <h3 class="flex1">{{localize 'CoC7.Inventory'}}</h3>
             </div>
-            <div class="inventory flexrow pannel expanded">
+            <div class="inventory flexrow-coc7 pannel expanded">
               {{> "systems/CoC7/templates/actors/parts/actor-inventory-items.html"}}
             </div>
           </section>
         {{/if}}
 
         <section class="sheet-section">
-          <div class="section-header flexrow" data-pannel="description">
+          <div class="section-header flexrow-coc7" data-pannel="description">
             <h3 class="flex1">{{localize 'CoC7.Notes'}} </h3>
           </div>
           <div class="description pannel expanded resizededitor">
@@ -353,17 +353,17 @@
         </section>
 
         <section class="sheet-section">
-          <div class="section-header flexrow" data-pannel="effects">
+          <div class="section-header flexrow-coc7" data-pannel="effects">
             <h3 class="flex1">{{localize 'CoC7.Effects'}} <i class="game-icon game-icon-aura"></i></h3>
           </div>
-          <div class="effects flexrow pannel">
+          <div class="effects flexrow-coc7 pannel">
             {{> "systems/CoC7/templates/common/active-effects.hbs"}}
           </div>
         </section>
 
         {{#if isKeeper}}
           <section class="sheet-section">
-            <div class="section-header flexrow" data-pannel="keeper">
+            <div class="section-header flexrow-coc7" data-pannel="keeper">
               <h3 class="flex1 keeper-only-tab">{{localize 'CoC7.GmNotes'}} <i class="game-icon game-icon-tentacles-skull"></i></h3>
             </div>
             <div class="keeper pannel resizededitor">

--- a/templates/actors/parts/actor-active-effects-v3.hbs
+++ b/templates/actors/parts/actor-active-effects-v3.hbs
@@ -2,11 +2,11 @@
 <ol class="items-list effects-list">
   {{#each effects as |section sid|}}
     {{#unless section.hidden}}
-      <li class="items-header flexrow" data-effect-type="{{section.type}}">
-        <h3 class="item-name effect-name flexrow">{{localize section.label}}</h3>
+      <li class="items-header flexrow-coc7" data-effect-type="{{section.type}}">
+        <h3 class="item-name effect-name flexrow-coc7">{{localize section.label}}</h3>
         <div class="effect-source">{{localize "CoC7.Source"}}</div>
         <div class="effect-source">{{localize "CoC7.Duration"}}</div>
-        <div class="item-controls effect-controls flexrow">
+        <div class="item-controls effect-controls flexrow-coc7">
           {{#if @root.editable}}
             <a class="effect-control" data-action="create" title="{{localize 'CoC7.Create'}}">
               <i class="fas fa-plus"></i> {{localize "CoC7.Add"}}
@@ -24,14 +24,14 @@
         </li>
       {{/if}}
       {{#each section.effects as |effect|}}
-        <li class="item effect flexrow" data-effect-id="{{effect.id}}">
-          <div class="item-name effect-name flexrow">
+        <li class="item effect flexrow-coc7" data-effect-id="{{effect.id}}">
+          <div class="item-name effect-name flexrow-coc7">
             <img class="item-image" src="{{effect.icon}}" />
             <h4>{{#if effect.name}}{{effect.name}}{{!-- // FoundryVTT v10 --}}{{else}}{{effect.label}}{{/if}}</h4>
           </div>
           <div class="effect-source">{{effect.sourceName}}</div>
           <div class="effect-duration">{{effect.duration.label}}</div>
-          <div class="item-controls effect-controls flexrow">
+          <div class="item-controls effect-controls flexrow-coc7">
             {{#if @root.editable}}
               <a class="effect-control" data-action="toggle" title="{{#if effect.disabled}}{{localize 'CoC7.Enable'}}{{else}}{{localize 'CoC7.Disable'}}{{/if}}">
                 <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>

--- a/templates/actors/parts/actor-background-v3.hbs
+++ b/templates/actors/parts/actor-background-v3.hbs
@@ -8,7 +8,7 @@
     </div>
   {{/unless}}
   {{#each biographySections as |section index|}}
-    <div class="section-header bio-section flexrow" data-index='{{index}}'>
+    <div class="section-header bio-section flexrow-coc7" data-index='{{index}}'>
       {{#if ../data.system.flags.locked}}
         <h3>{{section.title}}</h3>
       {{else}}
@@ -26,12 +26,12 @@
   {{/each}}
 {{/if}}
 {{#if data.system.sanityLossEvents}}
-  <div class="section-header flexrow">
+  <div class="section-header flexrow-coc7">
     <h3>{{localize 'CoC7.BackgroundEncounters'}}</h3>
   </div>
   <div class="bio-section-events">
     {{#each data.system.sanityLossEvents as |sanityLossEvent mythosOffset|}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <div>{{sanityLossEvent.type}}</div>
         <div class="bio-section-values">
           {{#if sanityLossEvent.immunity}}
@@ -42,7 +42,7 @@
         </div>
       </div>
     {{else}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         -
       </div>
     {{/each}}

--- a/templates/actors/parts/actor-background.html
+++ b/templates/actors/parts/actor-background.html
@@ -3,15 +3,15 @@
     <div class='add-new-section button'>{{localize 'CoC7.BackgroundNewSection'}}</div>
   </div>
 {{/unless}}
-<div class='flexrow'>
+<div class='flexrow-coc7'>
   {{#each data.system.biography as |section index|}}
-    <div class='flexcol bio-section' data-index='{{index}}' style='flex: 0 0 50%;'>
+    <div class='flexcol-coc7 bio-section' data-index='{{index}}' style='flex: 0 0 50%;'>
       {{#if ../data.system.flags.locked}}
-        <div class='flexrow' style='flex: initial;'>
+        <div class='flexrow-coc7' style='flex: initial;'>
           <label style='height: 1rem;margin: 0;border: 0;font-family: customSheetFont, "Palatino Linotype", serif;font-size: .75rem;'>{{section.title}}</label>
         </div>
       {{else}}
-        <div class='flexrow' style='flex: initial;'>
+        <div class='flexrow-coc7' style='flex: initial;'>
           <input class='bio-section-title' type="text" value="{{section.title}}" placeholder="{{localize 'CoC7.BackgroundSectionNameHolder'}}">
           <div class="flex1" style='height: fit-content;'></div>
           <div class="item-controls" style='height: fit-content;font-size: 10px;line-height: 18px;'>

--- a/templates/actors/parts/actor-combat-v3.hbs
+++ b/templates/actors/parts/actor-combat-v3.hbs
@@ -1,7 +1,7 @@
 <h2>{{localize 'CoC7.Combat'}}</h2>
 <div class="combat-panel">
   <div class="weapon-list melee">
-    <div class="section-header flexrow">
+    <div class="section-header flexrow-coc7">
       <h3>{{localize 'CoC7.MeleeWeapons'}}</h3>
       {{#unless data.system.flags.locked}}
         <div class="header-buttons">
@@ -14,7 +14,7 @@
         <li class="weapon-row item weapon{{#unless weapon.skillSet}} error{{/unless}}" data-item-id="{{weapon._id}}" title="{{#unless weapon.skillSet}}{{localize 'CoC7.NoSkill'}}{{/unless}}">
           <div class="expand-arrow show-detail"><i class="fa-solid fa-play"></i></div>
           <div class="item-image" style="background-image: url('{{weapon.img}}')"></div>
-          <div class="flexrow">
+          <div class="flexrow-coc7">
             <div class="weapon-name combat{{#if weapon.skillSet}} rollable{{else}} item-edit{{/if}}">{{weapon.name}}</div>
             {{#if weapon.system.properties.thrown}}
               <a class="weapon-name combat alternativ-skill{{#if weapon.skillSet}} rollable{{else}} item-edit{{/if}}" title="Throw"><i class="game-icon game-icon-thrown-knife"></i></a>
@@ -47,7 +47,7 @@
   </div>
 
   <div class="weapon-list range">
-    <div class="section-header flexrow">
+    <div class="section-header flexrow-coc7">
       <h3>{{localize 'CoC7.RangeWeapons'}}</h3>
       {{#unless data.system.flags.locked}}
         <div class="header-buttons">
@@ -60,7 +60,7 @@
         <li class="weapon-row item weapon{{#unless weapon.skillSet}} error{{/unless}}" data-item-id="{{weapon._id}}" title="{{#unless weapon.skillSet}}{{localize 'CoC7.NoSkill'}}{{/unless}}">
           <div class="expand-arrow show-detail"><i class="fa-solid fa-play"></i></div>
           <div class="item-image" style="background-image: url('{{weapon.img}}')"></div>
-          <div class="flexrow">
+          <div class="flexrow-coc7">
             <div class="weapon-name combat{{#if weapon.skillSet}} rollable{{else}} item-edit{{/if}}">{{weapon.name}}</div>
             {{#if weapon.usesAlternateSkill}}
               <a class="weapon-name combat alternativ-skill{{#if weapon.skillSet}} rollable{{else}} item-edit{{/if}}" title="{{localize 'CoC7.AutomaticFire'}}"><i class="game-icon game-icon-machine-gun-magazine"></i></a>
@@ -101,7 +101,7 @@
   </div>
 
   <div class="skill-list melee">
-    <div class="section-header flexrow">
+    <div class="section-header flexrow-coc7">
       <h3>{{localize 'CoC7.MeleeSkills'}}</h3>
       {{#unless data.system.flags.locked}}
         <div class="header-buttons">
@@ -111,7 +111,7 @@
     </div>
     <ol class="item-list skill melee">
       {{#each meleeSkills as |skill|}}
-        <li class="item itemV2 skill flexrow" data-skill-id="{{skill._id}}" data-item-id="{{skill._id}}">
+        <li class="item itemV2 skill flexrow-coc7" data-skill-id="{{skill._id}}" data-item-id="{{skill._id}}">
           <div class="item-image" style="background-image: url('{{skill.img}}')"></div>
           {{#if ../data.system.flags.locked}}
             <div class="item-name skill-name combat rollable">{{skill.name}}</div>
@@ -144,7 +144,7 @@
   </div>
 
   <div class="skill-list range">
-    <div class="section-header flexrow">
+    <div class="section-header flexrow-coc7">
       <h3>{{localize 'CoC7.RangeSkills'}}</h3>
       {{#unless data.system.flags.locked}}
         <div class="header-buttons">
@@ -154,7 +154,7 @@
     </div>
     <ol class="item-list skill range">
       {{#each rangeSkills as |skill|}}
-        <li class="item itemV2 skill flexrow" data-skill-id="{{skill._id}}" data-item-id="{{skill._id}}">
+        <li class="item itemV2 skill flexrow-coc7" data-skill-id="{{skill._id}}" data-item-id="{{skill._id}}">
           <div class="item-image" style="background-image: url('{{skill.img}}')"></div>
           {{#if ../data.system.flags.locked}}
             <div class="item-name skill-name combat rollable">{{skill.name}}</div>

--- a/templates/actors/parts/actor-development-v3.hbs
+++ b/templates/actors/parts/actor-development-v3.hbs
@@ -78,7 +78,7 @@
 <ol class="skills-list">
   {{#each skills as |skill id|}}
     <li class="item{{#if ../pulpRuleArchetype}} pulpCharacter{{/if}}" data-skill-id="{{skill._id}}" data-item-id="{{skill._id}}">
-      <div class="item-controls flexrow">
+      <div class="item-controls flexrow-coc7">
         {{#unless skill.system.properties.noadjustments}}
           <div class="item-control occupation-skill-flag{{#if../allowCharCreation}} clickable{{/if}}" title="{{localize 'CoC7.OccupationSkill'}}">
             {{#if skill.system.flags.occupation}}

--- a/templates/actors/parts/actor-inventory-items.html
+++ b/templates/actors/parts/actor-inventory-items.html
@@ -6,8 +6,8 @@
     {{#if showInventoryItems}}
       <div class="inventory-section">
         <ol class="item-list">
-          <li class="flexrow inventory-header">
-            <div class="item-name flexrow">
+          <li class="flexrow-coc7 inventory-header">
+            <div class="item-name flexrow-coc7">
               <h3>{{localize 'CoC7.Items'}}</h3>
               {{#unless data.system.flags.locked}}
                 <div style='flex:initial;'>
@@ -17,7 +17,7 @@
             </div>
           </li>
           {{#each itemsByType.item as |item id|}}
-            <li class="item flexrow" data-item-id="{{item._id}}">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}">
               <div class="item-image" style="background-image: url({{item.img}})"></div>
               <h4 class="item-name show-detail">{{#unless (eq system.quantity 1)}}{{system.quantity}} x {{/unless}}{{item.name}}</h4>
               <div class="item-controls">
@@ -33,8 +33,8 @@
     {{#if showInventoryBooks}}
       <div class="inventory-section">
         <ol class="item-list">
-          <li class="flexrow inventory-header">
-            <div class="item-name flexrow">
+          <li class="flexrow-coc7 inventory-header">
+            <div class="item-name flexrow-coc7">
               <h3>{{localize 'CoC7.Books'}}</h3>
               {{#unless data.system.flags.locked}}
                 <div style='flex:initial;'>
@@ -44,7 +44,7 @@
             </div>
           </li>
           {{#each itemsByType.book as |item id|}}
-            <li class="item flexrow" data-item-id="{{item._id}}">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}">
               <div class="item-image" style="background-image: url({{item.img}})"></div>
               <h4 class="item-name show-detail">{{item.name}}</h4>
               <div class="item-controls">
@@ -60,8 +60,8 @@
     {{#if showInventorySpells}}
       <div class="inventory-section">
         <ol class="item-list">
-          <li class="flexrow inventory-header">
-            <div class="item-name flexrow">
+          <li class="flexrow-coc7 inventory-header">
+            <div class="item-name flexrow-coc7">
               <h3>{{localize 'CoC7.Spells'}}</h3>
               {{#unless data.system.flags.locked}}
                 <div style='flex:initial;'>
@@ -71,7 +71,7 @@
             </div>
           </li>
           {{#each itemsByType.spell as |item id|}}
-            <li class="item flexrow" data-item-id="{{item._id}}">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}">
               <div class="item-image" style="background-image: url({{item.img}})"></div>
               <h4 class="item-name show-detail">{{item.name}}</h4>
               <div class="item-controls">
@@ -87,13 +87,13 @@
     {{#if showInventoryTalents}}
       <div class="inventory-section">
         <ol class="item-list">
-          <li class="flexrow inventory-header">
-            <div class="item-name flexrow">
+          <li class="flexrow-coc7 inventory-header">
+            <div class="item-name flexrow-coc7">
               <h3>{{localize 'CoC7.PulpTalents'}}</h3>
             </div>
           </li>
           {{#each itemsByType.talent as |item id|}}
-            <li class="item flexrow" data-item-id="{{item._id}}">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}">
               <div class="item-image" style="background-image: url({{item.img}})"></div>
               <h4 class="item-name show-detail">{{item.name}}</h4>
               <div class="item-controls">
@@ -108,8 +108,8 @@
     {{#if showInventoryWeapons}}
       <div class="inventory-section">
         <ol class="item-list">
-          <li class="flexrow inventory-header">
-            <div class="item-name flexrow">
+          <li class="flexrow-coc7 inventory-header">
+            <div class="item-name flexrow-coc7">
               <h3>{{localize 'CoC7.Weapons'}}</h3>
               {{#unless data.system.flags.locked}}
                 <div style='flex:initial;'>
@@ -119,7 +119,7 @@
             </div>
           </li>
           {{#each itemsByType.weapon as |item id|}}
-            <li class="item flexrow" data-item-id="{{item._id}}">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}">
               <div class="item-image" style="background-image: url({{item.img}})"></div>
               <h4 class="item-name show-detail">{{item.name}}</h4>
               <div class="item-controls">
@@ -135,8 +135,8 @@
     {{#if showInventoryArmor}}
       <div class="inventory-section">
         <ol class="item-list">
-          <li class="flexrow inventory-header">
-            <div class="item-name flexrow">
+          <li class="flexrow-coc7 inventory-header">
+            <div class="item-name flexrow-coc7">
               <h3>{{localize 'CoC7.Armor'}}</h3>
               {{#unless data.system.flags.locked}}
                 <div style='flex:initial;'>
@@ -146,7 +146,7 @@
             </div>
           </li>
           {{#each itemsByType.armor as |item id|}}
-            <li class="item flexrow" data-item-id="{{item._id}}">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}">
               <div class="item-image" style="background-image: url({{item.img}})"></div>
               <h4 class="item-name show-detail">{{item.name}}</h4>
               <div class="item-controls">
@@ -162,13 +162,13 @@
     {{#if showInventoryStatuses}}
       <div class="inventory-section">
         <ol class="item-list">
-          <li class="flexrow inventory-header">
-            <div class="item-name flexrow">
+          <li class="flexrow-coc7 inventory-header">
+            <div class="item-name flexrow-coc7">
               <h3>{{localize 'CoC7.Status'}}</h3>
             </div>
           </li>
           {{#each itemsByType.status as |item id|}}
-            <li class="item flexrow" data-item-id="{{item._id}}">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}">
               <div class="item-image" style="background-image: url({{item.img}})"></div>
               <h4 class="item-name show-detail">{{item.name}}</h4>
               <div class="item-controls">

--- a/templates/actors/parts/actor-inventory.html
+++ b/templates/actors/parts/actor-inventory.html
@@ -1,10 +1,10 @@
-<div class="flexrow" style="height: 100%">
-  <div class="flexcol flex3 inventory">
+<div class="flexrow-coc7" style="height: 100%">
+  <div class="flexcol-coc7 flex3 inventory">
     {{> "systems/CoC7/templates/actors/parts/actor-inventory-items.html"}}
   </div>
-  <div class="flexcol flex2 cash" style="border: 1px groove;">
+  <div class="flexcol-coc7 flex2 cash" style="border: 1px groove;">
     {{#unless data.system.flags.locked}}
-      <div class="flexrow cash-row">
+      <div class="flexrow-coc7 cash-row">
         {{#if data.system.flags.manualCredit}}
           <label>{{localize 'CoC7.ManualCreditValues'}}</label>
           <div class='flex1'></div>
@@ -14,7 +14,7 @@
         </div>
       </div>
     {{/unless}}
-    <div class="flexrow cash-row">
+    <div class="flexrow-coc7 cash-row">
       <label>{{localize 'CoC7.MonetarySpendingLevel'}}</label>
       {{#if data.system.flags.manualCredit}}
         <input type="text" name="system.monetary.spendingLevel" value="{{data.system.monetary.spendingLevel}}">
@@ -22,7 +22,7 @@
         <span>{{monetary.spendingLevel}}</span>
       {{/if}}
     </div>
-    <div class="flexrow cash-row">
+    <div class="flexrow-coc7 cash-row">
       <label>{{localize 'CoC7.MonetaryCash'}}</label>
       {{#if data.system.flags.manualCredit}}
         <input type="text" name="system.monetary.cash" value="{{data.system.monetary.cash}}">
@@ -30,10 +30,10 @@
         <span>{{monetary.cash}}</span>
       {{/if}}
     </div>
-    <div class="flexrow cash-row">
+    <div class="flexrow-coc7 cash-row">
       <label>{{localize 'CoC7.MonetarySpent'}}</label><input type="text" name="system.monetary.spent" value="{{data.system.monetary.spent}}">
     </div>
-    <div class="flexrow  cash-row">
+    <div class="flexrow-coc7  cash-row">
       <label>{{localize 'CoC7.MonetaryAssets'}}</label>
       {{#if data.system.flags.manualCredit}}
         <input type="text" name="system.monetary.assets" value="{{data.system.monetary.assets}}">

--- a/templates/actors/parts/actor-keeper-mythos-enounters.hbs
+++ b/templates/actors/parts/actor-keeper-mythos-enounters.hbs
@@ -1,5 +1,5 @@
-<div class="flexcol bio-section" style="flex: 0 0 50%;">
-  <div class="flexrow" style="flex: initial;">
+<div class="flexcol-coc7 bio-section" style="flex: 0 0 50%;">
+  <div class="flexrow-coc7" style="flex: initial;">
     <label style="height: 1rem;margin: 0;border: 0;font-family: customSheetFont, 'Palatino Linotype', serif;font-size: .75rem;flex: 1;">{{localize 'CoC7.SanityLossEncounters'}}</label>
     <div class="item-controls" style="height: fit-content;font-size: 10px;flex: 0 0 16px;">
       <a class="sanity-loss-type-add" title="{{localize 'CoC7.AddSanityLossEncounter'}}" data-type="encounter"><i class="fas fa-plus-square"></i></a>
@@ -8,7 +8,7 @@
   <div class="bio-section-value" style="min-height: 80px;">
     {{#each data.system.sanityLossEvents as |sanityLossEvent mythosOffset|}}
       {{#unless sanityLossEvent.immunity}}
-        <div class="flexrow" data-offset="{{mythosOffset}}">
+        <div class="flexrow-coc7" data-offset="{{mythosOffset}}">
           <div class="bio-section-type">{{sanityLossEvent.type}}</div>
           <div class="bio-section-values">
             <input class="mythosEncountersTotalLoss" type="text" value="{{sanityLossEvent.totalLoss}}" data-dtype="Number">
@@ -21,8 +21,8 @@
     {{/each}}
   </div>
 </div>
-<div class="flexcol bio-section" style="flex: 0 0 50%;">
-  <div class="flexrow" style="flex: initial;">
+<div class="flexcol-coc7 bio-section" style="flex: 0 0 50%;">
+  <div class="flexrow-coc7" style="flex: initial;">
     <label style="height: 1rem;margin: 0;border: 0;font-family: customSheetFont, 'Palatino Linotype', serif;font-size: .75rem;flex: 1;">{{localize 'CoC7.SanityLossImmunities'}}</label>
     <div class="item-controls" style="height: fit-content;font-size: 10px;flex: 0 0 16px;">
       <a class="sanity-loss-type-add" title="{{localize 'CoC7.AddSanityLossImmunity'}}" data-type="immunity"><i class="fas fa-plus-square"></i></a>
@@ -31,7 +31,7 @@
   <div class="bio-section-value" style="min-height: 80px;">
     {{#each data.system.sanityLossEvents as |sanityLossEvent mythosOffset|}}
       {{#if sanityLossEvent.immunity}}
-        <div class="flexrow" data-offset="{{mythosOffset}}">
+        <div class="flexrow-coc7" data-offset="{{mythosOffset}}">
           <div class="bio-section-type">{{sanityLossEvent.type}}</div>
           <div class="item-controls">
             <a class="item-control sanity-loss-type-delete" title="{{localize 'CoC7.DeleteSanityLossImmunity'}}"><i class="fas fa-trash"></i></a>

--- a/templates/actors/parts/actor-keeper-notes-v3.hbs
+++ b/templates/actors/parts/actor-keeper-notes-v3.hbs
@@ -5,7 +5,7 @@
 {{/if}}
 <div class="bio-section-boxes">
   <div class="bio-section-events">
-    <div class="section-header flexrow">
+    <div class="section-header flexrow-coc7">
       <h3>{{localize 'CoC7.SanityLossEncounters'}}</h3>
       <div class="header-buttons">
         <a class="sanity-loss-type-add" title="{{localize 'CoC7.AddSanityLossEncounter'}}" data-type="encounter"><i class="fas fa-plus-square"></i></a>
@@ -14,7 +14,7 @@
     <div class="bio-section-value" style="min-height: 80px;">
       {{#each data.system.sanityLossEvents as |sanityLossEvent mythosOffset|}}
         {{#unless sanityLossEvent.immunity}}
-          <div class="flexrow" data-offset="{{mythosOffset}}">
+          <div class="flexrow-coc7" data-offset="{{mythosOffset}}">
             <div class="bio-section-type">{{sanityLossEvent.type}}</div>
             <div class="bio-section-values">
               <input class="mythosEncountersTotalLoss" type="text" value="{{sanityLossEvent.totalLoss}}" data-dtype="Number">
@@ -28,7 +28,7 @@
     </div>
   </div>
   <div class="bio-section-events">
-    <div class="section-header flexrow">
+    <div class="section-header flexrow-coc7">
       <h3>{{localize 'CoC7.SanityLossImmunities'}}</h3>
       <div class="header-buttons">
         <a class="sanity-loss-type-add" title="{{localize 'CoC7.AddSanityLossImmunity'}}" data-type="immunity"><i class="fas fa-plus-square"></i></a>
@@ -37,7 +37,7 @@
     <div class="bio-section-value" style="min-height: 80px;">
       {{#each data.system.sanityLossEvents as |sanityLossEvent mythosOffset|}}
         {{#if sanityLossEvent.immunity}}
-          <div class="flexrow" data-offset="{{mythosOffset}}">
+          <div class="flexrow-coc7" data-offset="{{mythosOffset}}">
             <div class="bio-section-type">{{sanityLossEvent.type}}</div>
             <div class="item-controls">
               <a class="item-control sanity-loss-type-delete" title="{{localize 'CoC7.DeleteSanityLossImmunity'}}"><i class="fas fa-trash"></i></a>
@@ -50,11 +50,11 @@
 </div>
 <div class="bio-section-boxes">
   <div class="bio-section-events">
-    <div class="section-header flexrow">
+    <div class="section-header flexrow-coc7">
       <h3>{{localize 'CoC7.BackgroundFlags'}}</h3>
     </div>
     <div class="bio-section-value" style="min-height: 80px;">
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <div class="bio-section-type">{{localize 'CoC7.BackgroundFlagsMythosExperienced'}}</div>
         <div class="item-controls">
           <a class="item-control toggle-keeper-flags" title="{{localize 'CoC7.BackgroundFlagsMythosExperienced'}}" data-flag="mythosInsanityExperienced">
@@ -66,7 +66,7 @@
           </a>
         </div>
       </div>
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <div class="bio-section-type">{{localize 'CoC7.BackgroundFlagsMythosHardened'}}</div>
         <div class="item-controls">
           <a class="item-control toggle-keeper-flags" title="{{localize 'CoC7.BackgroundFlagsMythosHardened'}}" data-flag="mythosHardened">
@@ -83,7 +83,7 @@
 </div>
 
 <div>
-  <div class="section-header flexrow">
+  <div class="section-header flexrow-coc7">
     <h3>{{localize 'CoC7.MonetaryTitle'}}</h3>
     {{#unless data.system.flags.locked}}
       <div class="header-buttons">
@@ -109,7 +109,7 @@
       </div>
     {{/if}}
     {{#each data.system.monetary.values as |value index|}}
-      <div class="flexrow form-group item" data-index="{{index}}">
+      <div class="flexrow-coc7 form-group item" data-index="{{index}}">
         <input name="system.monetary.values.{{index}}.name" value="{{localize value.name}}" type="text" placeholder="{{localize 'CoC7.Name'}}">
         <input name="system.monetary.values.{{index}}.min" value="{{value.min}}" class="cash-assets-range" type="number" placeholder="{{localize 'CoC7.MonetaryCreditRatingMin'}}">
         <input name="system.monetary.values.{{index}}.max" value="{{value.max}}" class="cash-assets-range" type="number" placeholder="{{localize 'CoC7.MonetaryCreditRatingMax'}}">

--- a/templates/actors/parts/actor-mythos-enounters.hbs
+++ b/templates/actors/parts/actor-mythos-enounters.hbs
@@ -1,11 +1,11 @@
 {{#if data.system.sanityLossEvents}}
-  <div class="flexcol bio-section" style="flex: 0 0 50%;">
-    <div class="flexrow" style="flex: initial;">
+  <div class="flexcol-coc7 bio-section" style="flex: 0 0 50%;">
+    <div class="flexrow-coc7" style="flex: initial;">
       <label style="height: 1rem;margin: 0;border: 0;font-family: customSheetFont, 'Palatino Linotype', serif;font-size: .75rem;">{{localize 'CoC7.BackgroundEncounters'}}</label>
     </div>
     <div class="bio-section-value" style="min-height: 80px;">
       {{#each data.system.sanityLossEvents as |sanityLossEvent mythosOffset|}}
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <div>{{sanityLossEvent.type}}</div>
           <div class="bio-section-values">
             {{#if sanityLossEvent.immunity}}
@@ -16,7 +16,7 @@
           </div>
         </div>
       {{else}}
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           -
         </div>
       {{/each}}

--- a/templates/actors/parts/actor-possessions-v3.hbs
+++ b/templates/actors/parts/actor-possessions-v3.hbs
@@ -1,11 +1,11 @@
 <h2>{{ localize 'CoC7.Possessions'}}</h2>
-<div class="inventory flexrow">
+<div class="inventory flexrow-coc7">
   <div class="flex3">
     {{#unless hasInventory}}
       <h3 class="warning">{{localize 'CoC7.InventoryIsCurrentlyEmpty'}}</h3>
     {{else}}
       {{#if showInventoryItems}}
-        <div class="section-header flexrow">
+        <div class="section-header flexrow-coc7">
           <h3>{{localize 'CoC7.Items'}}</h3>
           {{#unless data.system.flags.locked}}
             <div class="header-buttons">
@@ -15,7 +15,7 @@
         </div>
         <ol class="item-list">
           {{#each itemsByType.item as |item id|}}
-            <li class="item flexrow" data-item-id="{{item._id}}">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}">
               <div class="item-image" style="background-image: url({{item.img}})"></div>
               <h4 class="item-name show-detail">{{system.quantity}} x {{item.name}}</h4>
               <div class="item-controls">
@@ -28,7 +28,7 @@
         </ol>
       {{/if}}
       {{#if showInventoryBooks}}
-        <div class="section-header flexrow">
+        <div class="section-header flexrow-coc7">
           <h3>{{localize 'CoC7.Books'}}</h3>
           {{#unless data.system.flags.locked}}
             <div class="header-buttons">
@@ -38,7 +38,7 @@
         </div>
         <ol class="item-list">
           {{#each itemsByType.book as |item id|}}
-            <li class="item flexrow" data-item-id="{{item._id}}">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}">
               <div class="item-image" style="background-image: url({{item.img}})"></div>
               <h4 class="item-name show-detail">{{item.name}}</h4>
               <div class="item-controls">
@@ -51,7 +51,7 @@
         </ol>
       {{/if}}
       {{#if showInventorySpells}}
-        <div class="section-header flexrow">
+        <div class="section-header flexrow-coc7">
           <h3>{{localize 'CoC7.Spells'}}</h3>
           {{#unless data.system.flags.locked}}
             <div class="header-buttons">
@@ -61,7 +61,7 @@
         </div>
         <ol class="item-list">
           {{#each itemsByType.spell as |item id|}}
-            <li class="item flexrow" data-item-id="{{item._id}}">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}">
               <div class="item-image" style="background-image: url({{item.img}})"></div>
               <h4 class="item-name show-detail">{{item.name}}</h4>
               <div class="item-controls">
@@ -74,12 +74,12 @@
         </ol>
       {{/if}}
       {{#if showInventoryTalents}}
-        <div class="section-header flexrow">
+        <div class="section-header flexrow-coc7">
           <h3>{{localize 'CoC7.PulpTalents'}}</h3>
         </div>
         <ol class="item-list">
           {{#each itemsByType.talent as |item id|}}
-            <li class="item flexrow" data-item-id="{{item._id}}">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}">
               <div class="item-image" style="background-image: url({{item.img}})"></div>
               <h4 class="item-name show-detail">{{item.name}}</h4>
               <div class="item-controls">
@@ -91,7 +91,7 @@
         </ol>
       {{/if}}
       {{#if showInventoryWeapons}}
-        <div class="section-header flexrow">
+        <div class="section-header flexrow-coc7">
           <h3>{{localize 'CoC7.Weapons'}}</h3>
           {{#unless data.system.flags.locked}}
             <div class="header-buttons">
@@ -101,7 +101,7 @@
         </div>
         <ol class="item-list">
           {{#each itemsByType.weapon as |item id|}}
-            <li class="item flexrow" data-item-id="{{item._id}}">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}">
               <div class="item-image" style="background-image: url({{item.img}})"></div>
               <h4 class="item-name show-detail">{{item.name}}</h4>
               <div class="item-controls">
@@ -114,7 +114,7 @@
         </ol>
       {{/if}}
       {{#if showInventoryArmor}}
-        <div class="section-header flexrow">
+        <div class="section-header flexrow-coc7">
           <h3>{{localize 'CoC7.Armor'}}</h3>
           {{#unless data.system.flags.locked}}
             <div class="header-buttons">
@@ -124,7 +124,7 @@
         </div>
         <ol class="item-list">
           {{#each itemsByType.armor as |item id|}}
-            <li class="item flexrow" data-item-id="{{item._id}}">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}">
               <div class="item-image" style="background-image: url({{item.img}})"></div>
               <h4 class="item-name show-detail">{{item.name}}</h4>
               <div class="item-controls">
@@ -137,12 +137,12 @@
         </ol>
       {{/if}}
       {{#if showInventoryStatuses}}
-        <div class="section-header flexrow">
+        <div class="section-header flexrow-coc7">
           <h3>{{localize 'CoC7.Status'}}</h3>
         </div>
         <ol class="item-list">
           {{#each itemsByType.status as |item id|}}
-            <li class="item flexrow" data-item-id="{{item._id}}">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}">
               <div class="item-image" style="background-image: url({{item.img}})"></div>
               <h4 class="item-name show-detail">{{item.name}}</h4>
               <div class="item-controls">
@@ -159,7 +159,7 @@
   </div>
   <div class="flex2 cash">
     {{#unless data.system.flags.locked}}
-      <div class="flexrow cash-row">
+      <div class="flexrow-coc7 cash-row">
         {{#if data.system.flags.manualCredit}}
           <label>{{localize 'CoC7.ManualCreditValues'}}</label>
           <div class='flex1'></div>
@@ -169,7 +169,7 @@
         </div>
       </div>
     {{/unless}}
-    <div class="flexrow cash-row">
+    <div class="flexrow-coc7 cash-row">
       <label>{{localize 'CoC7.MonetarySpendingLevel'}}</label>
       {{#if data.system.flags.manualCredit}}
         <input type="text" name="system.monetary.spendingLevel" value="{{data.system.monetary.spendingLevel}}">
@@ -177,7 +177,7 @@
         <span>{{monetary.spendingLevel}}</span>
       {{/if}}
     </div>
-    <div class="flexrow cash-row">
+    <div class="flexrow-coc7 cash-row">
       <label>{{localize 'CoC7.MonetaryCash'}}</label>
       {{#if data.system.flags.manualCredit}}
         <input type="text" name="system.monetary.cash" value="{{data.system.monetary.cash}}">
@@ -185,10 +185,10 @@
         <span>{{monetary.cash}}</span>
       {{/if}}
     </div>
-    <div class="flexrow cash-row">
+    <div class="flexrow-coc7 cash-row">
       <label>{{localize 'CoC7.MonetarySpent'}}</label><input type="text" name="system.monetary.spent" value="{{data.system.monetary.spent}}">
     </div>
-    <div class="flexrow  cash-row">
+    <div class="flexrow-coc7  cash-row">
       <label>{{localize 'CoC7.MonetaryAssets'}}</label>
       {{#if data.system.flags.manualCredit}}
         <input type="text" name="system.monetary.assets" value="{{data.system.monetary.assets}}">

--- a/templates/actors/parts/actor-skills-v3.hbs
+++ b/templates/actors/parts/actor-skills-v3.hbs
@@ -1,4 +1,4 @@
-<div class="flexrow">
+<div class="flexrow-coc7">
   <div class="header-buttons"></div>
   <h2>{{localize 'CoC7.Skills'}}</h2>
   <div class="header-buttons">
@@ -16,7 +16,7 @@
 <ol class="item-list{{#if showPartValues}} show-part-values{{/if}}">
   {{#if skillListModeValue}}
     {{#each skillsByValue as |skill|}}
-      <li class="item itemV2 skill flexrow" data-skill-id="{{skill._id}}" data-item-id="{{skill._id}}">
+      <li class="item itemV2 skill flexrow-coc7" data-skill-id="{{skill._id}}" data-item-id="{{skill._id}}">
         <div class="item-image" style="background-image: url('{{skill.img}}')"></div>
         <div class="item-name skill-name rollable flex3" title="{{skill.name}}">{{skill.name}}</div>
         <div class="skill-value item-score">{{skill.system.value}}</div>
@@ -36,9 +36,9 @@
   {{else}}
     {{#each skillList as |skill|}}
       {{#if skill.isSpecialization}}
-        <li class="specialization-header flexrow"> {{skill.name}} </li>
+        <li class="specialization-header flexrow-coc7"> {{skill.name}} </li>
       {{else}}
-        <li class="item itemV2 skill flexrow {{#if skill.system.properties.special}}specialization{{/if}}" data-skill-id="{{skill._id}}" data-item-id="{{skill._id}}">
+        <li class="item itemV2 skill flexrow-coc7 {{#if skill.system.properties.special}}specialization{{/if}}" data-skill-id="{{skill._id}}" data-item-id="{{skill._id}}">
           <div class="item-image" style="background-image: url('{{skill.img}}')"></div>
           {{#if ../data.system.flags.locked}}
             <div class="item-name skill-name rollable flex1">{{#if skill.system.properties.special}}{{skill.system.skillName}}{{else}}{{skill.name}}{{/if}}</div>

--- a/templates/actors/parts/character-development-v2.html
+++ b/templates/actors/parts/character-development-v2.html
@@ -1,7 +1,7 @@
 <ol class="skills-list">
   {{#each skills as |skill id|}}
     <li class="item {{#if ../pulpRuleArchetype}}pulpCharacter{{/if}}" data-skill-id="{{skill._id}}" data-item-id="{{skill._id}}">
-      <div class="item-controls flexrow">
+      <div class="item-controls flexrow-coc7">
         {{#unless skill.system.properties.noadjustments}}
           <div class="item-control occupation-skill-flag {{#if../allowCharCreation}}clickable{{/if}}" title="{{localize 'CoC7.OccupationSkill'}}">
             {{#if skill.system.flags.occupation}}

--- a/templates/actors/parts/combat.html
+++ b/templates/actors/parts/combat.html
@@ -13,7 +13,7 @@
         <li class="weapon-row item weapon {{#unless weapon.skillSet}}error{{/unless}}" data-item-id="{{weapon._id}}" title="{{#unless weapon.skillSet}}{{localize 'CoC7.NoSkill'}}{{/unless}}">
           <div class="expand-arrow show-detail"></div>
           <div class="weapon-image" style="background-image: url('{{weapon.img}}')"></div>
-          <div class="flexrow">
+          <div class="flexrow-coc7">
             <div class="weapon-name combat {{#if weapon.skillSet}}rollable{{else}}item-edit{{/if}}">{{weapon.name}}</div>
             {{#if weapon.system.properties.thrown}}
               <a class="weapon-name combat alternativ-skill {{#if weapon.skillSet}}rollable{{else}}item-edit{{/if}}" title="Throw"><i class="game-icon game-icon-thrown-knife"></i></a>
@@ -57,7 +57,7 @@
         <li class="weapon-row item weapon {{#unless weapon.skillSet}}error{{/unless}}" data-item-id="{{weapon._id}}" title="{{#unless weapon.skillSet}}{{localize 'CoC7.NoSkill'}}{{/unless}}">
           <div class="expand-arrow show-detail"></div>
           <div class="weapon-image" style="background-image: url('{{weapon.img}}')"></div>
-          <div class="flexrow">
+          <div class="flexrow-coc7">
             <div class="weapon-name combat {{#if weapon.skillSet}}rollable{{else}}item-edit{{/if}}">{{weapon.name}}</div>
             {{#if weapon.usesAlternateSkill}}
               <a class="weapon-name combat alternativ-skill {{#if weapon.skillSet}}rollable{{else}}item-edit{{/if}}" title="{{localize 'CoC7.AutomaticFire'}}"><i class="game-icon game-icon-machine-gun-magazine"></i></a>

--- a/templates/actors/parts/npc-combat.html
+++ b/templates/actors/parts/npc-combat.html
@@ -1,6 +1,6 @@
-<div class="flexrow combat-header" style="border-bottom: 1px groove;text-align: center;font-weight: bold;">
+<div class="flexrow-coc7 combat-header" style="border-bottom: 1px groove;text-align: center;font-weight: bold;">
   <div class="flex2" style="border-right: 1px groove; padding-left: 2px;">{{localize 'CoC7.WeaponName'}}</div>
-  <div class="flex4 flexrow" style="border-right: 1px groove; padding-left: 2px;">
+  <div class="flex4 flexrow-coc7" style="border-right: 1px groove; padding-left: 2px;">
     <div class="flex1">{{localize 'CoC7.WeaponSkill'}}</div>
     <div class="flex1">{{localize 'CoC7.WeaponSkillAlt'}}</div>
   </div>
@@ -9,10 +9,10 @@
 <ol class="weapons-list" style="padding: 0; margin: 0;">
   {{#each weapons as |weapon id|}}
     {{#if ../data.system.flags.locked}}
-      <li class="item weapon flexcol" data-item-id="{{weapon._id}}">
-        <div class="flexrow" style="align-items: center;">
+      <li class="item weapon flexcol-coc7" data-item-id="{{weapon._id}}">
+        <div class="flexrow-coc7" style="align-items: center;">
           <div class="flex2 weapon-name combat rollable" style="border-right: 1px groove;">{{weapon.name}}</div>
-          <div class="flexrow flex4 weapon-skills" style="border-right: 1px groove; padding-left: 2px;">
+          <div class="flexrow-coc7 flex4 weapon-skills" style="border-right: 1px groove; padding-left: 2px;">
             {{#if weapon.skillSet}}
               <div class="item-tag weapon-skill rollable" style="flex: 0 0 49%" data-skill-id="{{weapon.system.skill.main.id}}" title="Roll {{weapon.system.skill.main.name}} skill">{{weapon.system.skill.main.name}} ({{weapon.system.skill.main.value}}%)</div>
               {{#if weapon.usesAlternateSkill}}
@@ -25,7 +25,7 @@
               {{/if}}
             {{/if}}
           </div>
-          <div class="flexrow flex2" style="font-size: 10px; padding-left: 2px;">
+          <div class="flexrow-coc7 flex2" style="font-size: 10px; padding-left: 2px;">
             {{#if weapon.system.properties.rngd}}
               {{#if weapon.system.properties.shotgun}}
                 {{#each weapon.system.range as |range key|}}
@@ -38,9 +38,9 @@
                   <a class="roll" data-mode="roll" title="{{weapon.system.range.normal.value}}" data-formula="{{weapon.system.range.normal.damage}}"><i class="fas fa-dice-d20"></i> {{weapon.system.range.normal.damage}}</a>
                 </div>
               {{/if}}
-              <div class='flexrow' style='flex: 0 0 35px;'>
+              <div class='flexrow-coc7' style='flex: 0 0 35px;'>
                 <span class="tag" style='line-height: 16px;font-size: 10px;'>{{weapon.system.ammo}}</span>
-                <div class='flexcol' style='font-size: 9px;'>
+                <div class='flexcol-coc7' style='font-size: 9px;'>
                   <i class="fas fa-redo-alt reload-weapon" title="Reload"></i>
                   <i class="far fa-plus-square add-ammo" title="Add 1 ammunition"></i>
                 </div>
@@ -59,14 +59,14 @@
         </div>
       </li>
     {{else}}
-      <li class="item flexcol" style="border-bottom: 1px groove; margin-bottom: 2px; padding-bottom: 2px;" data-item-id="{{weapon._id}}">
-        <div class="flexrow" style="align-items: center;">
+      <li class="item flexcol-coc7" style="border-bottom: 1px groove; margin-bottom: 2px; padding-bottom: 2px;" data-item-id="{{weapon._id}}">
+        <div class="flexrow-coc7" style="align-items: center;">
           <div class="flex2">
             <input class="weapon-name" style="display: flex; height: fit-content;padding: 0 1px;text-align: left;" type="text" value="{{weapon.name}}">
           </div>
-          <div class="flexrow flex4 weapon-skills" style="flex-wrap: nowrap;">
+          <div class="flexrow-coc7 flex4 weapon-skills" style="flex-wrap: nowrap;">
 
-            <div class="flex1 flexrow">
+            <div class="flex1 flexrow-coc7">
               <select class="item-tag weapon-skill {{#unless weapon.skillSet}}no-skill-set{{/unless}}" data-skill="main" data-skill-id="{{weapon.system.skill.main.id}}">
                 {{#select weapon.system.skill.main.id}}
                   {{#unless weapon.skillSet}}
@@ -78,7 +78,7 @@
                 {{/select}}
               </select>
             </div>
-            <div class="flex1 flexrow">
+            <div class="flex1 flexrow-coc7">
               {{#if weapon.usesAlternateSkill}}
                 <select class="item-tag weapon-skill {{#unless weapon.skillSet}}no-skill-set{{/unless}}" data-skill="alternativ" data-skill-id="{{weapon.system.skill.alternativ.id}}">
                   {{#select weapon.system.skill.alternativ.id}}
@@ -94,7 +94,7 @@
             </div>
 
           </div>
-          <div class="flexrow flex2" style="font-size: 10px;">
+          <div class="flexrow-coc7 flex2" style="font-size: 10px;">
             {{#if weapon.system.properties.shotgun}}
               {{#each weapon.system.range as |range key|}}
                 <div class="flex1">

--- a/templates/actors/parts/npc-skills.html
+++ b/templates/actors/parts/npc-skills.html
@@ -1,6 +1,6 @@
-<div class="flexrow">
+<div class="flexrow-coc7">
   {{#each skills as |skill id|}}
-    <div class="item flexrow {{#if skill.system.properties.combat}}combat-skill{{/if}}" style="flex: 0 0 33%;flex-wrap: wrap;border-right: 1px groove;" data-skill-id="{{skill._id}}" data-item-id="{{skill._id}}" data-context-menu="skill-roll" data-target-type="skill">
+    <div class="item flexrow-coc7 {{#if skill.system.properties.combat}}combat-skill{{/if}}" style="flex: 0 0 33%;flex-wrap: wrap;border-right: 1px groove;" data-skill-id="{{skill._id}}" data-item-id="{{skill._id}}" data-context-menu="skill-roll" data-target-type="skill">
       {{#if skill.system.properties.special}}
         <div class="npc-specialization">{{skill.system.specialization}}</div>
       {{/if}}

--- a/templates/actors/storage-sheet.html
+++ b/templates/actors/storage-sheet.html
@@ -1,6 +1,6 @@
-<form class="{{cssClass}} flexcol" autocomplete="off">
-  <header class="sheet-header flexrow" style="flex: 0 0 80px;padding-bottom: 2px;">
-    <div class="header-details flexrow">
+<form class="{{cssClass}} flexcol-coc7" autocomplete="off">
+  <header class="sheet-header flexrow-coc7" style="flex: 0 0 80px;padding-bottom: 2px;">
+    <div class="header-details flexrow-coc7">
       <h1 class="name">
         <input name="name" type="text" value="{{actor.name}}" placeholder="{{ localize 'CoC7.Name' }}" style="margin:0; padding:0;" />
       </h1>
@@ -31,11 +31,11 @@
     <div class="tab active" data-group="primary" data-tab="items">
       {{> "systems/CoC7/templates/actors/parts/actor-inventory-items.html"}}
     </div>
-    <div class="tab flexrow" data-group="primary" data-tab="description">
+    <div class="tab flexrow-coc7" data-group="primary" data-tab="description">
       {{editor enrichedDescriptionValue target="system.description.value" engine="prosemirror" button=true owner=owner editable=editable}}
     </div>
     {{#if isKeeper}}
-      <div class="tab flexcol" data-group="primary" data-tab="keeper">
+      <div class="tab flexcol-coc7" data-group="primary" data-tab="keeper">
         {{editor enrichedDescriptionKeeper target="system.description.keeper" engine="prosemirror" button=true owner=owner editable=editable}}
       </div>
     {{/if}}

--- a/templates/actors/vehicle.html
+++ b/templates/actors/vehicle.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}} sheetV2 flexcol" autocomplete="off">
+<form class="{{cssClass}} sheetV2 flexcol-coc7" autocomplete="off">
   <div class="token-extras">
     {{#if canDragToken}}
       <div draggable="true" class="token-drag-handle" title="{{ localize 'CoC7.ActorIsTokenHint'}}"><i class="fas fa-user-circle"></i></div>
@@ -28,28 +28,28 @@
       </div>
 
       <div class="infos">
-        <div class="row flexrow">
+        <div class="row flexrow-coc7">
           <input class="name" name="name" type="text" value="{{actor.name}}" placeholder="{{ localize 'CoC7.Name' }}" />
         </div>
 
-        <div class="row flexrow">
+        <div class="row flexrow-coc7">
           <input class="name" type="text" name="system.infos.type" value="{{data.system.infos.type}}" placeholder="{{ localize 'CoC7.Type' }}" />
         </div>
-        <div class="row flexrow">
+        <div class="row flexrow-coc7">
           <input class="name" type="text" name="system.infos.origin" value="{{data.system.infos.origin}}" placeholder="{{ localize 'CoC7.Origin' }}" />
         </div>
-        <div class="row flexrow">
+        <div class="row flexrow-coc7">
           <label>{{ localize 'CoC7.Crew' }} :</label>
           <input type="text" name="system.crew.total" value="{{data.system.crew.total}}" />
         </div>
       </div>
 
       <div class="flex1" style="padding: 1px, 3px;">
-        <div class="attribute flexrow">
+        <div class="attribute flexrow-coc7">
           <div class="flex1"><label>{{localize "CoC7.Movement"}} :</label></div>
           <div class="flex1"><span>{{actor.mov}}</span></div>
           <div class="flex1"><label>{{localize "CoC7.Build"}} :</label></div>
-          <div class="flex2 flexrow"><input class="attribute-value" type="text" value="{{actor.hp}}" name="system.attribs.build.current" /><span>/{{actor.build}}</span></div>
+          <div class="flex2 flexrow-coc7"><input class="attribute-value" type="text" value="{{actor.hp}}" name="system.attribs.build.current" /><span>/{{actor.build}}</span></div>
         </div>
         {{#if data.system.attribs.armor.localized}}
           <label>{{ localize 'CoC7.ArmourPlating'}} :</label>
@@ -64,7 +64,7 @@
             {{/each}}
           </div>
         {{else}}
-          <div class="flexrow">
+          <div class="flexrow-coc7">
             <label>{{localize "CoC7.Armor"}} :</label>
             <span>{{data.system.attribs.armor.value}}</span>
           </div>

--- a/templates/apps/actor-importer.html
+++ b/templates/apps/actor-importer.html
@@ -67,7 +67,7 @@
       <textarea id="coc-pasted-character-data" name="coc-pasted-character-data" rows="30" style="min-height:300px" placeholder="{{placeholder}}">{{characterData}}</textarea>
     </div>
   {{/if}}
-  <div class="dialog-buttons flexrow">
+  <div class="dialog-buttons flexrow-coc7">
     <button class="submit-button" data-button="import">
       <i class="fas fa-file-import"></i>
       {{localize 'CoC7.Import'}}

--- a/templates/apps/bonus.html
+++ b/templates/apps/bonus.html
@@ -1,9 +1,9 @@
 <form id="bonus-roll-form">
 
-  <div class="flexcol">
+  <div class="flexcol-coc7">
 
     {{#if cardTypes}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize 'CoC7.CardType'}}</label>
         <select name="cardType">
           {{selectOptions cardTypes selected=options.cardType localize=true}}
@@ -12,14 +12,14 @@
     {{/if}}
 
     {{#if options.askValue}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize 'CoC7.RollThreshold'}}</label>
         <input type="number" name="threshold" value="{{options.threshold}}" />
       </div>
     {{/if}}
 
     {{#unless hideDifficulty}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize 'CoC7.RollDifficulty'}}</label>
         <select name="difficulty">
           {{#if options.difficulty}}
@@ -38,23 +38,23 @@
     {{/unless}}
 
     {{#if allowFlatDiceModifier}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize 'CoC7.FlatDiceModifier'}}</label>
         <input type="number" name="flatDiceModifier" value="{{#if options.flatDiceModifier}}{{options.flatDiceModifier}}{{else}}0{{/if}}" />
       </div>
     {{/if}}
 
     {{#if allowFlatThresholdModifier}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize 'CoC7.FlatModifier'}}</label>
         <input type="number" name="flatThresholdModifier" value="{{#if options.flatThresholdModifier}}{{options.flatThresholdModifier}}{{else}}0{{/if}}" />
       </div>
     {{/if}}
 
-    <div class="flexrow" style="padding: 4px 0;">
+    <div class="flexrow-coc7" style="padding: 4px 0;">
       <div style="flex: 1;"><label>{{localize 'CoC7.BonusDice'}}</label></div>
       <div style="flex: 1;display: flex;flex-direction: column;">
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <span style="flex: 1; text-align: left;">-2</span>
           <span style="flex: 1; text-align: center;"></span>
           <span style="flex: 1; text-align: center;">-1</span>

--- a/templates/apps/char-roll.html
+++ b/templates/apps/char-roll.html
@@ -1,8 +1,8 @@
 <form id="char-roll-form" class="coc7 skill-selector">
-  <div class="flexcol">
+  <div class="flexcol-coc7">
     <ol class="item-list">
-      <li class="item flexrow" data-key="str">
-        <div class="item-name flexrow">
+      <li class="item flexrow-coc7" data-key="str">
+        <div class="item-name flexrow-coc7">
           <label class="flex2">{{characteristics.list.str.label}}{{#if characteristics.rolls.enabled}} - {{characteristics.rolls.str}}{{/if}}:</label>
           {{#unless characteristics.rolls.enabled}}
             <a class="decrease-characteristic"><i class="fas fa-minus-circle"></i></a>
@@ -15,8 +15,8 @@
           {{/if}}
         </div>
       </li>
-      <li class="item flexrow" data-key="con">
-        <div class="item-name flexrow">
+      <li class="item flexrow-coc7" data-key="con">
+        <div class="item-name flexrow-coc7">
           <label class="flex2">{{characteristics.list.con.label}}{{#if characteristics.rolls.enabled}} - {{characteristics.rolls.con}}{{/if}}:</label>
           {{#unless characteristics.rolls.enabled}}
             <a class="decrease-characteristic"><i class="fas fa-minus-circle"></i></a>
@@ -29,8 +29,8 @@
           {{/if}}
         </div>
       </li>
-      <li class="item flexrow" data-key="siz">
-        <div class="item-name flexrow">
+      <li class="item flexrow-coc7" data-key="siz">
+        <div class="item-name flexrow-coc7">
           <label class="flex2">{{characteristics.list.siz.label}}{{#if characteristics.rolls.enabled}} - {{characteristics.rolls.siz}}{{/if}}:</label>
           {{#unless characteristics.rolls.enabled}}
             <a class="decrease-characteristic"><i class="fas fa-minus-circle"></i></a>
@@ -43,8 +43,8 @@
           {{/if}}
         </div>
       </li>
-      <li class="item flexrow" data-key="dex">
-        <div class="item-name flexrow">
+      <li class="item flexrow-coc7" data-key="dex">
+        <div class="item-name flexrow-coc7">
           <label class="flex2">{{characteristics.list.dex.label}}{{#if characteristics.rolls.enabled}} - {{characteristics.rolls.dex}}{{/if}}:</label>
           {{#unless characteristics.rolls.enabled}}
             <a class="decrease-characteristic"><i class="fas fa-minus-circle"></i></a>
@@ -57,8 +57,8 @@
           {{/if}}
         </div>
       </li>
-      <li class="item flexrow" data-key="app">
-        <div class="item-name flexrow">
+      <li class="item flexrow-coc7" data-key="app">
+        <div class="item-name flexrow-coc7">
           <label class="flex2">{{characteristics.list.app.label}}{{#if characteristics.rolls.enabled}} - {{characteristics.rolls.app}}{{/if}}:</label>
           {{#unless characteristics.rolls.enabled}}
             <a class="decrease-characteristic"><i class="fas fa-minus-circle"></i></a>
@@ -71,8 +71,8 @@
           {{/if}}
         </div>
       </li>
-      <li class="item flexrow" data-key="int">
-        <div class="item-name flexrow">
+      <li class="item flexrow-coc7" data-key="int">
+        <div class="item-name flexrow-coc7">
           <label class="flex2">{{characteristics.list.int.label}}{{#if characteristics.rolls.enabled}} - {{characteristics.rolls.int}}{{/if}}:</label>
           {{#unless characteristics.rolls.enabled}}
             <a class="decrease-characteristic"><i class="fas fa-minus-circle"></i></a>
@@ -85,8 +85,8 @@
           {{/if}}
         </div>
       </li>
-      <li class="item flexrow" data-key="pow">
-        <div class="item-name flexrow">
+      <li class="item flexrow-coc7" data-key="pow">
+        <div class="item-name flexrow-coc7">
           <label class="flex2">{{characteristics.list.pow.label}}{{#if characteristics.rolls.enabled}} - {{characteristics.rolls.pow}}{{/if}}:</label>
           {{#unless characteristics.rolls.enabled}}
             <a class="decrease-characteristic"><i class="fas fa-minus-circle"></i></a>
@@ -99,8 +99,8 @@
           {{/if}}
         </div>
       </li>
-      <li class="item flexrow" data-key="edu">
-        <div class="item-name flexrow">
+      <li class="item flexrow-coc7" data-key="edu">
+        <div class="item-name flexrow-coc7">
           <label class="flex2">{{characteristics.list.edu.label}}{{#if characteristics.rolls.enabled}} - {{characteristics.rolls.edu}}{{/if}}:</label>
           {{#unless characteristics.rolls.enabled}}
             <a class="decrease-characteristic"><i class="fas fa-minus-circle"></i></a>
@@ -113,8 +113,8 @@
           {{/if}}
         </div>
       </li>
-      <li class="item flexrow" data-key="luck">
-        <div class="item-name flexrow">
+      <li class="item flexrow-coc7" data-key="luck">
+        <div class="item-name flexrow-coc7">
           <label class="flex2">{{characteristics.list.luck.label}}{{#if characteristics.rolls.enabled}} - {{characteristics.rolls.luck}}{{/if}}:</label>
           {{#unless characteristics.rolls.enabled}}
             <a class="reset-characteristic"><i class="fas fa-eraser"></i></a>
@@ -126,25 +126,25 @@
     </ol>
 
     {{#if characteristics.points.enabled}}
-      <div class='points flexrow {{#if pointsWarning}}warning{{/if}}'>
+      <div class='points flexrow-coc7 {{#if pointsWarning}}warning{{/if}}'>
         <label>{{ localize 'CoC7.CharacteristicsPoints'}} :</label>
         <span class='total'>{{characteristics.points.total}}</span>
         <span class='sep'>/</span>
         <span class='value'>{{characteristics.points.value}}</span>
       </div>
 
-      <div class="card-buttons flexrow">
+      <div class="card-buttons flexrow-coc7">
         <button class='validate' data-action="validate">{{ localize "CoC7.Validate" }}</button>
       </div>
     {{/if}}
 
     {{#if characteristics.rolls.enabled}}
-      <div class='points flexrow'>
+      <div class='points flexrow-coc7'>
         <label>{{ localize 'CoC7.CharacteristicsPoints'}} :</label>
         <span class='total'>{{characteristics.points.total}}</span>
       </div>
 
-      <div class="card-buttons flexrow">
+      <div class="card-buttons flexrow-coc7">
         <button data-action="roll">{{ localize "CoC7.RollDice" }}</button>
         <button class='validate' data-action="validate">{{ localize "CoC7.Validate" }}</button>
       </div>

--- a/templates/apps/char-select.html
+++ b/templates/apps/char-select.html
@@ -1,10 +1,10 @@
 <form id="char-selection-form" class="coc7 skill-selector">
-    <div class="flexcol">
+    <div class="flexcol-coc7">
         <ol class="item-list">
             {{#each characteristics as |characteristic|}}
-                <li class="item flexrow selectable" data-key="{{characteristic.key}}">
-                    <div class="item-name flexrow">
-                        <h4>{{characteristic.label}} {{#if characteristic.value}}({{characteristic.value}}){{/if}}</h4>    
+                <li class="item flexrow-coc7 selectable" data-key="{{characteristic.key}}">
+                    <div class="item-name flexrow-coc7">
+                        <h4>{{characteristic.label}} {{#if characteristic.value}}({{characteristic.value}}){{/if}}</h4>
                     </div>
                 </li>
             {{/each}}

--- a/templates/apps/coc-id-actor-update-items.hbs
+++ b/templates/apps/coc-id-actor-update-items.hbs
@@ -1,4 +1,4 @@
-<form autocomplete="off" class="flexcol">
+<form autocomplete="off" class="flexcol-coc7">
   <div class="form-fields">
     <p style="background-color: rgba(255, 166, 0, 0.5); outline: 2px dashed rgba(255, 100, 0, 0.3); padding: 0.5rem;"><i class="fas fa-exclamation-triangle"></i> {{localize 'CoC7.ActorCoCIDItemsWarning'}}</p>
     <p>{{localize 'CoC7.ActorCoCIDItemsWhich'}}</p>
@@ -9,38 +9,38 @@
       {{/unless}}
       <li>{{localize 'CoC7.ActorCoCIDItemsRules3'}}</li>
     </ul>
-    <div class="form-group flexrow">
+    <div class="form-group flexrow-coc7">
       <label for="coc-id-actor-update-items-parent">{{localize 'CoC7.ActorCoCIDItemsUnlinkedToken'}}:</label>
       <div style="flex: 0 0 2rem">
         <input type="checkbox" name="coc-id-actor-update-items-parent" id="coc-id-actor-update-items-parent" value="on"  style="margin-left: -5px;" checked="checked">
       </div>
     </div>
-    <div class="form-group flexrow">
+    <div class="form-group flexrow-coc7">
       <label for="coc-id-actor-update-items-any">{{localize 'CoC7.ActorCoCIDItemsAny'}}:</label>
       <div style="flex: 0 0 2rem">
         <input type="checkbox" name="coc-id-actor-update-items-any" id="coc-id-actor-update-items-any" value="on"  style="margin-left: -5px;">
       </div>
     </div>
-    <div class="form-group flexrow">
+    <div class="form-group flexrow-coc7">
       <label for="coc-id-actor-update-items-which-1">{{localize 'CoC7.ActorCoCIDItemsSceneTokens'}}:</label>
       <div style="flex: 0 0 2rem">
         <input type="radio" name="coc-id-actor-update-items-which" id="coc-id-actor-update-items-which-1" value="1" style="margin-left: -2px; transform: scale(1.5);" checked="checked">
       </div>
     </div>
-    <div class="form-group flexrow">
+    <div class="form-group flexrow-coc7">
       <label for="coc-id-actor-update-items-which-2">{{localize 'CoC7.ActorCoCIDItemsActorSheets'}}:</label>
       <div style="flex: 0 0 2rem">
         <input type="radio" name="coc-id-actor-update-items-which" id="coc-id-actor-update-items-which-2" value="2" class="submit_on_change" style="margin-left: -2px; transform: scale(1.5);">
       </div>
     </div>
-    <div class="form-group flexrow">
+    <div class="form-group flexrow-coc7">
       <label for="coc-id-actor-update-items-which-3">{{localize 'CoC7.ActorCoCIDItemsActorDirectory'}}:</label>
       <div style="flex: 0 0 2rem">
         <input type="radio" name="coc-id-actor-update-items-which" id="coc-id-actor-update-items-which-3" value="3" class="submit_on_change" style="margin-left: -2px; transform: scale(1.5);">
       </div>
     </div>
   </div>
-  <div class="dialog-buttons flexrow">
+  <div class="dialog-buttons flexrow-coc7">
       <button class="submit-button" data-button="update">
         <i class="fas fa-check"></i>
         {{localize 'CoC7.ActorCoCIDItemsUpdate'}}

--- a/templates/apps/coc-id-batch.hbs
+++ b/templates/apps/coc-id-batch.hbs
@@ -3,13 +3,13 @@
   <p>{{{localize 'CoC7.CoCIDBatch.summary' type=object.typeName}}}</p>
   <div class="scrollsection">
     <ol class="skills-list">
-      <li class="item pointsrow flexrow">
+      <li class="item pointsrow flexrow-coc7">
         <span class="name" style="font-weight: bold;">{{type}}</span>
         <div class="value" style="font-weight: bold;">{{localize 'CoC7.CoCIDFlag.key'}}</div>
         <div class="value" style="font-weight: bold;">&nbsp;</div>
       </li>
       {{#each missingNames as |row|}}
-        <li class="item pointsrow flexrow" data-name="{{row.name}}">
+        <li class="item pointsrow flexrow-coc7" data-name="{{row.name}}">
           <span class="skill-name">{{row.name}}</span>
           <div class="value">
             <select class="existing">
@@ -21,7 +21,7 @@
               {{/select}}
             </select>
           </div>
-          <div class="value flexrow">
+          <div class="value flexrow-coc7">
             {{#if row.key}}
               {{row.custom}}
             {{else}}

--- a/templates/apps/coc-id-editor.hbs
+++ b/templates/apps/coc-id-editor.hbs
@@ -4,7 +4,7 @@
   <input type="hidden" name="id" value="{{id}}">
   <div class="form-group">
     <label for="_existing">{{localize 'CoC7.CoCIDFlag.key'}}:</label>
-    <div class="flexrow" style="flex: 2; border: 1px solid transparent; padding: 1px 3px 1px 0;">
+    <div class="flexrow-coc7" style="flex: 2; border: 1px solid transparent; padding: 1px 3px 1px 0;">
       {{#if existingKeys.length}}
         <select style="margin-left: -2px;" name="known">
           <option value="">{{localize 'CoC7.CoCIDFlag.new'}}</option>
@@ -26,7 +26,7 @@
   {{#if (and existingKeys.length (not isSystemID))}}
     <div class="form-group">
       <label>&nbsp;</label>
-      <div class="flexrow" style="flex: 2; border: 1px solid transparent; padding: 1px 3px 1px 0;">
+      <div class="flexrow-coc7" style="flex: 2; border: 1px solid transparent; padding: 1px 3px 1px 0;">
         <span style="flex: 0; margin-top: 2px;">{{idPrefix}}</span>
         <input type="text" style="flex: 2;" name="_existing" value="{{_existing}}" data-prefix="{{idPrefix}}">
       </div>
@@ -128,7 +128,7 @@
     </div>
     <div class="form-group">
       <label>{{localize 'CoC7.CoCIDFlag.foundry-id'}}:</label>
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <input type="text" value="{{object.id}}" readonly>
         <a title="{{localize 'CoC7.CopyToClipboard'}}" class="copy-to-clipboard">
           <i class="fas fa-copy"></i>
@@ -137,7 +137,7 @@
     </div>
     <div class="form-group">
       <label>{{localize 'CoC7.CoCIDFlag.foundry-uuid'}}:</label>
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <input type="text" value="{{object.uuid}}" readonly>
         <a title="{{localize 'CoC7.CopyToClipboard'}}" class="copy-to-clipboard">
           <i class="fas fa-copy"></i>
@@ -146,7 +146,7 @@
     </div>
     <div class="form-group">
       <label>{{localize 'CoC7.CoCIDFlag.get-this-document'}}:</label>
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <input type="text" value="await fromUuid('{{object.uuid}}')" readonly>
         <a title="{{localize 'CoC7.CopyToClipboard'}}" class="copy-to-clipboard">
           <i class="fas fa-copy"></i>
@@ -156,7 +156,7 @@
     {{#if (or id)}}
       <div class="form-group">
         <label>{{localize 'CoC7.CoCIDFlag.get-document-like-this'}}:</label>
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <input type="text" value="await game.system.api.cocid.fromCoCID('{{id}}', '{{lang}}')" readonly>
           <a title="{{localize 'CoC7.CopyToClipboard'}}" class="copy-to-clipboard">
             <i class="fas fa-copy"></i>

--- a/templates/apps/investigator-wizard.hbs
+++ b/templates/apps/investigator-wizard.hbs
@@ -1,5 +1,5 @@
-<form autocomplete="off" class="flexcol">
-  <div class="panel flexcol">
+<form autocomplete="off" class="flexcol-coc7">
+  <div class="panel flexcol-coc7">
     {{#if (eq object.step pages.PAGE_INTRODUCTION)}}
       {{!-- This page is mainly here to make cache population less obvious --}}
       {{> 'systems/CoC7/templates/apps/investigator-wizard/introduction.hbs'}}
@@ -33,7 +33,7 @@
       {{> 'systems/CoC7/templates/apps/investigator-wizard/create.hbs'}}
     {{/if}}
   </div>
-  <div class="dialog-buttons flexrow">
+  <div class="dialog-buttons flexrow-coc7">
     {{#unless (gt object.step 0)}}
       <div class="no-button"></div>
     {{else}}

--- a/templates/apps/investigator-wizard/configuration.hbs
+++ b/templates/apps/investigator-wizard/configuration.hbs
@@ -1,7 +1,7 @@
 <h1 style="flex: 0 0 auto;">{{localize 'CoC7.InvestigatorWizard.TitleKeeperConfiguration'}}</h1>
 <div class="erachange" style="display:none;flex: 1 0 0;">{{localize 'CoC7.InvestigatorWizard.ChangingEraDelay'}}</div>
 <div class="scrollsection">
-  <div class="form-group flexrow">
+  <div class="form-group flexrow-coc7">
     <label for="default-enabled">{{localize 'CoC7.InvestigatorWizard.PlayerEnabled'}}:</label>
     <div class="flex1">
       <input type="checkbox" name="default-enabled" value="on" class="submit_on_change" style="margin-left: -5px;" {{checked object.defaultQuantity}}>
@@ -34,32 +34,32 @@
     </select>
   </div>
   <h2>{{localize 'CoC7.InvestigatorWizard.Characteristics'}}</h2>
-  <div class="form-group flexrow">
+  <div class="form-group flexrow-coc7">
     <label for="rerolls-enabled">{{localize 'CoC7.InvestigatorWizard.AllowRerolls'}}:</label>
     <div class="flex1">
       <input type="checkbox" name="rerolls-enabled" value="on" class="submit_on_change" style="margin-left: -5px;" {{checked object.rerollsEnabled}}>
     </div>
   </div>
-  <div class="form-group flexrow">
+  <div class="form-group flexrow-coc7">
     <label for="characteristics-method-1">{{localize 'CoC7.InvestigatorWizard.UseSetupMethod'}}:</label>
     <div class="flex1">
       <input type="radio" name="characteristics-method" value="1" class="submit_on_change" style="margin-left: -2px; transform: scale(1.5);" {{checked (eq characteristicsMethod characteristicsMethods.METHOD_DEFAULT)}}>
     </div>
   </div>
-  <div class="form-group flexrow">
+  <div class="form-group flexrow-coc7">
     <label for="characteristics-method-2">{{localize 'CoC7.InvestigatorWizard.EnforcePointBuy'}}:</label>
     <div class="flex1">
       <input type="radio" name="characteristics-method" value="2" class="submit_on_change" style="margin-left: -2px; transform: scale(1.5);" {{checked (eq characteristicsMethod characteristicsMethods.METHOD_POINTS)}}>
     </div>
   </div>
-  <div class="form-group flexrow">
+  <div class="form-group flexrow-coc7">
     <label for="characteristics-method-3">{{localize 'CoC7.InvestigatorWizard.QuickFireValues'}}:</label>
     <div class="flex1">
       <input type="radio" name="characteristics-method" value="3" class="submit_on_change" style="margin-left: -2px; transform: scale(1.5);" {{checked (eq characteristicsMethod characteristicsMethods.METHOD_VALUES)}}>
     </div>
   </div>
   {{#if object.quickFireValues.length}}
-    <div class="form-group flexrow">
+    <div class="form-group flexrow-coc7">
       <label>{{localize 'CoC7.InvestigatorWizard.QuickFireValues'}}:</label>
       <div class="flex1">
         {{#each object.quickFireValues as |value offset|}}
@@ -68,7 +68,7 @@
       </div>
     </div>
   {{/if}}
-  <div class="form-group flexrow">
+  <div class="form-group flexrow-coc7">
     <label for="characteristics-method-4">{{localize 'CoC7.InvestigatorWizard.ChooseAfterRoll'}}:</label>
     <div class="flex1">
       <input type="radio" name="characteristics-method" value="4" class="submit_on_change" style="margin-left: -2px; transform: scale(1.5);" {{checked (eq characteristicsMethod characteristicsMethods.METHOD_CHOOSE)}}>

--- a/templates/apps/investigator-wizard/points-skills.hbs
+++ b/templates/apps/investigator-wizard/points-skills.hbs
@@ -1,7 +1,7 @@
 <h1 style="flex: 0 0 auto;">{{localize 'CoC7.InvestigatorWizard.TitlePointsSkills'}}</h1>
 <div class="scrollsection scroll-to-points">
   <ol class="skills-list">
-    <li class="item pointsrow flexrow">
+    <li class="item pointsrow flexrow-coc7">
       <span class="skill-name">&nbsp;</span>
       <div class="adjustment-value"><span title="{{localize 'CoC7.SkillBase'}}"><i class="fa-solid fa-percent"></i></span></div>
       <div class="adjustment-value"><span title="{{localize 'CoC7.SkillPersonal'}}"><i class="fa-solid fa-percent"></i></span></div>
@@ -13,7 +13,7 @@
       <div class="adjustment-value"><span title="{{localize 'CoC7.Value'}}"><i class="fa-solid fa-percent"></i></span></div>
     </li>
     {{#each skills as |skill|}}
-      <li class="item pointsrow flexrow" data-key="{{skill.key}}" data-index="{{skill.index}}">
+      <li class="item pointsrow flexrow-coc7" data-key="{{skill.key}}" data-index="{{skill.index}}">
         <span class="skill-name">{{skill.name}}</span>
         <div class="adjustment-value" title="{{localize 'CoC7.SkillBase'}}">
           {{skill.base}}
@@ -43,7 +43,7 @@
         </div>
       </li>
       {{!-- #if skill.showCreditRating}}
-        <li class="item pointsrow flexrow">
+        <li class="item pointsrow flexrow-coc7">
           <div style="align-self: flex-end; text-align: center;">Super Rich (90 - 98)</div>
           <div style="flex: 0 0 100px; text-align: center;">Cash<br>$50,000</div>
           <div style="flex: 0 0 100px; text-align: center;">Assets<br>$5,000,000</div>
@@ -54,21 +54,21 @@
   </ol>
 </div>
 <div style="flex: 0 0 auto;">
-  <div class="form-group status flexrow">
+  <div class="form-group status flexrow-coc7">
     <div style="flex: 0 0 auto;">{{#if (eq personal.count personal.total)}}<i class="fa-solid fa-circle-check"></i>{{else}}<i class="fa-solid fa-circle-xmark"></i>{{/if}}</div>
     <div>{{localize 'CoC7.InvestigatorWizard.SkillSpendInterestPoints' count=personal.count total=personal.total remaining=personal.remaining}}</div>
   </div>
-  <div class="form-group status flexrow">
+  <div class="form-group status flexrow-coc7">
     <div style="flex: 0 0 auto;">{{#if (eq occupation.count occupation.total)}}<i class="fa-solid fa-circle-check"></i>{{else}}<i class="fa-solid fa-circle-xmark"></i>{{/if}}</div>
     <div>{{localize 'CoC7.InvestigatorWizard.SkillSpendOccupationPoints' count=occupation.count total=occupation.total remaining=occupation.remaining}}</div>
   </div>
   {{#if (gt archetype.total 0)}}
-    <div class="form-group status flexrow">
+    <div class="form-group status flexrow-coc7">
       <div style="flex: 0 0 auto;">{{#if (eq archetype.count archetype.total)}}<i class="fa-solid fa-circle-check"></i>{{else}}<i class="fa-solid fa-circle-xmark"></i>{{/if}}</div>
       <div>{{localize 'CoC7.InvestigatorWizard.SkillSpendArchetypePoints' count=archetype.count total=archetype.total remaining=archetype.remaining}}</div>
     </div>
   {{/if}}
-  <div class="form-group status flexrow">
+  <div class="form-group status flexrow-coc7">
     <div style="flex: 0 0 auto;">{{#if creditRatingOkay}}<i class="fa-solid fa-circle-check"></i>{{else}}<i class="fa-solid fa-circle-xmark"></i>{{/if}}</div>
     <div>{{localize 'CoC7.CreditOutOfRange' min=object.creditRating.min max=object.creditRating.max}}</div>
   </div>

--- a/templates/apps/investigator-wizard/set-archetype-skills.hbs
+++ b/templates/apps/investigator-wizard/set-archetype-skills.hbs
@@ -1,7 +1,7 @@
 <h1 style="flex: 0 0 auto;">{{localize 'CoC7.InvestigatorWizard.TitleArchetypeSkills'}}</h1>
 <div class="scrollsection scroll-to-archetype">
   <div class="form-group">{{localize 'CoC7.InvestigatorWizard.ArchetypeDefaultSkills' count=max}}</div>
-  <div class="flexcol">
+  <div class="flexcol-coc7">
     <ol class="skills-list">
       {{#each skillItems as |skill|}}
         {{#if (eq skill.group 'default')}}
@@ -21,5 +21,5 @@
   </div>
 </div>
 <div style="flex: 0 0 auto;">
-  <div class="form-group status flexrow"><div style="flex: 0 0 auto;">{{#if (eq selected max)}}<i class="fa-solid fa-circle-check"></i>{{else}}<i class="fa-solid fa-circle-xmark"></i>{{/if}}</div><div>{{localize 'CoC7.InvestigatorWizard.SkillSpendArchetypeCountIncorrect' count=selected max=max}}</div></div>
+  <div class="form-group status flexrow-coc7"><div style="flex: 0 0 auto;">{{#if (eq selected max)}}<i class="fa-solid fa-circle-check"></i>{{else}}<i class="fa-solid fa-circle-xmark"></i>{{/if}}</div><div>{{localize 'CoC7.InvestigatorWizard.SkillSpendArchetypeCountIncorrect' count=selected max=max}}</div></div>
 </div>

--- a/templates/apps/investigator-wizard/set-attributes.hbs
+++ b/templates/apps/investigator-wizard/set-attributes.hbs
@@ -7,13 +7,13 @@
       {{else}}
         <h2>{{localize 'CoC7.InvestigatorWizard.MakeEDUImprovementChecks' total=object.requiresAgeAdjustments.edu.total}}</h2>
       {{/if}}
-      <div class="flexcol">
+      <div class="flexcol-coc7">
         <ol class="item-list">
-          <li class="item flexrow">
+          <li class="item flexrow-coc7">
             <label class="flex2">{{localize 'CHARAC.Education'}} ({{object.setupPoints.edu}}%):</label>
             <div>{{points.edu.value}}%</div>
           </li>
-          <li class="item flexrow" style="min-height: 2.1rem;">
+          <li class="item flexrow-coc7" style="min-height: 2.1rem;">
             <label class="flex2">&nbsp;</label>
             {{#unless object.requiresAgeAdjustments.edu.rolled}}
               <button class="roll_edu">{{localize 'CoC7.RollDice'}}</button>
@@ -25,11 +25,11 @@
     {{/if}}
     {{#if object.requiresAgeAdjustments.deduct}}
       <h2>{{localize 'CoC7.InvestigatorWizard.DeductPointsFromCharacteristics' total=object.requiresAgeAdjustments.deduct.total from=deductFrom}}</h2>
-      <div class="flexcol">
+      <div class="flexcol-coc7">
         <ol class="item-list">
           {{#each object.requiresAgeAdjustments.deduct.from as |characteristic|}}
-            <li class="item flexrow" data-offset="{{characteristic}}" data-min="{{lookup (lookup ../points characteristic) 'min'}}" data-max="0">
-              <div class="item-name flexrow">
+            <li class="item flexrow-coc7" data-offset="{{characteristic}}" data-min="{{lookup (lookup ../points characteristic) 'min'}}" data-max="0">
+              <div class="item-name flexrow-coc7">
                 <label class="flex2">{{localize (lookup (lookup ../points characteristic) 'label')}} ({{lookup ../object.setupPoints characteristic}}%):</label>
                 <a class="decrease-10-characteristic"><i class="fas fa-angles-down"></i></a>
                 <a class="decrease-characteristic"><i class="fas fa-minus-circle"></i></a>
@@ -39,8 +39,8 @@
               </div>
             </li>
           {{/each}}
-          <li class="item flexrow">
-            <div class="item-name flexrow">
+          <li class="item flexrow-coc7">
+            <div class="item-name flexrow-coc7">
               <label class="flex2">{{localize 'CoC7.CharacteristicsPoints'}}:</label>
               <div class="nothing-10-characteristic"></div>
               <div class="nothing-characteristic"></div>
@@ -59,10 +59,10 @@
     {{/if}}
     {{#if object.requiresAgeAdjustments.reduce}}
       <h2>{{localize 'CoC7.InvestigatorWizard.ReducePointsFromCharacteristic' total=object.requiresAgeAdjustments.reduce.total from=reduceFrom}}</h2>
-      <div class="flexcol">
+      <div class="flexcol-coc7">
         <ol class="item-list">
-          <li class="item flexrow">
-            <div class="item-name flexrow">
+          <li class="item flexrow-coc7">
+            <div class="item-name flexrow-coc7">
               <label class="flex2">{{localize (lookup (lookup points object.requiresAgeAdjustments.reduce.from) 'label')}} ({{lookup object.setupPoints object.requiresAgeAdjustments.reduce.from}}%):</label>
               <div>{{lookup (lookup points object.requiresAgeAdjustments.reduce.from) 'value'}}%</div>
             </div>
@@ -73,13 +73,13 @@
     {{/if}}
     {{#if object.requiresAgeAdjustments.luck}}
       <h2>{{localize 'CoC7.InvestigatorWizard.RollTwiceForLuck'}}</h2>
-      <div class="flexcol">
+      <div class="flexcol-coc7">
         <ol class="item-list">
-          <li class="item flexrow">
+          <li class="item flexrow-coc7">
             <label class="flex2">{{localize 'CoC7.Luck'}} ({{object.setupPoints.luck}}% / {{object.setupModifiers.luck}}%):</label>
             <div>{{luckValue}}%</div>
           </li>
-          <li class="item flexrow" style="min-height: 2.1rem;">
+          <li class="item flexrow-coc7" style="min-height: 2.1rem;">
             <label class="flex2">&nbsp;</label>
             {{#unless object.setupModifiers.luck}}
               <button class="roll_luck">{{localize 'CoC7.RollDice'}}</button>

--- a/templates/apps/investigator-wizard/set-characteristics.hbs
+++ b/templates/apps/investigator-wizard/set-characteristics.hbs
@@ -22,18 +22,18 @@
       {{#if object.coreCharacteristic}}
         <p>{{{localize 'CoC7.InvestigatorWizard.CoreCharacteristicName' coreCharacteristic=coreCharacteristic}}}</p>
       {{/if}}
-      <div class="flexcol">
+      <div class="flexcol-coc7">
         <ol class="item-list">
           {{#if (eq characteristicsMethod characteristicsMethods.METHOD_CHOOSE)}}
             {{#if (or object.rerollsEnabled (not object.rolledValues.length))}}
-              <li class="item flexrow">
+              <li class="item flexrow-coc7">
                 <div class="flex2"></div>
                 <button class="roll_choose">{{localize 'CoC7.RollDice'}}</button>
                 <div class="flex2"></div>
               </li>
             {{/if}}
             {{#if object.rolledValues.length}}
-              <li class="item flexrow unsorted-characteristics" data-empty="x">
+              <li class="item flexrow-coc7 unsorted-characteristics" data-empty="x">
               {{#each object.rolledValues as |roll offset|}}
                 {{#unless roll.assigned}}
                   <div draggable="true" class="draggable characteristic" data-offset="{{offset}}">
@@ -44,7 +44,7 @@
               </li>
             {{/if}}
           {{else}}
-          <li class="item flexrow unsorted-characteristics" data-characteristic-key="-">
+          <li class="item flexrow-coc7 unsorted-characteristics" data-characteristic-key="-">
             &nbsp;
             {{#each object.placeable as |value|}}
               <div draggable="true" class="draggable characteristic" data-characteristic-key="-" data-value="{{value}}">
@@ -54,8 +54,8 @@
           </li>
           {{/if}}
           {{#each setup.characteristics as |characteristic|}}
-            <li class="item flexrow" data-characteristic-key="{{characteristic.key}}">
-              <div class="item-name flexrow">
+            <li class="item flexrow-coc7" data-characteristic-key="{{characteristic.key}}">
+              <div class="item-name flexrow-coc7">
                 <label class="flex2">{{localize characteristic.label}}:</label>
                 <div class="nothing-characteristic"></div>
                 <div draggable="true" class="{{#if (eq (lookup ../object.setupPoints characteristic.key) '')}}notdraggable{{else}}draggable{{/if}}" data-characteristic-key="{{characteristic.key}}">
@@ -65,8 +65,8 @@
               </div>
             </li>
           {{/each}}
-          <li class="item flexrow" data-key="luck" data-roll="{{setup.luck.roll}}">
-            <div class="item-name flexrow">
+          <li class="item flexrow-coc7" data-key="luck" data-roll="{{setup.luck.roll}}">
+            <div class="item-name flexrow-coc7">
               <label class="flex2">{{localize setup.luck.label}} - {{setup.luck.roll}}:</label>
               <div class="nothing-characteristic"></div>
               <input class="flex1 save-characteristic-on-blur" type="text" name="luck" value="{{lookup object.setupPoints 'luck'}}" placeholder="{{localize 'CoC7.Value'}}" />
@@ -77,7 +77,7 @@
               {{/if}}
             </div>
           </li>
-          <li class="item flexrow">
+          <li class="item flexrow-coc7">
             <label for="age" class="flex2">{{localize 'CoC7.InvestigatorWizard.AgeRange'}}</label>
             <div class="nothing-characteristic"></div>
             <input type="number" class="submit_on_blur" name="age" value="{{object.age}}">
@@ -86,11 +86,11 @@
         </ol>
       </div>
     {{else}}
-      <div class="flexcol">
+      <div class="flexcol-coc7">
         <ol class="item-list">
           {{#each setup.characteristics as |characteristic|}}
-            <li class="item flexrow" data-key="{{characteristic.key}}" data-roll="{{characteristic.roll}}">
-              <div class="item-name flexrow">
+            <li class="item flexrow-coc7" data-key="{{characteristic.key}}" data-roll="{{characteristic.roll}}">
+              <div class="item-name flexrow-coc7">
                 <label class="flex2">{{localize characteristic.label}}{{#if (eq ../characteristicsMethod ../characteristicsMethods.METHOD_ROLL)}} - {{characteristic.roll}}{{/if}}:</label>
                 {{#if (eq ../characteristicsMethod ../characteristicsMethods.METHOD_POINTS)}}
                   <a class="decrease-10-characteristic"><i class="fas fa-angles-down"></i></a>
@@ -110,8 +110,8 @@
               </div>
             </li>
           {{/each}}
-          <li class="item flexrow" data-key="luck" data-roll="{{setup.luck.roll}}">
-            <div class="item-name flexrow">
+          <li class="item flexrow-coc7" data-key="luck" data-roll="{{setup.luck.roll}}">
+            <div class="item-name flexrow-coc7">
               <label class="flex2">{{localize setup.luck.label}} - {{setup.luck.roll}}:</label>
               {{#if (eq characteristicsMethod characteristicsMethods.METHOD_POINTS)}}
                 <div class="nothing-10-characteristic"></div>
@@ -128,12 +128,12 @@
               {{/if}}
             </div>
           </li>
-          <li class="item flexrow">
+          <li class="item flexrow-coc7">
             &nbsp;
           </li>
           {{#if (eq characteristicsMethod characteristicsMethods.METHOD_POINTS)}}
-            <li class="item flexrow">
-              <div class="item-name flexrow">
+            <li class="item flexrow-coc7">
+              <div class="item-name flexrow-coc7">
                 <label class="flex2">{{localize 'CoC7.CharacteristicsPoints'}}:</label>
                 {{#if (eq characteristicsMethod characteristicsMethods.METHOD_POINTS)}}
                   <div class="nothing-characteristic"></div>
@@ -146,30 +146,30 @@
                 <div class="nothing-characteristic"></div>
               </div>
             </li>
-            <li class="item flexrow">
+            <li class="item flexrow-coc7">
               &nbsp;
             </li>
           {{else}}
-            <li class="item flexrow">
-              <div class="item-name flexrow">
+            <li class="item flexrow-coc7">
+              <div class="item-name flexrow-coc7">
                 <label class="flex2">{{localize 'CoC7.CharacteristicsPoints'}}:</label>
                 <span class='total'>{{setup.total}}</span>
                 <div class="nothing-characteristic"></div>
               </div>
             </li>
-            <li class="item flexrow">
+            <li class="item flexrow-coc7">
               &nbsp;
             </li>
-            <li class="item flexrow">
+            <li class="item flexrow-coc7">
               <label class="flex2">&nbsp;</label>
               <button class="roll_all">{{localize 'CoC7.RollDice'}}</button>
               <div class="nothing-characteristic"></div>
             </li>
-            <li class="item flexrow">
+            <li class="item flexrow-coc7">
               &nbsp;
             </li>
           {{/if}}
-          <li class="item flexrow">
+          <li class="item flexrow-coc7">
             <label for="age" class="flex2">{{localize 'CoC7.InvestigatorWizard.AgeRange'}}</label>
             <div class="nothing-characteristic"></div>
             <input type="number" class="submit_on_blur" name="age" value="{{object.age}}">

--- a/templates/apps/investigator-wizard/set-investigator.hbs
+++ b/templates/apps/investigator-wizard/set-investigator.hbs
@@ -28,7 +28,7 @@
   </div>
   <div class="form-group">
     <label for="avatar">{{localize 'CoC7.InvestigatorWizard.CharacterAvatarImage'}}:</label>
-    <div class="flexrow">
+    <div class="flexrow-coc7">
       <input type="text" name="avatar" value="{{object.avatar}}" class="submit_on_change">
       {{filePicker type='image' target='avatar'}}
     </div>
@@ -39,7 +39,7 @@
   </div>
   <div class="form-group">
     <label for="token">{{localize 'CoC7.InvestigatorWizard.CharacterTokenImage'}}:</label>
-    <div class="flexrow">
+    <div class="flexrow-coc7">
       <input type="text" name="token" value="{{object.token}}" class="submit_on_change">
       {{filePicker type='image' target='token'}}
     </div>

--- a/templates/apps/investigator-wizard/set-occupation-skills.hbs
+++ b/templates/apps/investigator-wizard/set-occupation-skills.hbs
@@ -1,7 +1,7 @@
 <h1 style="flex: 0 0 auto;">{{localize 'CoC7.InvestigatorWizard.TitleOccupationSkills'}}</h1>
 <div class="scrollsection scroll-to-occupation">
   <div class="form-group">{{localize 'CoC7.InvestigatorWizard.OccupationDefaultSkills' count=default}}</div>
-  <div class="flexcol">
+  <div class="flexcol-coc7">
     <ol class="skills-list">
       {{#each skillItems as |skill|}}
         {{#if (eq skill.group 'default')}}
@@ -32,5 +32,5 @@
   </div>
 </div>
 <div style="flex: 0 0 auto;">
-  <div class="form-group status flexrow"><div style="flex: 0 0 auto;">{{#if (eq selected max)}}<i class="fa-solid fa-circle-check"></i>{{else}}<i class="fa-solid fa-circle-xmark"></i>{{/if}}</div><div>{{localize 'CoC7.InvestigatorWizard.SkillSpendOccupationCountIncorrect' count=selected max=max}}</div></div>
+  <div class="form-group status flexrow-coc7"><div style="flex: 0 0 auto;">{{#if (eq selected max)}}<i class="fa-solid fa-circle-check"></i>{{else}}<i class="fa-solid fa-circle-xmark"></i>{{/if}}</div><div>{{localize 'CoC7.InvestigatorWizard.SkillSpendOccupationCountIncorrect' count=selected max=max}}</div></div>
 </div>

--- a/templates/apps/investigator-wizard/toggle-skill.hbs
+++ b/templates/apps/investigator-wizard/toggle-skill.hbs
@@ -16,7 +16,7 @@
     </li>
   {{/if}}
 {{else}}
-  <li class="item flexrow toggle {{#unless skill.isCreditRating}}toggleable{{/unless}}" data-key="{{skill.key}}" data-index="{{skill.index}}" data-toggle-key="{{toggleKey}}">
+  <li class="item flexrow-coc7 toggle {{#unless skill.isCreditRating}}toggleable{{/unless}}" data-key="{{skill.key}}" data-index="{{skill.index}}" data-toggle-key="{{toggleKey}}">
     <div style="flex: 0 0 auto;">
       {{#if skill.toggle}}
         <i class="fas fa-circle"></i>

--- a/templates/apps/investigator-wizard/view-attributes.hbs
+++ b/templates/apps/investigator-wizard/view-attributes.hbs
@@ -1,10 +1,10 @@
 <h1 style="flex: 0 0 auto;">{{localize 'CoC7.InvestigatorWizard.TitleAttributes'}}</h1>
 <div class="scrollsection">
-  <div class="flexcol">
+  <div class="flexcol-coc7">
     <ol class="item-list">
       {{#each points as |characteristic id|}}
-        <li class="item flexrow">
-          <div class="item-name flexrow">
+        <li class="item flexrow-coc7">
+          <div class="item-name flexrow-coc7">
             <label class="flex2">{{localize characteristic.label}}:</label>
             <div>{{characteristic.prefix}}{{characteristic.value}}{{characteristic.suffix}}</div>
           </div>

--- a/templates/apps/link-creation.html
+++ b/templates/apps/link-creation.html
@@ -155,7 +155,7 @@
 
         {{!-- Effects Tab --}}
         <section class="tab" data-tab="effects">
-          <header class="effect-change effects-header flexrow">
+          <header class="effect-change effects-header flexrow-coc7">
             <div class="key">{{ localize "EFFECT.ChangeKey" }}</div>
             <div class="mode">{{ localize "EFFECT.ChangeMode" }}</div>
             <div class="value">{{ localize "EFFECT.ChangeValue" }}</div>
@@ -165,7 +165,7 @@
           </header>
           <ol class="changes-list">
             {{#each link.effect.changes as |change i|}}
-              <li class="effect-change flexrow" data-index="{{i}}">
+              <li class="effect-change flexrow-coc7" data-index="{{i}}">
                 <div class="key">
                   <input type="text" name="effect.changes.{{i}}.key" value="{{change.key}}" />
                 </div>
@@ -249,7 +249,7 @@
           <div class='form-group subgroup'>
             <label>{{localize 'CoC7.BonusDice'}}</label>
             <div class="penalty-selector">
-              <div class="flexrow">
+              <div class="flexrow-coc7">
                 <span style="flex: 1; text-align: left;">-2</span>
                 <span style="flex: 1; text-align: center;"></span>
                 <span style="flex: 1; text-align: center;">-1</span>

--- a/templates/apps/point-select.html
+++ b/templates/apps/point-select.html
@@ -1,12 +1,12 @@
 <form id="skill-selection-form" class="coc7 skill-selector">
-    <div class="flexcol">
-        <div class='flexrow header'>{{ localize 'CoC7.SkillTotalOccupation' }} :<div class="points">{{total}}</div></div>
+    <div class="flexcol-coc7">
+        <div class='flexrow-coc7 header'>{{ localize 'CoC7.SkillTotalOccupation' }} :<div class="points">{{total}}</div></div>
         <ol class="item-list">
             {{#each characteristics as |characteristic key|}}
                 {{#if characteristic.selected}}
-                    <li class="item flexrow {{#if characteristic.optional}}selectable{{else}}selected{{/if}}" data-key="{{key}}">
-                        <div class="item-name flexrow">
-                            <h4>{{characteristic.name}} ({{characteristic.value}}x{{characteristic.multiplier}}:{{characteristic.total}})</h4>    
+                    <li class="item flexrow-coc7 {{#if characteristic.optional}}selectable{{else}}selected{{/if}}" data-key="{{key}}">
+                        <div class="item-name flexrow-coc7">
+                            <h4>{{characteristic.name}} ({{characteristic.value}}x{{characteristic.multiplier}}:{{characteristic.total}})</h4>
                         </div>
                     </li>
                 {{/if}}

--- a/templates/apps/sandata.html
+++ b/templates/apps/sandata.html
@@ -1,12 +1,12 @@
 
 <form id="san-data-form">
-    <div class="flexcol dialog-form">
-        <div class="flexrow form-group">
+    <div class="flexcol-coc7 dialog-form">
+        <div class="flexrow-coc7 form-group">
             <label>{{localize 'CoC7.MinSanloss'}}</label>
             <input type="text" name="sanMin" />
         </div>
 
-        <div class="flexrow form-group">
+        <div class="flexrow-coc7 form-group">
             <label>{{localize 'CoC7.MaxSanloss'}}</label>
             <input type="text" name="sanMax" />
         </div>

--- a/templates/apps/sanity-loss-type.hbs
+++ b/templates/apps/sanity-loss-type.hbs
@@ -21,7 +21,7 @@
       <input type="text" class="field_value" value="{{object.value}}" data-dtype="Number">
     </div>
   {{/unless}}
-  <div class="flexrow" style="margin: 10px 0 0;">
+  <div class="flexrow-coc7" style="margin: 10px 0 0;">
     <button class="dialog-button add" type="button" data-button="add">
       <i class="fas fa-check"></i>
       {{ localize 'CoC7.Add' }}

--- a/templates/apps/skill-details.html
+++ b/templates/apps/skill-details.html
@@ -1,11 +1,11 @@
-<form class="flexcol">
-  <header class="sheet-header flexrow" style="flex: 0 0 64px;padding-bottom: 2px;">
-    <div class="header-details flexrow">
+<form class="flexcol-coc7">
+  <header class="sheet-header flexrow-coc7" style="flex: 0 0 64px;padding-bottom: 2px;">
+    <div class="header-details flexrow-coc7">
       <h1 class="name" style="height: 48px;">
         <input name="name" type="text" value="{{content.name}}" readonly />
       </h1>
 
-      <ul class="summary flexrow">
+      <ul class="summary flexrow-coc7">
         <li class="flex2">
           <input type="text" value="{{content.system.specialization}}" readonly />
         </li>
@@ -19,7 +19,7 @@
 
   </header>
   <section class="sheet-body">
-    <div class="flexrow" style='height: 100%;'>
+    <div class="flexrow-coc7" style='height: 100%;'>
       <div class="item-properties">
         <ol class="properties-list">
           {{#each content.skillProperties}}

--- a/templates/apps/skill-select.html
+++ b/templates/apps/skill-select.html
@@ -1,6 +1,6 @@
 <form id="skill-selection-form" class="coc7 skill-selector">
-  <div class="flexcol">
-    <div class='flexrow header counter'>
+  <div class="flexcol-coc7">
+    <div class='flexrow-coc7 header counter'>
       <label>{{ localize 'CoC7.Chosen' }} :</label>
       <span class="count">0</span>
       <span class="sep">/</span>
@@ -9,8 +9,8 @@
 
     <ol class="item-list">
       {{#each skills as |skill i|}}
-        <li class="item flexrow" data-index="{{i}}">
-          <div class="item-name flexrow">
+        <li class="item flexrow-coc7" data-index="{{i}}">
+          <div class="item-name flexrow-coc7">
             <h4>{{skill.name}} ({{skill.system.base}}%)</h4>
           </div>
           <div class="item-controls">

--- a/templates/apps/skill-spec-select.html
+++ b/templates/apps/skill-spec-select.html
@@ -1,8 +1,8 @@
 <form id="skill-select-form">
 
-    <div class="flexcol">
+    <div class="flexcol-coc7">
         {{#if hasSkills}}
-            <div class="flexrow">
+            <div class="flexrow-coc7">
                 <select name="existing-skill">
                     <option value="" disabled  selected>{{localize 'CoC7.SelectSkill'}}</option>
                     {{#each skills as |skill|}}
@@ -11,21 +11,21 @@
                 </select>
             </div>
 
-            <div class="flexrow">
+            <div class="flexrow-coc7">
                 <label>{{localize 'CoC7.Or'}}</label>
             </div>
         {{/if}}
 
 
         {{#unless name}}
-        <div class="flexrow">
+        <div class="flexrow-coc7">
             <input name="new-skill-name" type="text" placeholder="{{ localize 'CoC7.CreateNewSkill' }}"/>
         </div>
         {{/unless}}
 
         <br>
 
-        <div class="flexrow">
+        <div class="flexrow-coc7">
             <label>{{localize 'CoC7.BaseSkillValue'}} :</label>
             <input name="base-value" type="text" value="{{base}}" placeholder="{{ localize 'CoC7.SkillBase' }}"/>
         </div>

--- a/templates/apps/skill-specialization-select.hbs
+++ b/templates/apps/skill-specialization-select.hbs
@@ -1,7 +1,7 @@
 <form>
-  <div class="flexcol">
+  <div class="flexcol-coc7">
     {{#if object.allowSelect}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <select name="existing-skill">
           <option value="">{{localize 'CoC7.SkillPickNameOnly'}}</option>
           {{#select object.selected}}
@@ -15,17 +15,17 @@
     {{/if}}
 
     {{#if (and object.allowCustom (eq object.selected ''))}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize 'CoC7.CustomSpecialisationLabel' specialisation=object.label}}</label>
       </div>
 
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <input name="new-skill-name" type="text" value="{{object.name}}" placeholder="{{ localize 'CoC7.CreateNewSkill' }}"/>
       </div>
 
       {{#unless object.fixedBaseValue}}
         <br>
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <label>{{localize 'CoC7.BaseSkillValue'}} :</label>
           <input name="base-value" type="text" value="{{object.baseValue}}" placeholder="{{ localize 'CoC7.SkillBase' }}"/>
         </div>

--- a/templates/apps/skill-value.html
+++ b/templates/apps/skill-value.html
@@ -1,8 +1,8 @@
 
 <form id="skill-select-form">
 
-    <div class="flexcol">
-        <div class="flexrow">
+    <div class="flexcol-coc7">
+        <div class="flexrow-coc7">
             <label>{{localize 'CoC7.SkillValue'}} :</label>
             <input name="base-value" type="text" value="{{base}}" placeholder="{{ localize 'CoC7.Value' }}"/>
         </div>

--- a/templates/chat/cards/chase-obstacle.html
+++ b/templates/chat/cards/chase-obstacle.html
@@ -1,5 +1,5 @@
 <div class="coc7 chat-card chat-card-v2">
-  <form class="flexcol">
+  <form class="flexcol-coc7">
     <header class="card-header">
       <div class="left-portrait">
         {{#if displayActorOnCard}}
@@ -91,7 +91,7 @@
                 <div class="flex3">
                   <span>{{localize 'CoC7.ObstacleDamage'}} : {{{inlineDamageRoll}}} (<i class="icon game-icon game-icon-life-bar" title="{{localize 'CoC7.HitPoints'}}"></i>{{data.obstacle.HitPoints}})</span>
                 </div>
-                <div class="flexrow flex1">
+                <div class="flexrow-coc7 flex1">
                   <input type="text" data-ecc-permissions="gm" name="data.totalObstacleDamage" value="{{data.totalObstacleDamage}}" data-dtype="Number">
                   <a data-ecc-permissions="gm" data-flag="obstacleDestoyed" class="flex0 icon bigger ecc-switch" title="{{ localize 'CoC7.RemoveObstacle' }}"><i class="game-icon game-icon-wrecking-ball"></i></a>
                 </div>
@@ -135,7 +135,7 @@
                         {{#if data.obstacle.hasDamage }}
                           {{!-- Armor relevant only if there's some damage --}}
                           <div class="form-group armor">
-                            <div class="flexrow flex-end">
+                            <div class="flexrow-coc7 flex-end">
                               <a data-ecc-permissions="gm" data-flag="ignoreArmor" class="ecc-switch" title="{{ localize 'CoC7.IgnoreArmor' }}">
                                 {{#if data.flags.ignoreArmor}}
                                   <i class="game-icon game-icon-armor-downgrade"></i>
@@ -151,7 +151,7 @@
                           </div>
                         {{/if}}
                         <div class="form-group small">
-                          <div class="flexrow flex1">
+                          <div class="flexrow-coc7 flex1">
                             {{#if data.obstacle.hazard}}
                               <a data-ecc-permissions="gm" data-name="data.obstacle.hasActionCost" class="icon ecc-switch" title="{{ localize 'CoC7.ActionCostOnFail' }}">
                                 <i class="fas fa-bahai"></i>
@@ -161,7 +161,7 @@
                               {{/if}}
                             {{/if}}
                           </div>
-                          <div class="flexrow flex1">
+                          <div class="flexrow-coc7 flex1">
                             <a data-ecc-permissions="gm" data-name="data.obstacle.hasDamage" class="icon ecc-switch" title="{{ localize 'CoC7.DamageOnFail' }}">
                               <i class="game-icon game-icon-broken-bone"></i>
                             </a>
@@ -239,7 +239,7 @@
                   {{#if customWeapon}}
                     <div class="form-group small">
                       <div class="flex1"></div>
-                      <div class="flex1 flexrow">
+                      <div class="flex1 flexrow-coc7">
                         <span class="icon bigger" title="{{ localize 'CoC7.DamageInflicted' }}"><i class="game-icon game-icon-rolling-dices"></i></span>
                         <input type="text" data-ecc-permissions="gm" name="data.customWeaponDamage" value="{{data.customWeaponDamage}}">
                       </div>

--- a/templates/chat/cards/combined-roll.html
+++ b/templates/chat/cards/combined-roll.html
@@ -1,6 +1,6 @@
 <div class="coc7 chat-card chat-card-v2 roll-card combined">
     {{#unless closed}}
-    <div class='flexrow toggle gm-visible-only'>
+    <div class='flexrow-coc7 toggle gm-visible-only'>
         <span class="flex1 toggle-switch gm-select-only {{#if any}}switched-on{{/if}} "
         title="{{localize 'CoC7.CombinedAnyHint'}}"
         data-flag="any"

--- a/templates/chat/cards/damage.html
+++ b/templates/chat/cards/damage.html
@@ -1,7 +1,7 @@
 <div class="coc7 chat-card damage">
 
-  <header class="card-header flexcol">
-    <div class="flexrow">
+  <header class="card-header flexcol-coc7">
+    <div class="flexrow-coc7">
       {{#if displayActorOnCard}}
         <img class="open-actor" data-actor-key="{{actorKey}}" style="flex: none;" src="{{actorImg}}" title="{{name}}" width="36" height="36" />
       {{/if}}
@@ -36,8 +36,8 @@
           <span class='tag owner-visible-only'>{{localize 'CoC7.Armor'}}: {{armor}}</span>
         {{/if}}
       {{else}}
-        <div class="armor flexrow">
-          <div class="flexrow flex-end gm-visible-only">
+        <div class="armor flexrow-coc7">
+          <div class="flexrow-coc7 flex-end gm-visible-only">
             <a class='ic-switch gm-visible-only{{#unless ignoreArmor}} switched-on{{/unless}}' data-flag='ignoreArmor'>
               {{#if ignoreArmor}}
                 <i class="game-icon game-icon-armor-downgrade"></i>
@@ -57,7 +57,7 @@
               {{/if}}
             {{/unless}}
           </div>
-          <div class="flexrow flex-end owner-visible-only owner-info" data-actor-key="{{targetKey}}">
+          <div class="flexrow-coc7 flex-end owner-visible-only owner-info" data-actor-key="{{targetKey}}">
             {{#unless ignoreArmor}}
               <label>{{localize 'CoC7.Armor'}}:</label>
               <span>{{armor}}</span>

--- a/templates/chat/cards/opposed-roll.html
+++ b/templates/chat/cards/opposed-roll.html
@@ -1,5 +1,5 @@
 <div class="coc7 chat-card chat-card-v2 roll-card opposed {{#if combat}}combat{{/if}}">
-  <div class="title flexrow">
+  <div class="title flexrow-coc7">
     <div class="opposed-card-flag gm-visible-only {{#if combat}}active{{/if}}">
       <a data-action='toggle-combat'><i class="game-icon game-icon-crossed-swords"></i></a>
     </div>
@@ -18,7 +18,7 @@
       </div>
     {{else}}
       {{#if needsTieBreaker}}
-        <div class="flexrow gm-visible-only toggle">
+        <div class="flexrow-coc7 gm-visible-only toggle">
           <span class="flex1 toggle-switch gm-select-only {{#if advantageAttacker}}switched-on{{/if}} " title="{{localize 'CoC7.AdvantageAttacker'}}" data-flag="advantageAttacker" data-selected={{advantageAttacker}}>{{localize 'CoC7.AdvantageAttacker'}}</span>
           <span class="flex1 toggle-switch gm-select-only {{#if advantageDefender}}switched-on{{/if}}" title="{{localize 'CoC7.AdvantageDefender'}}" data-flag="advantageDefender" data-selected={{advantageDefender}}>{{localize 'CoC7.AdvantageDefender'}}</span>
         </div>
@@ -63,7 +63,7 @@
               {{#if ../closed}}
                 {{{r._htmlRoll}}}
               {{else}}
-                <div class='flexrow owner-only'>{{{r._htmlRoll}}}</div>
+                <div class='flexrow-coc7 owner-only'>{{{r._htmlRoll}}}</div>
               {{/if}}
             {{else}}
               {{{r._htmlRoll}}}

--- a/templates/chat/cards/test.html
+++ b/templates/chat/cards/test.html
@@ -1,6 +1,6 @@
 {{!-- TO BE REMOVED FOR PROD --}}
 <div class="test">
-  <form class="flexcol">
+  <form class="flexcol-coc7">
     <input type="text" name="data.armor" value="{{data.armor}}" />
     <input type="range" data-ecc-permissions="gm" name="data.bonusDice" min="-2" max="2" value="{{data.bonusDice}}" class="slider">
     <select name="data.mySelect">
@@ -24,7 +24,7 @@
     </div>
 
 
-    <div class="flexrow ecc-radio" data-ecc-permissions="gm">
+    <div class="flexrow-coc7 ecc-radio" data-ecc-permissions="gm">
       <span class="flex1 ecc-switch" data-flag="advantageAttacker">{{localize 'CoC7.AdvantageAttacker'}}</span>
       <span class="flex1 ecc-switch" data-flag="advantageDefender">{{localize 'CoC7.AdvantageDefender'}}</span>
     </div>

--- a/templates/chat/chat-message.html
+++ b/templates/chat/chat-message.html
@@ -1,5 +1,5 @@
-<li class="message flexcol {{cssClass}}" data-message-id="{{message._id}}" {{#if borderColor}}style="border-color:{{borderColor}}" {{/if}}>
-  <header class="message-header flexrow">
+<li class="message flexcol-coc7 {{cssClass}}" data-message-id="{{message._id}}" {{#if borderColor}}style="border-color:{{borderColor}}" {{/if}}>
+  <header class="message-header flexrow-coc7">
     {{#if message.flags.img}}
       <img class="sender-image flex0" style='object-fit: contain;border:none;' src="{{message.flags.img}}" title="{{alias}}" width="36" height="36" />
       <h4 class="message-sender sender-image" style="margin-left:2px;line-height: 36px;">{{alias}}</h4>

--- a/templates/chat/combat/damage-result.html
+++ b/templates/chat/combat/damage-result.html
@@ -8,8 +8,8 @@
     data-target-card="{{targetCard}}"
     data-result="{{result}}">
 
-    <header class="card-header flexcol">
-        <div class="flexrow">
+    <header class="card-header flexcol-coc7">
+        <div class="flexrow-coc7">
             {{#if displayActorOnCard}}
             <img class="open-actor" data-actor-key="{{actorKey}}" style="flex: none;" src="{{actorImg}}" title="{{name}}" width="36" height="36"/>
             {{/if}}
@@ -37,7 +37,7 @@
                 {{#each roll._dice as |die key| }}
                 <section class="tooltip-part">
                     <div class="dice">
-                        <span class="part-formula part-header flexrow">
+                        <span class="part-formula part-header flexrow-coc7">
                             {{die.formula}}
                             <div class="flex1"></div>
                             <span class="part-total flex0">{{die.total}}</span>
@@ -54,10 +54,10 @@
 
             <div class="dice-total success {{#if critical}} critical{{/if}}">
                 {{result}}
-            </div> 
+            </div>
         </div>
     </div>
- 
+
     {{#if targetKey}}
     <div class="card-buttons gm-visible-only">
         <button data-action="deal-melee-damage">{{ localize 'CoC7.InflictPain' }}</button>

--- a/templates/chat/combat/melee-initiator.html
+++ b/templates/chat/combat/melee-initiator.html
@@ -2,8 +2,8 @@
 
   <div class="roll"></div>
 
-  <header class="card-header flexcol">
-    <div class="flexrow">
+  <header class="card-header flexcol-coc7">
+    <div class="flexrow-coc7">
       {{#if displayActorOnCard}}
         <img class="open-actor" data-actor-key="{{actorKey}}" style="flex: none;" src="{{actorImg}}" title="{{name}}" width="36" height="36" />
       {{/if}}
@@ -39,19 +39,19 @@
       {{/if}}
     </div>
 
-    <div class="flexrow bonus-selection">
+    <div class="flexrow-coc7 bonus-selection">
       <span class="flex1 toggle-switch outnumbered {{#unless rolled}}simple-flag{{/unless}} {{#if outnumbered}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.TitleOutNumbered'}}" style="text-align:center" data-flag="outnumbered" data-selected={{outnumbered}}>{{localize 'CoC7.OutNumbered'}}</span>
       <span class="flex1 toggle-switch surprised {{#unless rolled}}simple-flag{{/unless}} {{#if surprised}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.TitleSurprised'}}" style="text-align:center" data-flag="surprised" data-selected={{surprised}}>{{localize 'CoC7.combatCard.surprised'}}</span>
       <span class="flex1 toggle-switch auto-success {{#unless rolled}}simple-flag{{/unless}} {{#if autoSuccess}}switched-on{{/if}} gm-visible-only" title="{{localize 'CoC7.TitleAutoSuccess'}}" style="text-align:center" data-flag="auto-success" data-selected={{autoSuccess}}>{{localize 'CoC7.combatCard.autoSuccess'}}</span>
     </div>
 
     <div style="flex: 1;display: flex;flex-direction: column;margin: 0.5rem 1rem 0;opacity:0.6">
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <span style="flex: 4; text-align: left">{{localize 'CoC7.PenaltyDice'}}</span>
         <span style="flex: 1">&nbsp;</span>
         <span style="flex: 4; text-align: right">{{localize 'CoC7.BonusDice'}}</span>
       </div>
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <span style="flex: 1; text-align: left;">-2</span>
         <span style="flex: 1; text-align: center;"></span>
         <span style="flex: 1; text-align: center;">-1</span>
@@ -73,7 +73,7 @@
         <div class="dice-tooltip" style="display: none;">
           <section class="tooltip-part">
             <div class="dice ten-dice">
-              <span class="part-formula part-header flexrow">
+              <span class="part-formula part-header flexrow-coc7">
                 {{#if check.dices.tenOnlyOneDie}}
                   {{localize 'CoC7.TensDie'}}
                 {{else}}
@@ -91,7 +91,7 @@
           </section>
           <section class="tooltip-part">
             <div class="dice unit-die">
-              <span class="part-formula part-header flexrow">
+              <span class="part-formula part-header flexrow-coc7">
                 {{localize 'CoC7.UnitsDie'}}
                 <div class="flex1"></div>
                 <span class="part-total flex0">{{check.dices.unit.value}}</span>

--- a/templates/chat/combat/melee-resolution.html
+++ b/templates/chat/combat/melee-resolution.html
@@ -11,9 +11,9 @@
     data-is-blind="false"
     >
 
-  <header class="card-header flexcol">
+  <header class="card-header flexcol-coc7">
     {{#if winner}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         {{#if displayActorOnCard}}
           <img class="open-actor" data-actor-key="{{winner.actorKey}}" style="flex: none;" src="{{winner.actorImg}}" title="{{winner.name}}" width="36" height="36"/>
         {{/if}}
@@ -24,7 +24,7 @@
         {{/if}}
       </div>
     {{else}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <h3 style="text-align: center;font-weight: bolder;" class="card-title">{{resultString}}</h3>
       </div>
     {{/if}}
@@ -49,7 +49,7 @@
       </button>
     </div>
   {{else}}
-    <div class="flexrow">
+    <div class="flexrow-coc7">
       <h4 style="font-weight: bolder;">{{resultString}}</h4>
     </div>
   {{/if}}

--- a/templates/chat/combat/melee-target.html
+++ b/templates/chat/combat/melee-target.html
@@ -1,7 +1,7 @@
 <div class="coc7 chat-card melee target" data-actor-key="{{actorKey}}" data-initiator-key="{{initiatorKey}}" data-fast-forward="{{fastForward}}" data-resolved="{{resolved}}" data-outnumbered="{{outnumbered}}" data-surprised="{{surprised}}" data-auto-success="{{autoSuccess}}" data-dice-modifier="{{diceModifier}}" data-parent-message-id="{{parentMessageId}}" data-skill-id="{{skillId}}" data-item-id="{{itemId}}" data-dodging="{{dodging}}" data-not-responding="{{notResponding}}" data-fighting-back="{{fightingBack}}" data-maneuvering="{{maneuvering}}" data-resolution-card="{{resolutionCard}}" data-is-blind="false">
 
-  <header class="card-header flexcol">
-    <div class="flexrow">
+  <header class="card-header flexcol-coc7">
+    <div class="flexrow-coc7">
       {{#if displayActorOnCard}}
         <img class="open-actor" data-actor-key="{{actorKey}}" style="flex: none;" src="{{actorImg}}" title="{{name}}" width="36" height="36" />
       {{/if}}
@@ -43,11 +43,11 @@
   </header>
 
   {{#unless rolled}}
-    <div class="flexrow response-selection owner-only">
+    <div class="flexrow-coc7 response-selection owner-only">
       <span class="flex1 toggle-switch dodge {{#if actor.dodgeSkill.id}}{{#unless rolled}}simple-toggle{{/unless}}{{else}}inactive{{/if}} {{#if dodging}}switched-on{{/if}}" data-action="dodge" data-skill-id="{{actor.dodgeSkill.id}}">{{localize 'CoC7.Dodge'}}</span>
       <span class="flex1 toggle-switch no-response simple-toggle {{#if notResponding}}switched-on{{/if}}" data-action="noResponse">{{localize 'CoC7.NoResponse'}}</span>
     </div>
-    <div class="flexrow response-selection owner-only">
+    <div class="flexrow-coc7 response-selection owner-only">
       <div class="flex1 toggle-switch fight-back {{#unless rolled}}dropdown{{/unless}} {{#if fightingBack}}switched-on{{/if}}">
         <span class="combat-action {{#unless rolled}}dropbtn{{/unless}}">{{localize 'CoC7.FightBack'}}</span>
         <div class="actor-skill dropdown-content">
@@ -68,12 +68,12 @@
   {{/unless}}
   {{#unless (or rolled notResponding)}}
     <div class="owner-only" style="flex: 1;display: flex;flex-direction: column;margin: 0.5rem 1rem 0;opacity:0.6">
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <span style="flex: 4; text-align: left">{{localize 'CoC7.PenaltyDice'}}</span>
         <span style="flex: 1">&nbsp;</span>
         <span style="flex: 4; text-align: right">{{localize 'CoC7.BonusDice'}}</span>
       </div>
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <span style="flex: 1; text-align: left;">-2</span>
         <span style="flex: 1; text-align: center;"></span>
         <span style="flex: 1; text-align: center;">-1</span>
@@ -95,7 +95,7 @@
         <div class="dice-tooltip" style="display: none;">
           <section class="tooltip-part">
             <div class="dice">
-              <span class="part-formula part-header flexrow">
+              <span class="part-formula part-header flexrow-coc7">
                 {{#if check.dices.tenOnlyOneDie}}
                   {{localize 'CoC7.TensDie'}}
                 {{else}}
@@ -113,7 +113,7 @@
           </section>
           <section class="tooltip-part">
             <div class="dice">
-              <span class="part-formula part-header flexrow">
+              <span class="part-formula part-header flexrow-coc7">
                 {{localize 'CoC7.UnitsDie'}}
                 <div class="flex1"></div>
                 <span class="part-total flex0">{{check.dices.unit.value}}</span>

--- a/templates/chat/combat/range-initiator.html
+++ b/templates/chat/combat/range-initiator.html
@@ -1,6 +1,6 @@
 <div class="coc7 chat-card range initiator" data-actor-key="{{actorKey}}" data-item-id="{{item.id}}" data-fast-forward="{{fastForward}}" data-resolved="{{resolved}}" data-rolled="{{rolled}}" data-cover="{{cover}}" data-surprised="{{surprised}}" data-auto-success="{{autoSuccess}}" data-single-shot="{{singleShot}}" data-multiple-shots="{{multipleShots}}" data-burst="{{burst}}" data-full-auto="{{fullAuto}}" data-bonus-die-a="{{bonusDieA}}" data-bonus-die-b="{{bonusDieB}}" data-penalty-die-a="{{penaltyDieA}}" data-penalty-die-b="{{penaltyDieB}}" data-aiming={{aiming}} data-is-GM="{{isKeeper}}" data-aimed="{{aimed}}" data-damage-rolled="{{damageRolled}}" data-damage-dealt="{{damageDealt}}" data-total-bullets-fired="{{totalBulletsFired}}" data-roll-mode="{{rollMode}}" data-is-blind="false" data-volley-size="{{volleySize}}">
-  <header class="card-header flexcol">
-    <div class="flexrow">
+  <header class="card-header flexcol-coc7">
+    <div class="flexrow-coc7">
       {{#if displayActorOnCard}}
         <img class="open-actor" data-actor-key="{{actorKey}}" style="flex: none;" src="{{actorImg}}" title="{{name}}" width="36" height="36" />
       {{/if}}
@@ -34,7 +34,7 @@
           <span class='tag'>{{ localize 'CoC7.BurstSize' }}: {{#unless isVolleyMinSize}}<i class="volley-size decrease far fa-minus-square"></i> {{/unless}}{{volleySize}}{{#unless isVolleyMaxSize}} <i class="volley-size increase far fa-plus-square"></i>{{/unless}}</span>
         {{/if}}
       </div>
-      <div class="flexrow range-selection">
+      <div class="flexrow-coc7 range-selection">
         {{#if item.singleShot}}
           <span class="flex1 toggle-switch singleShot {{#unless rolled}}simple-flag{{/unless}} {{#if singleShot}}switched-on{{/if}}" title="{{localize 'CoC7.rangeCombatCard.SingleShot'}}" style="text-align:center" data-flag="single-shot" data-selected={{singleShot}}>{{localize 'CoC7.rangeCombatCard.SingleShot'}}</span>
         {{/if}}
@@ -43,7 +43,7 @@
         {{/if}}
       </div>
 
-      <div class="flexrow advantage-selection">
+      <div class="flexrow-coc7 advantage-selection">
         {{#if item.system.properties.brst}}
           <span class="flex1 toggle-switch burst {{#unless rolled}}simple-flag{{/unless}} {{#if burst}}switched-on{{/if}}" title="{{localize 'CoC7.rangeCombatCard.Burst'}}" style="text-align:center" data-flag="burst" data-selected={{burst}}>{{localize 'CoC7.rangeCombatCard.Burst'}}</span>
         {{/if}}
@@ -57,7 +57,7 @@
 
   <div class="targets">
 
-    <div class="flexrow targets-selector" style="max-height: 24px;">
+    <div class="flexrow-coc7 targets-selector" style="max-height: 24px;">
       {{#each targets as |trgt key|}}
         <div class="target-selector" style="flex: none;" data-key="{{key}}">
           {{#if trgt.active}}
@@ -89,19 +89,19 @@
             <span class="{{#if trgt.inMelee}}tag{{else}}invisible{{/if}}" title="{{localize 'CoC7.rangeCombatCard.InMeleeTitle'}}">{{localize 'CoC7.rangeCombatCard.InMelee'}}</span>
             <span class="{{#if trgt.fast}}tag{{else}}invisible{{/if}}" title="{{localize 'CoC7.rangeCombatCard.FastMovingTargetTitle'}}">{{localize 'CoC7.rangeCombatCard.FastMovingTarget'}}</span>
           {{else}}
-            <div class="flexrow range-selection">
+            <div class="flexrow-coc7 range-selection">
               <span class="flex1 toggle-switch baseRange target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.baseRange}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.rangeCombatCard.BaseRange'}}" style="text-align:center" data-flag="base-range" data-selected={{trgt.baseRange}}>{{localize 'CoC7.rangeCombatCard.BaseRange'}}</span>
               <span class="flex1 toggle-switch longRange target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.longRange}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.rangeCombatCard.LongRange'}}" style="text-align:center" data-flag="long-range" data-selected={{trgt.longRange}}>{{localize 'CoC7.rangeCombatCard.LongRange'}}</span>
               <span class="flex1 toggle-switch extremeRange target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.extremeRange}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.rangeCombatCard.ExtremeRange'}}" style="text-align:center" data-flag="extreme-range" data-selected={{trgt.extremeRange}}>{{localize 'CoC7.rangeCombatCard.ExtremeRange'}}</span>
             </div>
 
-            <div class="flexrow bonus-selection">
+            <div class="flexrow-coc7 bonus-selection">
               <span class="flex1 toggle-switch cover target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.cover}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.rangeCombatCard.CoverTitle'}}" style="text-align:center" data-flag="cover" data-selected={{trgt.cover}}>{{localize 'CoC7.rangeCombatCard.Cover'}}</span>
               <span class="flex1 toggle-switch surprised target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.surprised}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.rangeCombatCard.SurprisedTargetTitle'}}" style="text-align:center" data-flag="surprised" data-selected={{trgt.surprised}}>{{localize 'CoC7.combatCard.surprised'}}</span>
               <span class="flex1 toggle-switch pointBlankRange target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.pointBlankRange}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.rangeCombatCard.PointBlankRangeTitle'}}" style="text-align:center" data-flag="point-blank-range" data-selected={{trgt.pointBlankRange}}>{{localize 'CoC7.rangeCombatCard.PointBlankRange'}}</span>
             </div>
 
-            <div class="flexrow bonus-selection">
+            <div class="flexrow-coc7 bonus-selection">
               <span class="flex1 toggle-switch size target-flag
                 {{#unless ../rolled}}simple-flag{{/unless}}
                 {{#if trgt.big}}switched-on{{/if}}
@@ -112,22 +112,22 @@
               <span class="flex1 toggle-switch inMelee target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.inMelee}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.rangeCombatCard.InMeleeTitle'}}" style="text-align:center" data-flag="in-melee" data-selected={{trgt.inMelee}}>{{localize 'CoC7.rangeCombatCard.InMelee'}}</span>
               <span class="flex1 toggle-switch fast target-flag {{#unless ../rolled}}simple-flag{{/unless}} {{#if trgt.fast}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.rangeCombatCard.FastMovingTargetTitle'}}" style="text-align:center" data-flag="fast" data-selected={{trgt.fast}}>{{localize 'CoC7.rangeCombatCard.FastMovingTarget'}}</span>
             </div>
-            <div class="flexrow range-selection" style="border-top: 2px groove #fff; padding-top: 3px">
+            <div class="flexrow-coc7 range-selection" style="border-top: 2px groove #fff; padding-top: 3px">
               <span class="flex1 toggle-switch {{#unless ../rolled}}simple-flag{{/unless}} {{#if ../bonusDieA}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.AdditionalBonusDie'}}" style="text-align:center" data-flag="bonus-die-a">{{localize 'CoC7.AdditionalBonusDie'}}</span>
               <span class="flex1 toggle-switch {{#unless ../rolled}}simple-flag{{/unless}} {{#if ../bonusDieB}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.AdditionalBonusDie'}}" style="text-align:center" data-flag="bonus-die-b">{{localize 'CoC7.AdditionalBonusDie'}}</span>
             </div>
-            <div class="flexrow range-selection" style="border-bottom: 2px groove #fff; padding-top: 3px">
+            <div class="flexrow-coc7 range-selection" style="border-bottom: 2px groove #fff; padding-top: 3px">
               <span class="flex1 toggle-switch {{#unless ../rolled}}simple-flag{{/unless}} {{#if ../penaltyDieA}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.AdditionalPenaltyDie'}}" style="text-align:center" data-flag="penalty-die-a">{{localize 'CoC7.AdditionalPenaltyDie'}}</span>
               <span class="flex1 toggle-switch {{#unless ../rolled}}simple-flag{{/unless}} {{#if ../penaltyDieB}}switched-on{{/if}} gm-select-only" title="{{localize 'CoC7.AdditionalPenaltyDie'}}" style="text-align:center" data-flag="penalty-die-b">{{localize 'CoC7.AdditionalPenaltyDie'}}</span>
             </div>
 
             {{#if ../calculatedBonusDice}}
-            <div class="flexrow" style="margin-top: 5px;">
+            <div class="flexrow-coc7" style="margin-top: 5px;">
               <div style="text-align: center">{{localize 'CoC7.BonusDice'}}: {{../calculatedBonusDice}}</div>
             </div>
             {{/if}}
             {{#if ../calculatedPenaltyDice}}
-            <div class="flexrow" style="margin-top: 5px;">
+            <div class="flexrow-coc7" style="margin-top: 5px;">
               <div style="text-align: center">{{localize 'CoC7.PenaltyDice'}}: {{../calculatedPenaltyDice}}</div>
             </div>
             {{/if}}
@@ -201,7 +201,7 @@
 
   <div class="shots">
     {{#if shots}}
-      <div class="shots flexcol {{#if rolled}}invisible{{/if}}" style="border: 1px groove">
+      <div class="shots flexcol-coc7 {{#if rolled}}invisible{{/if}}" style="border: 1px groove">
         {{#each shots as |shot key|}}
           <div class='shot' data-shot-order="{{key}}" data-actor-key="{{shot.actorKey}}" data-actor-name="{{shot.actorName}}" data-difficulty="{{shot.difficulty}}" data-damage="{{shot.damage}}" data-modifier="{{shot.modifier}}" data-bullets-shot="{{shot.bulletsShot}}" data-transit-bullets="{{shot.transitBullets}}" data-bullets-shot-transit="{{shot.bulletsShotTransit}}" data-transit="{{shot.transit}}">
             {{#if shot.transit}}
@@ -238,7 +238,7 @@
               <div class="dice-tooltip" style="display: none;">
                 <section class="tooltip-part">
                   <div class="dice ten-dice">
-                    <span class="part-formula part-header flexrow">
+                    <span class="part-formula part-header flexrow-coc7">
                       {{#if roll.tenOnlyOneDie}}
                         {{localize 'CoC7.TensDie'}}
                       {{else}}
@@ -256,7 +256,7 @@
                 </section>
                 <section class="tooltip-part">
                   <div class="dice unit-die">
-                    <span class="part-formula part-header flexrow">
+                    <span class="part-formula part-header flexrow-coc7">
                       {{localize 'CoC7.UnitsDie'}}
                       <div class="flex1"></div>
                       <span class="part-total flex0">{{roll.dices.unit.value}}</span>
@@ -328,7 +328,7 @@
               <div class="dice-tooltip" style="display: none;">
                 <section class="tooltip-part">
                   <div class="dice ten-dice">
-                    <span class="part-formula part-header flexrow">
+                    <span class="part-formula part-header flexrow-coc7">
                       {{#each d.rolls as |roll|}}
                         <span class="part">{{roll.formula}}</span>
                       {{/each}}

--- a/templates/chat/messages/actor-picker.hbs
+++ b/templates/chat/messages/actor-picker.hbs
@@ -1,8 +1,8 @@
-<div class="directory flexcol">
+<div class="directory flexcol-coc7">
   <p style="flex: 0 0 auto;">{{localize 'CoC7.PickWhichActorDesc'}}</p>
   <ol class="directory-list">
     {{#each object.options}}
-    <li class="directory-item document actor flexrow{{#if (eq ../object.selected this.uuid)}} picked{{/if}}{{#if this.canPing}} can-ping{{/if}}" data-entry-uuid="{{this.uuid}}">
+    <li class="directory-item document actor flexrow-coc7{{#if (eq ../object.selected this.uuid)}} picked{{/if}}{{#if this.canPing}} can-ping{{/if}}" data-entry-uuid="{{this.uuid}}">
       <img class="thumbnail" title="{{this.name}}" src="{{this.img}}">
       <h4 class="entry-name document-name">{{this.name}}</h4>
     </li>

--- a/templates/chat/messages/combined.hbs
+++ b/templates/chat/messages/combined.hbs
@@ -1,7 +1,7 @@
 <div class="coc7 chat-card chat-card-v2 roll-card-v2 combined">
   <div>{{localize 'CoC7.CombinedRollCard'}}{{#if (eq combined 'any')}} ({{localize 'CoC7.Any'}}){{else if (eq combined 'all')}} ({{localize 'CoC7.All'}}){{/if}}</div>
   {{#if isEditable}}
-  <div class='flexrow toggle visible-only-gm'>
+  <div class='flexrow-coc7 toggle visible-only-gm'>
     <button class="flex1 toggle-switch select-only-gm{{#if (eq combined 'any')}} switched-on{{/if}}" title="{{localize 'CoC7.CombinedAnyHint'}}" data-key="combined" data-value="any">{{localize 'CoC7.Any'}}</button>
     <button class="flex1 toggle-switch select-only-gm{{#if (eq combined 'all')}} switched-on{{/if}}" title="{{localize 'CoC7.CombinedAllHint'}}" data-key="combined" data-value="all">{{localize 'CoC7.All'}}</button>
   </div>

--- a/templates/chat/messages/opposed.hbs
+++ b/templates/chat/messages/opposed.hbs
@@ -1,5 +1,5 @@
 <div class="coc7 chat-card chat-card-v2 roll-card-v2 opposed{{#if isCombat}} combat{{/if}}">
-  <div class="title flexrow">
+  <div class="title flexrow-coc7">
     <div class="opposed-card-flag visible-only-gm{{#if isCombat}} active{{/if}}">
       {{#if isEditable}}
         <a class="toggle-link select-only-gm" data-key="isCombat"><i class="game-icon game-icon-crossed-swords"></i></a>
@@ -12,7 +12,7 @@
   {{#if isCombat}}
     {{#if (and isEditable allRollsCompleted)}}
       {{#if needsTieBreaker}}
-        <div class="flexrow toggle visible-only-gm">
+        <div class="flexrow-coc7 toggle visible-only-gm">
           <button class="flex1 toggle-switch select-only-gm{{#if advantageAttacker}} switched-on{{/if}}" title="{{localize 'CoC7.AdvantageAttacker'}}" data-key="advantageAttacker">{{localize 'CoC7.AdvantageAttacker'}}</button>
           <button class="flex1 toggle-switch select-only-gm{{#if advantageDefender}} switched-on{{/if}}" title="{{localize 'CoC7.AdvantageDefender'}}" data-key="advantageDefender">{{localize 'CoC7.AdvantageDefender'}}</button>
         </div>

--- a/templates/chat/messages/roll-dice.hbs
+++ b/templates/chat/messages/roll-dice.hbs
@@ -35,7 +35,7 @@
           </section>
           <section class="tooltip-part">
             <div class="dice ten-dice">
-              <span class="part-formula part-header flexrow">
+              <span class="part-formula part-header flexrow-coc7">
                 {{#if rollStatus.completed.dices.tenOnlyOneDie}}
                   {{localize 'CoC7.TensDie'}}
                 {{else}}
@@ -53,7 +53,7 @@
           </section>
           <section class="tooltip-part">
             <div class="dice unit-die">
-              <span class="part-formula part-header flexrow">
+              <span class="part-formula part-header flexrow-coc7">
                 {{localize 'CoC7.UnitsDie'}}
                 <div class="flex1"></div>
                 <span class="part-total flex0">{{rollStatus.completed.dices.unit.value}}</span>
@@ -65,7 +65,7 @@
           </section>
           {{#if rollStatus.completed.totalLuckSpent}}
             <section class="tooltip-part">
-              <div class="part-formula part-header flexrow">
+              <div class="part-formula part-header flexrow-coc7">
                 {{localize 'CoC7.LuckSpentAlt'}}
                 <div class="flex1"></div>
                 <div class="part-total flex0">-{{rollStatus.completed.totalLuckSpent}}</div>

--- a/templates/chat/roll-result.html
+++ b/templates/chat/roll-result.html
@@ -76,7 +76,7 @@
     </div>
   {{else}}
     {{#if isUnknown}}
-      <div class="flexrow difficulty-selector gm-visible-only" style="padding-bottom: 2px;">
+      <div class="flexrow-coc7 difficulty-selector gm-visible-only" style="padding-bottom: 2px;">
         <span class="flex1 toggle-switch simple-flag {{#if gmDifficultyRegular}}switched-on{{/if}}"
         title="{{localize 'CoC7.RollDifficultyRegularTitle'}}"
         style="text-align:center;white-space: nowrap;"
@@ -125,7 +125,7 @@
         <div class="dice-tooltip" style="display: none;">
           <section class="tooltip-part">
             <div class="dice ten-dice">
-              <span class="part-formula part-header flexrow">
+              <span class="part-formula part-header flexrow-coc7">
                 {{#if dices.tenOnlyOneDie}}
                   {{localize 'CoC7.TensDie'}}
                 {{else}}
@@ -148,7 +148,7 @@
           </section>
           <section class="tooltip-part">
             <div class="dice unit-die">
-              <span class="part-formula part-header flexrow">
+              <span class="part-formula part-header flexrow-coc7">
                 {{localize 'CoC7.UnitsDie'}}
                 <div class="flex1"></div>
                 <span class="part-total flex0">{{dices.unit.value}}</span>

--- a/templates/chat/rolls/in-card-roll.html
+++ b/templates/chat/rolls/in-card-roll.html
@@ -1,6 +1,6 @@
 <div class="coc7 roll-result">
   {{#if isUnknown}}
-    <div class="flexrow difficulty-selector gm-visible-only" style="padding-bottom: 2px;">
+    <div class="flexrow-coc7 difficulty-selector gm-visible-only" style="padding-bottom: 2px;">
       <span class="flex1 toggle-switch simple-flag {{#if gmDifficultyRegular}}switched-on{{/if}}"
         title="{{localize 'CoC7.RollDifficultyRegularTitle'}}"
         style="text-align:center;white-space: nowrap;"
@@ -44,7 +44,7 @@
         </section>
         <section class="tooltip-part">
           <div class="dice ten-dice">
-            <span class="part-formula part-header flexrow">
+            <span class="part-formula part-header flexrow-coc7">
               {{#if dices.tenOnlyOneDie}}
                 {{localize 'CoC7.TensDie'}}
               {{else}}
@@ -67,7 +67,7 @@
         </section>
         <section class="tooltip-part">
           <div class="dice unit-die">
-            <span class="part-formula part-header flexrow">
+            <span class="part-formula part-header flexrow-coc7">
               {{localize 'CoC7.UnitsDie'}}
               <div class="flex1"></div>
               <span class="part-total flex0">{{dices.unit.value}}</span>

--- a/templates/chat/rolls/roll-tooltip.html
+++ b/templates/chat/rolls/roll-tooltip.html
@@ -2,7 +2,7 @@
   {{#each parts}}
     <section class="tooltip-part">
       <div class="dice">
-        <header class="part-header flexrow">
+        <header class="part-header flexrow-coc7">
           <span class="part-formula" title="{{this.successRequired}}">{{this.formula}}</span>
           <span class="part-total {{this.class}}" title="{{this.resultType}}">{{this.total}}</span>
         </header>

--- a/templates/common/active-effects.hbs
+++ b/templates/common/active-effects.hbs
@@ -1,11 +1,11 @@
 <ol class="items-list effects-list">
   {{#each effects as |section sid|}}
     {{#unless section.hidden}}
-      <li class="items-header flexrow" data-effect-type="{{section.type}}">
-        <h3 class="item-name effect-name flexrow">{{localize section.label}}</h3>
+      <li class="items-header flexrow-coc7" data-effect-type="{{section.type}}">
+        <h3 class="item-name effect-name flexrow-coc7">{{localize section.label}}</h3>
         <div class="effect-source">{{localize "CoC7.Source"}}</div>
         <div class="effect-source">{{localize "CoC7.Duration"}}</div>
-        <div class="item-controls effect-controls flexrow">
+        <div class="item-controls effect-controls flexrow-coc7">
           {{#if @root.editable}}
             <a class="effect-control" data-action="create" title="{{localize 'CoC7.Create'}}">
               <i class="fas fa-plus"></i> {{localize "CoC7.Add"}}
@@ -24,14 +24,14 @@
 
       <ol class="item-list">
         {{#each section.effects as |effect|}}
-          <li class="item effect flexrow" data-effect-id="{{effect.id}}">
-            <div class="item-name effect-name flexrow">
+          <li class="item effect flexrow-coc7" data-effect-id="{{effect.id}}">
+            <div class="item-name effect-name flexrow-coc7">
               <img class="item-image" src="{{effect.icon}}"/>
               <h4>{{#if effect.name}}{{effect.name}}{{!-- // FoundryVTT v10 --}}{{else}}{{effect.label}}{{/if}}</h4>
             </div>
             <div class="effect-source">{{effect.sourceName}}</div>
             <div class="effect-duration">{{effect.duration.label}}</div>
-            <div class="item-controls effect-controls flexrow">
+            <div class="item-controls effect-controls flexrow-coc7">
               {{#if @root.editable}}
                 <a class="effect-control" data-action="toggle" title="{{#if effect.disabled}}{{localize 'CoC7.Enable'}}{{else}}{{localize 'CoC7.Disable'}}{{/if}}">
                   <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>

--- a/templates/items/archetype.html
+++ b/templates/items/archetype.html
@@ -1,11 +1,11 @@
-<form class="{{cssClass}} flexcol" autocomplete="off">
-  <header class="sheet-header flexrow" style="flex: 0 0 64px;padding-bottom: 2px;">
-    <div class="header-details flexrow">
+<form class="{{cssClass}} flexcol-coc7" autocomplete="off">
+  <header class="sheet-header flexrow-coc7" style="flex: 0 0 64px;padding-bottom: 2px;">
+    <div class="header-details flexrow-coc7">
       <h1 class="name" style="height: 48px;">
         <input name="name" type="text" value="{{item.name}}" placeholder="{{ localize 'CoC7.Name' }}" />
       </h1>
 
-      <ul class="summary flexrow">
+      <ul class="summary flexrow-coc7">
         <li class="flex2">
           <input type="text" name="system.source" value="{{data.system.source}}" placeholder="{{ localize 'CoC7.Source' }}" />
         </li>
@@ -32,7 +32,7 @@
   <section style="overflow: hidden;flex: 1;" class="sheet-body">
 
     {{!-- Description Tab --}}
-    <div class="tab flexrow active" data-group="primary" data-tab="description">
+    <div class="tab flexrow-coc7 active" data-group="primary" data-tab="description">
 
       <div class="item-properties">
         <ol class="properties-list">
@@ -121,8 +121,8 @@
 
         <ol class="item-list">
           {{#each data.system.skills as |skill|}}
-            <li class="item flexrow" data-item-id="{{skill._id}}" data-cocid="{{skill.flags.CoC7.cocidFlag.id}}">
-              <div class="item-name flexrow">
+            <li class="item flexrow-coc7" data-item-id="{{skill._id}}" data-cocid="{{skill.flags.CoC7.cocidFlag.id}}">
+              <div class="item-name flexrow-coc7">
                 <h4>{{skill.name}} ({{skill.system.base}}%)</h4>
               </div>
 

--- a/templates/items/armor.hbs
+++ b/templates/items/armor.hbs
@@ -1,6 +1,6 @@
-<form class="{{cssClass}} flexcol" autocomplete="off">
-  <header class="sheet-header flexrow" style="flex: 0 0 64px;padding-bottom: 2px;">
-    <div class="header-details flexrow">
+<form class="{{cssClass}} flexcol-coc7" autocomplete="off">
+  <header class="sheet-header flexrow-coc7" style="flex: 0 0 64px;padding-bottom: 2px;">
+    <div class="header-details flexrow-coc7">
       <h1 class="name" style="height: 48px;">
         <input name="name" type="text" value="{{item.name}}" placeholder="{{ localize 'CoC7.Name' }}" />
       </h1>
@@ -21,7 +21,7 @@
 
   {{!-- Item Sheet Body --}}
   <section style="overflow: hidden;flex: 1;" class="sheet-body">
-    <div class="tab flexrow active" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="description">
+    <div class="tab flexrow-coc7 active" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="description">
       {{editor enrichedDescriptionValue target="system.description.value" engine="prosemirror" button=true owner=owner editable=editable}}
     </div>
 

--- a/templates/items/book/details.html
+++ b/templates/items/book/details.html
@@ -2,7 +2,7 @@
   <div class="traits">
     <div class="type">
       <label>{{localize "CoC7.BookType"}}</label>
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <input id="mythos" type="checkbox" name="system.type.mythos" {{checked data.system.type.mythos}} />
         <label class="option" for="system.type.mythos">{{localize "CoC7.Mythos"}}</label>
 
@@ -13,7 +13,7 @@
         <label class="option" for="system.type.other">{{localize "CoC7.Other"}}</label>
       </div>
     </div>
-    <div class="flexrow">
+    <div class="flexrow-coc7">
       <label>{{localize "CoC7.DifficultyLevel"}}:</label>
       <select name="system.difficultyLevel">
         {{#select data.system.difficultyLevel}}
@@ -26,7 +26,7 @@
       </select>
     </div>
     {{#if data.system.type.mythos}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize "CoC7.StudyTime"}}:</label>
         <input type="number" name="system.study.necessary" value="{{data.system.study.necessary}}" />
         <select name="system.study.units">
@@ -40,7 +40,7 @@
       </div>
     {{/if}}
     {{#if (or data.system.type.mythos data.system.type.occult)}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize "CoC7.SANLoss"}}:</label>
         <input type="text" name="system.sanityLoss" value="{{data.system.sanityLoss}}" />
       </div>
@@ -50,21 +50,21 @@
     <label>{{localize "CoC7.Gains"}}</label>
     <br>
     {{#if data.system.type.mythos}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize "CoC7.CthulhuMythosInitial"}}:</label>
         <input type="number" name="system.gains.cthulhuMythos.initial" value="{{data.system.gains.cthulhuMythos.initial}}" />
       </div>
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize "CoC7.CthulhuMythosFinal"}}:</label>
         <input type="number" name="system.gains.cthulhuMythos.final" value="{{data.system.gains.cthulhuMythos.final}}" />
       </div>
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize "CoC7.MythosRating"}}:</label>
         <input type="number" name="system.mythosRating" value="{{data.system.mythosRating}}" />
       </div>
     {{/if}}
     {{#if data.system.type.occult}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize "CoC7.Occult"}}:</label>
         <input type="number" name="system.gains.occult" value="{{data.system.gains.occult}}" />
       </div>
@@ -72,7 +72,7 @@
   </div>
   <div class="other">
     {{#if data.system.type.other}}
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <table>
           <tr>
             <th><label>{{localize "CoC7.Skill"}}</label></th>

--- a/templates/items/book/main.html
+++ b/templates/items/book/main.html
@@ -1,22 +1,22 @@
-<form class="{{cssClass}} flexcol" autocomplete="off">
+<form class="{{cssClass}} flexcol-coc7" autocomplete="off">
   <div class="container">
     <div class="portrait">
       <img src="{{item.img}}" title="{{item.name}}" data-edit="img" />
     </div>
     <div class="information">
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <input class="name" name="name" type="text" value="{{item.name}}" />
       </div>
       {{#if (or isKeeper initialReading)}}
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <label>{{localize "CoC7.Author"}}:</label>
           <input type="text" name="system.author" value="{{data.system.author}}" />
         </div>
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <label>{{localize "CoC7.Date"}}:</label>
           <input type="text" name="system.date" value="{{data.system.date}}" />
         </div>
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <label>{{localize "CoC7.language"}}:</label>
           <input type="text" name="system.language" value="{{data.system.language}}" />
         </div>
@@ -24,7 +24,7 @@
     </div>
     <div class="aside">
       {{#if data.system.initialReading}}
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <span>
             <label>
               {{localize "CoC7.InitialReading"}}
@@ -32,7 +32,7 @@
           </span>
           <i class="fas fa-check"></i>
         </div>
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <span>
             <label>
               {{localize "CoC7.FullStudies"}}:
@@ -50,7 +50,7 @@
           </span>
         </div>
       {{else}}
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           {{#if (and hasOwner (or isKeeper isOwner))}}
             <span id="attempt-initial-reading">
               <label>

--- a/templates/items/chase.html
+++ b/templates/items/chase.html
@@ -1,4 +1,4 @@
-<form class="{{cssClass}} flexcol" autocomplete="off">
+<form class="{{cssClass}} flexcol-coc7" autocomplete="off">
   <div class="container expanded">
     <header class="sheet-header">
       {{#unless started}}
@@ -8,11 +8,11 @@
         </div>
       {{/unless}}
       {{#if activeLocation.uuid}}
-        <div class="flexrow chase-location" data-uuid="{{activeLocation.uuid}}">
+        <div class="flexrow-coc7 chase-location" data-uuid="{{activeLocation.uuid}}">
           {{#unless activeLocation.init}}
             <div class="location-controls"><a class="location-control" data-action="add-before" title="{{localize 'CoC7.InsertLocation'}}"><i class="icon fas fa-plus-circle"></i></a></div>
           {{/unless}}
-          <div class="active-location flexcol">
+          <div class="active-location flexcol-coc7">
             {{#if activeLocation}}
               <datalist id="check-all-options">
                 {{#each item.allSkillsAndCharacteristics as |o|}}
@@ -41,8 +41,8 @@
                   <i class="icon game-icon game-icon-pin"></i>
                 </a>
               </div>
-              <div class="details flexrow">
-                <div class="obstacle flexcol" data-uuid="{{activeLocation.uuid}}">
+              <div class="details flexrow-coc7">
+                <div class="obstacle flexcol-coc7" data-uuid="{{activeLocation.uuid}}">
                   {{#unless activeLocation.first}}
                     <div class="form-group">
                       <div class="tag obstacle-type barrier {{#if activeLocation.obstacleDetails.barrier}}switched-on{{/if}}">barrier</div>
@@ -61,7 +61,7 @@
                         {{/if}}
                       </div>
                       <div class="form-group">
-                        <div class="flexrow flex1">
+                        <div class="flexrow-coc7 flex1">
                           <a toggle="locations.{{activeLocation.uuid}}.obstacleDetails.hasDamage" class="flex0 icon toggle {{#if activeLocation.obstacleDetails.hasDamage}}switched-on{{/if}}" title="{{ localize 'CoC7.DamageOnFail' }}">
                             <i class="game-icon game-icon-broken-bone"></i>
                           </a>
@@ -70,7 +70,7 @@
                           {{/if}}
                         </div>
                         {{#if activeLocation.obstacleDetails.barrier}}
-                          <div class="flexrow flex1">
+                          <div class="flexrow-coc7 flex1">
                             <a toggle="locations.{{activeLocation.uuid}}.obstacleDetails.hasHitPoints" class="flex0 icon toggle {{#if activeLocation.obstacleDetails.hasHitPoints}}switched-on{{/if}}" title="{{ localize 'CoC7.ObstacleHasHitPoint' }}">
                               <i class="game-icon game-icon-life-bar"></i>
                             </a>
@@ -79,7 +79,7 @@
                             {{/if}}
                           </div>
                         {{else}}
-                          <div class="flexrow flex1">
+                          <div class="flexrow-coc7 flex1">
                             <a toggle="locations.{{activeLocation.uuid}}.obstacleDetails.hasActionCost" class="flex0 icon toggle {{#if activeLocation.obstacleDetails.hasActionCost}}switched-on{{/if}}" title="{{ localize 'CoC7.ActionCostOnFail' }}">
                               <i class="fas fa-bahai"></i>
                             </a>
@@ -92,7 +92,7 @@
                     {{/if}}
                   {{/unless}}
                 </div>
-                <div class="obstacle flexcol" data-uuid="{{nextLocation.uuid}}" data-caca="true">
+                <div class="obstacle flexcol-coc7" data-uuid="{{nextLocation.uuid}}" data-caca="true">
                   {{#unless activeLocation.last}}
                     <div class="form-group">
                       <div class="tag obstacle-type barrier {{#if nextLocation.obstacleDetails.barrier}}switched-on{{/if}}">barrier</div>
@@ -111,7 +111,7 @@
                         {{/if}}
                       </div>
                       <div class="form-group">
-                        <div class="flexrow flex1">
+                        <div class="flexrow-coc7 flex1">
                           <a toggle="locations.{{nextLocation.uuid}}.obstacleDetails.hasDamage" class="flex0 icon toggle {{#if nextLocation.obstacleDetails.hasDamage}}switched-on{{/if}}" title="{{ localize 'CoC7.DamageOnFail' }}">
                             <i class="game-icon game-icon-broken-bone"></i>
                           </a>
@@ -120,7 +120,7 @@
                           {{/if}}
                         </div>
                         {{#if nextLocation.obstacleDetails.barrier}}
-                          <div class="flexrow flex1">
+                          <div class="flexrow-coc7 flex1">
                             <a toggle="locations.{{nextLocation.uuid}}.obstacleDetails.hasHitPoints" class="flex0 icon toggle {{#if nextLocation.obstacleDetails.hasHitPoints}}switched-on{{/if}}" title="{{ localize 'CoC7.ObstacleHasHitPoint' }}">
                               <i class="game-icon game-icon-life-bar"></i>
                             </a>
@@ -129,7 +129,7 @@
                             {{/if}}
                           </div>
                         {{else}}
-                          <div class="flexrow flex1">
+                          <div class="flexrow-coc7 flex1">
                             <a toggle="locations.{{nextLocation.uuid}}.obstacleDetails.hasActionCost" class="flex0 icon toggle {{#if nextLocation.obstacleDetails.hasActionCost}}switched-on{{/if}}" title="{{ localize 'CoC7.ActionCostOnFail' }}">
                               <i class="fas fa-bahai"></i>
                             </a>
@@ -173,7 +173,7 @@
             <div class="initiative-track">
               {{#each item.participantsByInitiative as |p i|}}
                 <div class="initiative-block {{p.cssClass}}" data-uuid="{{p.uuid}}">
-                  <div class="header flexrow">
+                  <div class="header flexrow-coc7">
                     <div class="name">{{p.name}}</div>
                     <div class="participant-controls">
                       <a class="participant-control" title="{{localize 'CoC7.Remove'}}" data-action="removeParticipant">
@@ -187,11 +187,11 @@
                       </a>
                     </div>
                   </div>
-                  <div class="participant flexrow">
+                  <div class="participant flexrow-coc7">
                     <div class="portrait">
                       <img src="{{p.icon}}" title="{{p.name}}" />
                     </div>
-                    <div class="infos flexcol">
+                    <div class="infos flexcol-coc7">
                       <div>{{localize 'CoC7.Chase.InitiativeShort' value=p.initiative}}</div>
                       <div>{{localize 'CoC7.Chase.AdjustedMovementShort' value=p.adjustedMov}}</div>
                       <div>{{localize 'CoC7.HP'}}: <input type="text" name="system.participants.{{p.uuid}}.hp" value="{{p.hp}}" data-dtype="Number" />
@@ -245,7 +245,7 @@
           <div class="chase-track">
             {{#each locations as |location i|}}
               <div class="chase-location" data-uuid="{{location.uuid}}">
-                <div class="flexrow people">
+                <div class="flexrow-coc7 people">
                   {{#unless location.first}}
                     {{#if location.obstacle}}
                       <div class="spacer"></div>
@@ -261,10 +261,10 @@
                     {{/each}}
                   </div>
                 </div>
-                <div class="flexrow">
+                <div class="flexrow-coc7">
                   {{#unless location.first}}
                     {{#if location.obstacle}}
-                      <div class="flexrow obstalce flex-content" title="{{location.obstacleDetails.name}}">
+                      <div class="flexrow-coc7 obstalce flex-content" title="{{location.obstacleDetails.name}}">
                         <div class="warning">
                           {{#if location.obstacleDetails.barrier}}
                             <i class="game-icon game-icon-barrier"></i>
@@ -276,7 +276,7 @@
                     {{/if}}
                   {{/unless}}
 
-                  <div class="flexrow name flex1">
+                  <div class="flexrow-coc7 name flex1">
                     {{#if location.first}}
                       <div class="spacer"></div>
                     {{else}}

--- a/templates/items/item-sheetV2.html
+++ b/templates/items/item-sheetV2.html
@@ -1,18 +1,18 @@
-<form class="{{cssClass}} flexcol" autocomplete="off">
+<form class="{{cssClass}} flexcol-coc7" autocomplete="off">
   <div class="container expanded">
     <header class="sheet-header">
       <div class="sheet-portrait">
         <img class="photo" src="{{item.img}}" title="{{item.name}}" data-edit="img" />
       </div>
       <div class="infos">
-        <div class="row flexrow">
+        <div class="row flexrow-coc7">
           <input class="name" name="name" type="text" value="{{item.name}}" placeholder="{{ localize 'CoC7.Name' }}" />
         </div>
-        <div class="row flexrow">
+        <div class="row flexrow-coc7">
           <label>{{localize 'CoC7.ItemQuantity'}}</label>
           <input type="text" name="system.quantity" value="{{data.system.quantity}}" data-dtype="Number" />
         </div>
-        <div class="row flexrow">
+        <div class="row flexrow-coc7">
           <label>{{localize 'CoC7.ItemWeight'}}</label>
           <input type="text" name="system.weight" value="{{data.system.weight}}" data-dtype="Number" />
         </div>
@@ -29,14 +29,14 @@
     </nav>
 
     <section class="sheet-body">
-      <div class="tab description flexrow active" style="border-top: 2px groove #eeede0;padding: 0 0 0 5px;overflow: auto;" data-group="primary" data-tab="description">
+      <div class="tab description flexrow-coc7 active" style="border-top: 2px groove #eeede0;padding: 0 0 0 5px;overflow: auto;" data-group="primary" data-tab="description">
         {{editor enrichedDescriptionValue target="system.description.value" engine="prosemirror" button=true owner=owner editable=editable}}
       </div>
       <div class="tab effects" data-group="primary" data-tab="effects">
         {{> "systems/CoC7/templates/common/active-effects.hbs"}}
       </div>
       {{#if isKeeper}}
-        <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+        <div class="tab keeper flexcol-coc7" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
           {{editor enrichedDescriptionKeeper target="system.description.keeper" engine="prosemirror" button=true owner=owner editable=editable}}
         </div>
       {{/if}}

--- a/templates/items/occupation.html
+++ b/templates/items/occupation.html
@@ -1,11 +1,11 @@
-<form class="{{cssClass}} flexcol" autocomplete="off">
-  <header class="sheet-header flexrow" style="flex: 0 0 64px;padding-bottom: 2px;">
-    <div class="header-details flexrow">
+<form class="{{cssClass}} flexcol-coc7" autocomplete="off">
+  <header class="sheet-header flexrow-coc7" style="flex: 0 0 64px;padding-bottom: 2px;">
+    <div class="header-details flexrow-coc7">
       <h1 class="name" style="height: 48px;">
         <input name="name" type="text" value="{{item.name}}" placeholder="{{ localize 'CoC7.Name' }}" />
       </h1>
 
-      <ul class="summary flexrow">
+      <ul class="summary flexrow-coc7">
         <li class="flex2">
           <input type="text" name="system.source" value="{{data.system.source}}" placeholder="{{ localize 'CoC7.Source' }}" />
         </li>
@@ -33,7 +33,7 @@
   <section style="overflow: hidden;flex: 1;" class="sheet-body">
 
     {{!-- Description Tab --}}
-    <div class="tab flexrow active" data-group="primary" data-tab="description">
+    <div class="tab flexrow-coc7 active" data-group="primary" data-tab="description">
 
       <div class="item-properties">
         <ol class="properties-list">
@@ -51,7 +51,7 @@
 
       <h3 class="form-header">{{ localize "CoC7.OccupationType" }}</h3>
       <div class="occupation-type form-group stacked">
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <label class="checkbox">
             <input type="checkbox" name="system.type.classic" {{checked data.system.type.classic}} /> {{ localize "CoC7.Classic" }}
           </label>
@@ -184,8 +184,8 @@
 
         <ol class="item-list">
           {{#each data.system.skills as |skill|}}
-            <li class="item flexrow" data-item-id="{{skill._id}}" data-cocid="{{skill.flags.CoC7.cocidFlag.id}}">
-              <div class="item-name flexrow">
+            <li class="item flexrow-coc7" data-item-id="{{skill._id}}" data-cocid="{{skill.flags.CoC7.cocidFlag.id}}">
+              <div class="item-name flexrow-coc7">
                 <h4>{{skill.name}} ({{skill.system.base}}%)</h4>
               </div>
 
@@ -217,8 +217,8 @@
                 <h3 class="warning">{{ localize "CoC7.EmptySkillList" }}</h3>
               {{/if}}
               {{#each group.skills as |skill|}}
-                <li class="item flexrow" data-item-id="{{skill._id}}" data-cocid="{{skill.flags.CoC7.cocidFlag.id}}">
-                  <div class="item-name flexrow">
+                <li class="item flexrow-coc7" data-item-id="{{skill._id}}" data-cocid="{{skill.flags.CoC7.cocidFlag.id}}">
+                  <div class="item-name flexrow-coc7">
                     <h4>{{skill.name}} ({{skill.system.base}}%)</h4>
                   </div>
                   <div class="item-controls">
@@ -240,7 +240,7 @@
       {{/unless}}
     </div>
     {{#if isKeeper}}
-      <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+      <div class="tab keeper flexcol-coc7" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
         {{editor enrichedDescriptionKeeper target="system.description.keeper" engine="prosemirror" button=true owner=owner editable=editable}}
       </div>
     {{/if}}

--- a/templates/items/setup.html
+++ b/templates/items/setup.html
@@ -1,11 +1,11 @@
-<form class="{{cssClass}} flexcol" autocomplete="off">
-  <header class="sheet-header flexrow" style="flex: 0 0 64px;padding-bottom: 2px;">
-    <div class="header-details flexrow">
+<form class="{{cssClass}} flexcol-coc7" autocomplete="off">
+  <header class="sheet-header flexrow-coc7" style="flex: 0 0 64px;padding-bottom: 2px;">
+    <div class="header-details flexrow-coc7">
       <h1 class="name" style="height: 48px;">
         <input name="name" type="text" value="{{item.name}}" placeholder="{{localize 'CoC7.Name'}}" />
       </h1>
 
-      <ul class="summary flexrow">
+      <ul class="summary flexrow-coc7">
         <li class="flex2">
           <input type="text" name="system.source" value="{{data.system.source}}" placeholder="{{localize 'CoC7.Source'}}" />
         </li>
@@ -30,7 +30,7 @@
   <section style="overflow: hidden;flex: 1;" class="sheet-body">
 
     {{!-- Description Tab --}}
-    <div class="tab flexrow active" data-group="primary" data-tab="description">
+    <div class="tab flexrow-coc7 active" data-group="primary" data-tab="description">
 
       <div class="item-properties">
         <ol class="properties-list">
@@ -83,7 +83,7 @@
           </div>
         {{/if}}
         {{#each data.system.monetary.values as |value index|}}
-          <div class="flexrow form-group item" data-index="{{index}}">
+          <div class="flexrow-coc7 form-group item" data-index="{{index}}">
             <input name="system.monetary.values.{{index}}.name" value="{{localize value.name}}" type="text" placeholder="{{localize 'CoC7.Name'}}">
             <input name="system.monetary.values.{{index}}.min" value="{{value.min}}" class="cash-assets-range" type="number" placeholder="{{localize 'CoC7.MonetaryCreditRatingMin'}}">
             <input name="system.monetary.values.{{index}}.max" value="{{value.max}}" class="cash-assets-range" type="number" placeholder="{{localize 'CoC7.MonetaryCreditRatingMax'}}">
@@ -145,8 +145,8 @@
 
         <ol class="item-list">
           {{#each otherItems as |item|}}
-            <li class="item flexrow" data-item-id="{{item._id}}" data-cocid="{{item.flags.CoC7.cocidFlag.id}}">
-              <div class="item-name flexrow">
+            <li class="item flexrow-coc7" data-item-id="{{item._id}}" data-cocid="{{item.flags.CoC7.cocidFlag.id}}">
+              <div class="item-name flexrow-coc7">
                 <h4>{{item.name}} ({{item.type}})</h4>
               </div>
 
@@ -169,8 +169,8 @@
 
         <ol class="item-list">
           {{#each skills as |skill|}}
-            <li class="item flexrow" data-item-id="{{skill._id}}" data-cocid="{{skill.flags.CoC7.cocidFlag.id}}">
-              <div class="item-name flexrow">
+            <li class="item flexrow-coc7" data-item-id="{{skill._id}}" data-cocid="{{skill.flags.CoC7.cocidFlag.id}}">
+              <div class="item-name flexrow-coc7">
                 <h4>{{skill.name}} ({{skill.system.base}}%)</h4>
               </div>
 
@@ -237,7 +237,7 @@
       </div>
     </div>
     {{#if isKeeper}}
-      <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+      <div class="tab keeper flexcol-coc7" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
         {{editor enrichedDescriptionKeeper target="system.description.keeper" engine="prosemirror" button=true owner=owner editable=editable}}
       </div>
     {{/if}}

--- a/templates/items/skill-sheet.html
+++ b/templates/items/skill-sheet.html
@@ -1,5 +1,5 @@
-<form class="{{cssClass}} flexcol" autocomplete="off">
-  <div class="item-header flexrow" style="flex: 0 0 110px;">
+<form class="{{cssClass}} flexcol-coc7" autocomplete="off">
+  <div class="item-header flexrow-coc7" style="flex: 0 0 110px;">
     <div class="item-property" style="display: flex; flex-direction: column; flex: 1;">
       <div class="item-name" style="display: flex; flex-direction: row; height: 24px;">
         <input type="hidden" name="name" value="{{item.name}}" />
@@ -29,7 +29,7 @@
       </div>
 
       {{#unless hasOwner}}
-        <div class="flexrow" style="margin: 4px 0;">
+        <div class="flexrow-coc7" style="margin: 4px 0;">
           <label style="margin-right: 10px;">{{ localize "CoC7.Eras" }}</label>
           <div class="skill-attributes" data-set="eras">
             {{#each _eras as |era key|}}
@@ -53,14 +53,14 @@
   </nav>
 
   <section class="sheet-body">
-    <div class="tab description flexrow active" style="border-top: 2px groove #eeede0;padding: 0 0 0 5px;overflow: auto;" data-group="primary" data-tab="description">
+    <div class="tab description flexrow-coc7 active" style="border-top: 2px groove #eeede0;padding: 0 0 0 5px;overflow: auto;" data-group="primary" data-tab="description">
       {{editor enrichedDescriptionValue target="system.description.value" engine="prosemirror" button=true owner=owner editable=editable}}
     </div>
     <div class="tab coc7" data-group="primary" data-tab="effects">
       {{> "systems/CoC7/templates/common/active-effects.hbs"}}
     </div>
     {{#if isKeeper}}
-      <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+      <div class="tab keeper flexcol-coc7" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
         {{editor enrichedDescriptionKeeper target="system.description.keeper" engine="prosemirror" button=true owner=owner editable=editable}}
       </div>
     {{/if}}

--- a/templates/items/spell/details.html
+++ b/templates/items/spell/details.html
@@ -1,7 +1,7 @@
 <div class="details">
   <div class="type">
     <label>{{localize "CoC7.SpellType"}}</label>
-    <div class="flexrow">
+    <div class="flexrow-coc7">
       <input id="bind" type="checkbox" name="system.type.bind" {{checked data.system.type.bind}} />
       <label class="option" for="system.type.bind">{{localize "CoC7.BindSpell"}}</label>
       <input id="call" type="checkbox" name="system.type.call" {{checked data.system.type.call}} />
@@ -22,28 +22,28 @@
   </div>
   <div class="cost">
     <div class="left">
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize "CoC7.SanityCost"}}:</label>
         <input type="text" name="system.costs.sanity" value="{{data.system.costs.sanity}}" />
       </div>
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize "CoC7.PowerCost"}}:</label>
         <input type="text" name="system.costs.power" value="{{data.system.costs.power}}" />
       </div>
     </div>
     <div class="right">
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize "CoC7.HitPointsCost"}}:</label>
         <input type="text" name="system.costs.hitPoints" value="{{data.system.costs.hitPoints}}" />
       </div>
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <label>{{localize "CoC7.MagicPointsCost"}}:</label>
         <input type="text" name="system.costs.magicPoints" value="{{data.system.costs.magicPoints}}" />
       </div>
     </div>
   </div>
   <div class="other">
-    <div class="flexrow">
+    <div class="flexrow-coc7">
       <label>{{localize "CoC7.OtherCosts"}}:</label>
       <input type="text" name="system.costs.others" value="{{data.system.costs.others}}" />
     </div>

--- a/templates/items/spell/main.html
+++ b/templates/items/spell/main.html
@@ -4,15 +4,15 @@
       <img src="{{item.img}}" title="{{item.name}}" data-edit="img" />
     </div>
     <div class="information">
-      <div class="flexrow">
+      <div class="flexrow-coc7">
         <input class="name" name="name" type="text" value="{{item.name}}" />
       </div>
       {{#if isKeeper}}
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <label>{{localize "CoC7.Source"}}:</label>
           <input type="text" name="system.source" value="{{data.system.source}}" />
         </div>
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <label>{{localize "CoC7.SpellCastingTime"}}:</label>
           <input type="text" name="system.castingTime" value="{{data.system.castingTime}}" />
         </div>
@@ -20,7 +20,7 @@
     </div>
     <div class="aside">
       {{#if (and hasOwner (or isKeeper isOwner))}}
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <span id="cast-spell" class="cast-button">
             <label>
               {{localize "CoC7.Cast"}}

--- a/templates/items/status.html
+++ b/templates/items/status.html
@@ -1,11 +1,11 @@
-<form class="{{cssClass}} flexcol" autocomplete="off">
-  <header class="sheet-header flexrow" style="flex: 0 0 64px;padding-bottom: 2px;">
-    <div class="header-details flexrow">
+<form class="{{cssClass}} flexcol-coc7" autocomplete="off">
+  <header class="sheet-header flexrow-coc7" style="flex: 0 0 64px;padding-bottom: 2px;">
+    <div class="header-details flexrow-coc7">
       <h1 class="name" style="height: 48px;">
         <input name="name" type="text" value="{{item.name}}" placeholder="{{ localize 'CoC7.Name' }}" />
       </h1>
 
-      <ul class="summary flexrow">
+      <ul class="summary flexrow-coc7">
         <li class="flex1">
           <input type="text" name="system.source" value="{{data.system.source}}" placeholder="{{ localize 'CoC7.Source' }}" />
         </li class="flex1">
@@ -29,7 +29,7 @@
   <section class="sheet-body">
 
     {{!-- Description Tab --}}
-    <div class="tab flexrow active" data-group="primary" data-tab="description">
+    <div class="tab flexrow-coc7 active" data-group="primary" data-tab="description">
 
       <div class="item-properties">
         <ol class="properties-list">
@@ -49,7 +49,7 @@
       {{!-- Talent Type --}}
       <div class="spell-type form-group stacked">
         <label>{{ localize "CoC7.InsanityType" }}</label>
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <label class="checkbox">
             <input type="checkbox" name="system.type.mania" {{checked data.system.type.mania}} /> {{ localize "CoC7.Mania" }}
           </label>
@@ -66,7 +66,7 @@
       {{> "systems/CoC7/templates/common/active-effects.hbs"}}
     </div>
     {{#if isKeeper}}
-      <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+      <div class="tab keeper flexcol-coc7" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
         {{editor enrichedDescriptionKeeper target="system.description.keeper" engine="prosemirror" button=true owner=owner editable=editable}}
       </div>
     {{/if}}

--- a/templates/items/talent.html
+++ b/templates/items/talent.html
@@ -1,11 +1,11 @@
-<form class="{{cssClass}} flexcol" autocomplete="off">
-  <header class="sheet-header flexrow" style="flex: 0 0 64px;padding-bottom: 2px;">
-    <div class="header-details flexrow">
+<form class="{{cssClass}} flexcol-coc7" autocomplete="off">
+  <header class="sheet-header flexrow-coc7" style="flex: 0 0 64px;padding-bottom: 2px;">
+    <div class="header-details flexrow-coc7">
       <h1 class="name" style="height: 48px;">
         <input name="name" type="text" value="{{item.name}}" placeholder="{{ localize 'CoC7.Name' }}" />
       </h1>
 
-      <ul class="summary flexrow">
+      <ul class="summary flexrow-coc7">
         <li class="flex1">
           <input type="text" name="system.source" value="{{data.system.source}}" placeholder="{{ localize 'CoC7.Source' }}" />
         </li class="flex1">
@@ -28,7 +28,7 @@
   <section class="sheet-body">
 
     {{!-- Description Tab --}}
-    <div class="tab flexrow active" data-group="primary" data-tab="description">
+    <div class="tab flexrow-coc7 active" data-group="primary" data-tab="description">
 
       <div class="item-properties">
         <ol class="properties-list">
@@ -48,7 +48,7 @@
       {{!-- Talent Type --}}
       <div class="spell-type form-group stacked">
         <label>{{ localize "CoC7.TalentType" }}</label>
-        <div class="flexrow">
+        <div class="flexrow-coc7">
           <label class="checkbox">
             <input type="checkbox" name="system.type.physical" {{checked data.system.type.physical}} /> {{ localize "CoC7.PhysicalTalent" }}
           </label>
@@ -77,7 +77,7 @@
       {{editor enrichedDescriptionNotes target="system.description.notes" engine="prosemirror" button=true owner=owner editable=editable}}
     </div>
     {{#if isKeeper}}
-      <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+      <div class="tab keeper flexcol-coc7" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
         {{editor enrichedDescriptionKeeper target="system.description.keeper" engine="prosemirror" button=true owner=owner editable=editable}}
       </div>
     {{/if}}

--- a/templates/items/weapon-sheet.html
+++ b/templates/items/weapon-sheet.html
@@ -1,10 +1,10 @@
-<form class="{{cssClass}} weapon flexcol" style="border: groove 2px;" autocomplete="off">
-  <div class="item-header flexrow" style="flex: 0 0 110px;">
+<form class="{{cssClass}} weapon flexcol-coc7" style="border: groove 2px;" autocomplete="off">
+  <div class="item-header flexrow-coc7" style="flex: 0 0 110px;">
     <div class="item-property" style="display: flex; flex-direction: column; flex: 1;">
       <div class="item-name" style="display: flex; flex-direction: row; height: 24px;">
         <input class="item-class" style="flex: 1;" type="text" name="name" value="{{item.name}}" placeholder="name" />
 
-        <div class="flexrow" style="flex: 2;flex-wrap: nowrap;">
+        <div class="flexrow-coc7" style="flex: 2;flex-wrap: nowrap;">
           {{#if hasOwner}}
             <select class="attribute-dtype" name="system.skill.main.id">
               {{#select data.system.skill.main.id}}
@@ -91,7 +91,7 @@
 
   {{!-- Sheet Body --}}
   <section class="sheet-body">
-    <div class="tab skills flexcol active" data-group="primary" data-tab="details">
+    <div class="tab skills flexcol-coc7 active" data-group="primary" data-tab="details">
       <h3 class="form-header" style="flex:0;">{{ localize "CoC7.EraAvailability" }}</h3>
       <div class="skill-attributes" style="margin-bottom: 6px;flex:0;" data-set="eras">
         {{#each _eras as |era key|}}
@@ -99,25 +99,25 @@
         {{/each}}
       </div>
 
-      <div class="flexrow" style="flex: 0 0 auto; border-top: 2px groove #eeede0;">
-        <div class="flexrow" style="flex: 0 0 32%">
+      <div class="flexrow-coc7" style="flex: 0 0 auto; border-top: 2px groove #eeede0;">
+        <div class="flexrow-coc7" style="flex: 0 0 32%">
           <label>{{localize 'CoC7.WeaponMalfunction'}} :</label>
           <input class="weapon-detail" style="flex: 0 0 40px;" type="text" name="system.malfunction" value="{{data.system.malfunction}}" placeholder="-" />
         </div>
-        <div class="flexrow" title="{{localize 'CoC7.WeaponUsesPerRoundHint'}}" style="flex: 0 0 32%">
+        <div class="flexrow-coc7" title="{{localize 'CoC7.WeaponUsesPerRoundHint'}}" style="flex: 0 0 32%">
           <label>{{localize 'CoC7.WeaponUsesPerRound'}} :</label>
           <input class="weapon-detail" style="flex: 0 0 40px;" type="text" name="system.usesPerRound.normal" value="{{data.system.usesPerRound.normal}}" placeholder="-" />
         </div>
-        <div class="flexrow" style="flex: 0 0 32%">
+        <div class="flexrow-coc7" style="flex: 0 0 32%">
           <label>{{localize 'CoC7.WeaponMax'}} :</label>
           <input class="weapon-detail" style="flex: 0 0 40px;" type="text" name="system.usesPerRound.max" value="{{data.system.usesPerRound.max}}" placeholder="-" />
         </div>
-        <div class="flexrow" style="flex: 0 0 32%">
+        <div class="flexrow-coc7" style="flex: 0 0 32%">
           <label>{{localize 'CoC7.WeaponBulletsInMag'}} :</label>
           <input class="weapon-detail" style="flex: 0 0 40px;" type="text" name="system.bullets" value="{{data.system.bullets}}" placeholder="-" />
         </div>
         {{#if data.system.properties.brst}}
-          <div class="flexrow" title="{{localize 'CoC7.BurstSizeHint'}}" style="flex: 0 0 32%">
+          <div class="flexrow-coc7" title="{{localize 'CoC7.BurstSizeHint'}}" style="flex: 0 0 32%">
             <label>{{localize 'CoC7.BurstSize'}} :</label>
             <input class="weapon-detail" style="flex: 0 0 40px;" type="text" name="system.usesPerRound.burst" value="{{data.system.usesPerRound.burst}}" placeholder="-" />
           </div>
@@ -131,7 +131,7 @@
       </div>
 
       <label>{{localize 'CoC7.ItemPrice'}} :</label>
-      <div class="flexrow" style="flex: none">
+      <div class="flexrow-coc7" style="flex: none">
         {{#each _eras as |era key|}}
           {{#if era.isEnabled}}
             <div style="display: flex; flex: 0 0 32%;">
@@ -150,11 +150,11 @@
 
     </div>
 
-    <div class="tab description flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="description">
+    <div class="tab description flexcol-coc7" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="description">
       {{editor enrichedDescriptionValue target="system.description.value" engine="prosemirror" button=true owner=owner editable=editable}}
     </div>
     {{#if isKeeper}}
-      <div class="tab keeper flexcol" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
+      <div class="tab keeper flexcol-coc7" style="border-top: 2px groove #eeede0;padding: 0 5px;" data-group="primary" data-tab="keeper">
         {{editor enrichedDescriptionKeeper target="system.description.keeper" engine="prosemirror" button=true owner=owner editable=editable}}
       </div>
     {{/if}}

--- a/templates/system/rule-settings.html
+++ b/templates/system/rule-settings.html
@@ -1,4 +1,4 @@
-<form class="flexcol" autocomplete="off">
+<form class="flexcol-coc7" autocomplete="off">
   <h2>{{localize 'CoC7.Settings.CoreRules.Title'}}</h2>
   <div class="form-group">
     <label>{{localize 'SETTINGS.developmentRollForLuck'}}</label>
@@ -106,7 +106,7 @@
     </div>
     <p class="notes">{{localize 'SETTINGS.OpposedRollTieBreakerHint'}}</p>
   </div>
-  <footer class="sheet-footer flexrow">
+  <footer class="sheet-footer flexrow-coc7">
     <button type="submit" name="submit">
       <i class="far fa-save"></i> {{localize "Save Changes"}}
     </button>


### PR DESCRIPTION
## Description.
Altered flexcol and flexrow styles conflict with v13 styles with the same name. Rename them to prevent immediate issues.

## Types of Changes.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
