### PR TITLE
Fixes on V3 Character sheet

### DIFF
--- a/styles/sheets/character-v3.less
+++ b/styles/sheets/character-v3.less
@@ -585,7 +585,7 @@
 
             .sheet-body {
               background-color: rgba(0, 0, 0, 0.08);
-              overflow-y: scroll;
+              overflow-y: auto;
               font-family: 'Lusitana';
               scrollbar-color: var(--main-sheet-back-color) var(--official-coc-label-color);
               scrollbar-width: thin;
@@ -1207,7 +1207,11 @@
                   }
 
                   .cash {
-                    overflow-x: scroll;
+                    textarea {
+                      width: 100%;
+                      resize: vertical;
+                    }
+                    overflow-x: auto;
                   }
                 }
               }

--- a/styles/sheets/character-v3.less
+++ b/styles/sheets/character-v3.less
@@ -5,6 +5,8 @@
   --occupation-points-color: #101345;
   --archetype-points-color: #79501c;
   --experience-points-color: #2e4b1f;
+  --sheet-v3-main-font: customSheetFont, "MODESTO CONDENSED";
+  --sheet-v3-secondary-font: customSheetFont, 'Lusitana';
 }
 
 .sheetV3.window-app {
@@ -98,7 +100,7 @@
 
           .tab-label {
             text-transform: uppercase;
-            font-family: "MODESTO CONDENSED";
+            font-family: var(--sheet-v3-main-font);
             width: 100%;
             height: 100%;
             padding-top: 30px;
@@ -311,7 +313,7 @@
                   align-items: center;
 
                   .detail-label {
-                    font-family: "MODESTO CONDENSED";
+                    font-family: var(--sheet-v3-main-font);
                     font-size: 1.4rem;
                     text-transform: uppercase;
                     flex: none;
@@ -322,7 +324,7 @@
                   }
 
                   .detail-value {
-                    font-family: 'Lusitana';
+                    font-family: var(--sheet-v3-secondary-font);
                     font-size: 20px;
                     color: var(--official-coc-label-color);
                     margin-left: 0.3rem;
@@ -341,7 +343,7 @@
               }
 
               .character-attributes {
-                font-family: "MODESTO CONDENSED";
+                font-family: var(--sheet-v3-main-font);
                 display: flex;
                 justify-content: space-between;
                 background: rgba(0, 0, 0, 0.08);
@@ -436,12 +438,12 @@
               }
 
               .secondary-attributes {
-                font-family: "MODESTO CONDENSED";
+                font-family: var(--sheet-v3-main-font);
                 border-radius: 15px;
                 column-gap: 0.4rem;
 
                 .secondary-attribute {
-                  font-family: "MODESTO CONDENSED";
+                  font-family: var(--sheet-v3-main-font);
                   background: rgba(0, 0, 0, 0.08);
                   border-radius: 15px;
                   margin-bottom: 0.3rem;
@@ -506,7 +508,7 @@
                 border-radius: 8px;
                 overflow: hidden;
                 font-size: 1.1rem;
-                font-family: "MODESTO CONDENSED";
+                font-family: var(--sheet-v3-main-font);
                 .flexcol-coc7();
 
                 .derived-attributes-top-line {
@@ -586,7 +588,7 @@
             .sheet-body {
               background-color: rgba(0, 0, 0, 0.08);
               overflow-y: auto;
-              font-family: 'Lusitana';
+              font-family: var(--sheet-v3-secondary-font);
               scrollbar-color: var(--main-sheet-back-color) var(--official-coc-label-color);
               scrollbar-width: thin;
               padding: 0 0.5rem 0 0.5rem;
@@ -664,7 +666,7 @@
 
               h2 {
                 color: var(--main-sheet-interactive-color);
-                font-family: "MODESTO CONDENSED";
+                font-family: var(--sheet-v3-main-font);
                 font-weight: bold;
                 text-transform: uppercase;
                 margin-top: 0.6rem;
@@ -674,7 +676,7 @@
               }
 
               h3 {
-                font-family: "MODESTO CONDENSED";
+                font-family: var(--sheet-v3-main-font);
                 font-size: 1.4rem;
                 text-transform: uppercase;
               }
@@ -720,7 +722,7 @@
                   text-align: center;
                   margin-bottom: 2px;
                   color: #fff;
-                  font-family: "MODESTO CONDENSED";
+                  font-family: var(--sheet-v3-main-font);
                   font-size: 1.4rem;
 
                   &.warning {
@@ -740,12 +742,12 @@
                       width: 100%;
                       height: 100%;
                       cursor: pointer;
-                      font-family: "MODESTO CONDENSED";
+                      font-family: var(--sheet-v3-main-font);
                     }
                   }
 
                   label {
-                    font-family: "MODESTO CONDENSED";
+                    font-family: var(--sheet-v3-main-font);
                     font-size: 1.2rem;
                   }
 
@@ -1079,7 +1081,7 @@
               .tab.background,
               .tab.keeper-notes {
                 input[type='text'].bio-section-title {
-                  font-family: "MODESTO CONDENSED";
+                  font-family: var(--sheet-v3-main-font);
                   font-size: 18px;
                   height: 1.5rem;
                 }

--- a/styles/sheets/character-v3.less
+++ b/styles/sheets/character-v3.less
@@ -8,7 +8,7 @@
 }
 
 .sheetV3.window-app {
-  min-height: 640px;
+  min-height: 800px;
   min-width: 762px;
 
   header {


### PR DESCRIPTION
Minor Fixes on the V3 character sheet style to address issues (#1712, #1711 and #1695)

## Description.

- Define a `min-height` on the V3 character sheet to prevent making part of it unaccesible when resizing. 
- Fix some scrollbar styles. 
- Recover the posibiity to add a custom font to be used on the character sheet. 

## Motivation and Context.

- Set character sheet V3 min-height, Fixes #1712
- Fix possesions textareas style. Fixes #1711
- Allow custom sheet fonts on sheet V3. Fixes #1695 


## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

