### PR TITLE
Make less than 50 translations page to allow easy copy and paste of missing keys

### DIFF
--- a/.github/MISSING.md
+++ b/.github/MISSING.md
@@ -1,0 +1,160 @@
+# Missing Translations.
+
+Thank you for being interested in making Call of Cthulhu 7th Edition for Foundry VTT better! Below is a list of translations keys on existing files that still need translated, based on `en.json`.
+
+[cs.json (20 untranslated strings)](#csjson)
+
+[es.json (30 untranslated strings)](#esjson)
+
+[ja.json (22 untranslated strings)](#jajson)
+
+[uk.json (21 untranslated strings)](#ukjson)
+
+[zh-TW.json (32 untranslated strings)](#zhtwjson)
+
+
+## cs.json
+20 untranslated strings
+```
+"CoC7.Entities.ExperiencePackage": "Experience Package",
+"CoC7.rangeCombatBlastDamage": "{min} to {max} yard(s) takes {total} points of damage",
+"CoC7.SkillExperiencePackage": "Experience Package",
+"CoC7.SkillTotalExperiencePackagePoints": "Experience Package points",
+"CoC7.ExperiencePackageSkill": "Experience Package Skill",
+"CoC7.SANSameLossAsMythosGain": "Sanity loss equal to Cthulhu Mythos gain",
+"CoC7.ExperiencePackageBackground": "Add to the investigator’s backstory based on the experience.",
+"CoC7.ExperiencePackageDialogTitle": "Select Experience Package options",
+"CoC7.ExperiencePackageSpellList": "Known Spells",
+"CoC7.ExperiencePackageApplySanity": "Apply Sanity Loss",
+"CoC7.EmptySpellList": "Add a spell by dropping it here.",
+"CoC7.EmptyStatusList": "Add a phobia/mania by dropping it here.",
+"CoC7.PromptAddInjuryScar": "Add an injury/scar",
+"CoC7.PromptAddStatus": "Add a Phobia/Mania",
+"CoC7.PromptAddSpells": "Add spells",
+"CoC7.ErrorExperiencePackageArchetype": "You can not use Experience Packages if Archetypes are enabled",
+"CoC7.ErrorExperiencePackageNotInvestigator": "You can only use Experience Package on Investigators",
+"CoC7.ErrorExperiencePackageNotGM": "Your keeper must apply Experience Packages",
+"CoC7.ClearExperiencePackageName": "Clear Experience Package name",
+"CoC7.SheetExperiencePackageName": "Experience"
+```
+## es.json
+30 untranslated strings
+```
+"CoC7.Entities.Armor": "Armor",
+"CoC7.Entities.ExperiencePackage": "Experience Package",
+"CoC7.rangeCombatBlastDamage": "{min} to {max} yard(s) takes {total} points of damage",
+"CoC7.SkillExperiencePackage": "Experience Package",
+"CoC7.SkillTotalExperiencePackagePoints": "Experience Package points",
+"CoC7.EraGasLightPulp": "Cthulhu by Gaslight - Pulp",
+"CoC7.AddArmor": "Add armor",
+"CoC7.ExperiencePackageSkill": "Experience Package Skill",
+"CoC7.Settings.ShowWorldEra.Name": "Show World Era in players list",
+"CoC7.Settings.ShowWorldEra.Hint": "",
+"SETTINGS.hidePartValues": "On investigator sheet only show half and extreme values when hovering over",
+"SETTINGS.DoNotPromptNoTargetSelected": "Do not prompt that no targets are selected",
+"SETTINGS.DoNotPromptNoTargetSelectedHit": "When rolling weapon attacks without tokens do not requestion confirmation of no targets",
+"CoC7.CoCIDFlag.keys.rt..backstory-injuries-and-scars": "Injuries and Scars",
+"CoC7.ActorCoCIDItemsAny": "Update (Any) specialization skills",
+"CoC7.SANSameLossAsMythosGain": "Sanity loss equal to Cthulhu Mythos gain",
+"CoC7.ExperiencePackageBackground": "Add to the investigator’s backstory based on the experience.",
+"CoC7.ExperiencePackageDialogTitle": "Select Experience Package options",
+"CoC7.ExperiencePackageSpellList": "Known Spells",
+"CoC7.ExperiencePackageApplySanity": "Apply Sanity Loss",
+"CoC7.EmptySpellList": "Add a spell by dropping it here.",
+"CoC7.EmptyStatusList": "Add a phobia/mania by dropping it here.",
+"CoC7.PromptAddInjuryScar": "Add an injury/scar",
+"CoC7.PromptAddStatus": "Add a Phobia/Mania",
+"CoC7.PromptAddSpells": "Add spells",
+"CoC7.ErrorExperiencePackageArchetype": "You can not use Experience Packages if Archetypes are enabled",
+"CoC7.ErrorExperiencePackageNotInvestigator": "You can only use Experience Package on Investigators",
+"CoC7.ErrorExperiencePackageNotGM": "Your keeper must apply Experience Packages",
+"CoC7.ClearExperiencePackageName": "Clear Experience Package name",
+"CoC7.SheetExperiencePackageName": "Experience"
+```
+## ja.json
+22 untranslated strings
+```
+"CoC7.Entities.ExperiencePackage": "Experience Package",
+"CoC7.rangeCombatBlastDamage": "{min} to {max} yard(s) takes {total} points of damage",
+"CoC7.SkillExperiencePackage": "Experience Package",
+"CoC7.SkillTotalExperiencePackagePoints": "Experience Package points",
+"CoC7.ExperiencePackageSkill": "Experience Package Skill",
+"CoC7.PersonalSpecialityPlaceholder": "other skill(s) as personal or era specialties",
+"CoC7.CoCIDFlag.keys.rt..backstory-injuries-and-scars": "Injuries and Scars",
+"CoC7.SANSameLossAsMythosGain": "Sanity loss equal to Cthulhu Mythos gain",
+"CoC7.ExperiencePackageBackground": "Add to the investigator’s backstory based on the experience.",
+"CoC7.ExperiencePackageDialogTitle": "Select Experience Package options",
+"CoC7.ExperiencePackageSpellList": "Known Spells",
+"CoC7.ExperiencePackageApplySanity": "Apply Sanity Loss",
+"CoC7.EmptySpellList": "Add a spell by dropping it here.",
+"CoC7.EmptyStatusList": "Add a phobia/mania by dropping it here.",
+"CoC7.PromptAddInjuryScar": "Add an injury/scar",
+"CoC7.PromptAddStatus": "Add a Phobia/Mania",
+"CoC7.PromptAddSpells": "Add spells",
+"CoC7.ErrorExperiencePackageArchetype": "You can not use Experience Packages if Archetypes are enabled",
+"CoC7.ErrorExperiencePackageNotInvestigator": "You can only use Experience Package on Investigators",
+"CoC7.ErrorExperiencePackageNotGM": "Your keeper must apply Experience Packages",
+"CoC7.ClearExperiencePackageName": "Clear Experience Package name",
+"CoC7.SheetExperiencePackageName": "Experience"
+```
+## uk.json
+21 untranslated strings
+```
+"CoC7.Entities.ExperiencePackage": "Experience Package",
+"CoC7.rangeCombatBlastDamage": "{min} to {max} yard(s) takes {total} points of damage",
+"CoC7.SkillExperiencePackage": "Experience Package",
+"CoC7.SkillTotalExperiencePackagePoints": "Experience Package points",
+"CoC7.ExperiencePackageSkill": "Experience Package Skill",
+"CoC7.CoCIDFlag.keys.rt..backstory-injuries-and-scars": "Injuries and Scars",
+"CoC7.SANSameLossAsMythosGain": "Sanity loss equal to Cthulhu Mythos gain",
+"CoC7.ExperiencePackageBackground": "Add to the investigator’s backstory based on the experience.",
+"CoC7.ExperiencePackageDialogTitle": "Select Experience Package options",
+"CoC7.ExperiencePackageSpellList": "Known Spells",
+"CoC7.ExperiencePackageApplySanity": "Apply Sanity Loss",
+"CoC7.EmptySpellList": "Add a spell by dropping it here.",
+"CoC7.EmptyStatusList": "Add a phobia/mania by dropping it here.",
+"CoC7.PromptAddInjuryScar": "Add an injury/scar",
+"CoC7.PromptAddStatus": "Add a Phobia/Mania",
+"CoC7.PromptAddSpells": "Add spells",
+"CoC7.ErrorExperiencePackageArchetype": "You can not use Experience Packages if Archetypes are enabled",
+"CoC7.ErrorExperiencePackageNotInvestigator": "You can only use Experience Package on Investigators",
+"CoC7.ErrorExperiencePackageNotGM": "Your keeper must apply Experience Packages",
+"CoC7.ClearExperiencePackageName": "Clear Experience Package name",
+"CoC7.SheetExperiencePackageName": "Experience"
+```
+## zh-TW.json
+32 untranslated strings
+```
+"CoC7.Entities.Armor": "Armor",
+"CoC7.Entities.ExperiencePackage": "Experience Package",
+"CoC7.Lck": "Lck",
+"CoC7.RollDifficultyImpossible": "Impossible",
+"CoC7.RollDifficultyImpossibleTitle": "Impossible difficulty",
+"CoC7.rangeCombatBlastDamage": "{min} to {max} yard(s) takes {total} points of damage",
+"CoC7.SkillExperiencePackage": "Experience Package",
+"CoC7.SkillTotalExperiencePackagePoints": "Experience Package points",
+"CoC7.AddArmor": "Add armor",
+"CoC7.ExperiencePackageSkill": "Experience Package Skill",
+"CoC7.Settings.ShowWorldEra.Name": "Show World Era in players list",
+"CoC7.Settings.ShowWorldEra.Hint": "",
+"SETTINGS.hidePartValues": "On investigator sheet only show half and extreme values when hovering over",
+"SETTINGS.DoNotPromptNoTargetSelected": "Do not prompt that no targets are selected",
+"SETTINGS.DoNotPromptNoTargetSelectedHit": "When rolling weapon attacks without tokens do not requestion confirmation of no targets",
+"CoC7.CoCIDFlag.keys.rt..backstory-injuries-and-scars": "Injuries and Scars",
+"CoC7.ActorCoCIDItemsAny": "Update (Any) specialization skills",
+"CoC7.SANSameLossAsMythosGain": "Sanity loss equal to Cthulhu Mythos gain",
+"CoC7.ExperiencePackageBackground": "Add to the investigator’s backstory based on the experience.",
+"CoC7.ExperiencePackageDialogTitle": "Select Experience Package options",
+"CoC7.ExperiencePackageSpellList": "Known Spells",
+"CoC7.ExperiencePackageApplySanity": "Apply Sanity Loss",
+"CoC7.EmptySpellList": "Add a spell by dropping it here.",
+"CoC7.EmptyStatusList": "Add a phobia/mania by dropping it here.",
+"CoC7.PromptAddInjuryScar": "Add an injury/scar",
+"CoC7.PromptAddStatus": "Add a Phobia/Mania",
+"CoC7.PromptAddSpells": "Add spells",
+"CoC7.ErrorExperiencePackageArchetype": "You can not use Experience Packages if Archetypes are enabled",
+"CoC7.ErrorExperiencePackageNotInvestigator": "You can only use Experience Package on Investigators",
+"CoC7.ErrorExperiencePackageNotGM": "Your keeper must apply Experience Packages",
+"CoC7.ClearExperiencePackageName": "Clear Experience Package name",
+"CoC7.SheetExperiencePackageName": "Experience"
+```

--- a/.github/TRANSLATIONS.md
+++ b/.github/TRANSLATIONS.md
@@ -18,7 +18,7 @@ The following translations have more than 50 untranslated strings [are you able 
 
 
 
-|Key|cs|es|ja|uk|zh-TW|
+|Key|[cs](./MISSING.md#csjson)|[es](./MISSING.md#esjson)|[ja](./MISSING.md#jajson)|[uk](./MISSING.md#ukjson)|[zh-TW](./MISSING.md#zhtwjson)|
 |:---|:---:|:---:|:---:|:---:|:---:|
 |**Remaining**:|**20**|**30**|**22**|**21**|**32**|
 |[CoC7.ActorCoCIDItemsAny](#coc7actorcociditemsany)|&#9989;|&#x274C;|&#9989;|&#9989;|&#x274C;|

--- a/generate-translations.js
+++ b/generate-translations.js
@@ -74,7 +74,7 @@ glob('./lang/*.json', {}, async function (er, files) {
   if (missing.length > 0) {
     output = output + '|Key|'
     Object.entries(langs).forEach(([key, value]) => {
-      output = output + key + '|'
+      output = output + '[' + key + '](./MISSING.md#' + (key + '.json').toLowerCase().replace(/[^a-zA-Z0-9]+/g, '') + ')|'
     })
     output = output + '\n'
     output = output + '|:---|'
@@ -117,6 +117,49 @@ glob('./lang/*.json', {}, async function (er, files) {
     output = output + anchors
   }
   write('./.github/TRANSLATIONS.md', output)
+  const missingPerLang = Object.keys(unordered)
+    .filter(lang => unordered[lang].length > 0)
+    .sort()
+    .reduce((obj, key) => {
+      obj[key] = unordered[key]
+      return obj
+    }, {})
+  if (Object.keys(missingPerLang).length > 0) {
+    output = ''
+    output = output + '# Missing Translations.\n\n'
+    output =
+      output +
+      'Thank you for being interested in making Call of Cthulhu 7th Edition for Foundry VTT better!'
+    output =
+      output +
+      ' Below is a list of translations keys on existing files that still need translated, based on `en.json`.\n\n'
+    Object.entries(missingPerLang).forEach(([key, values]) => {
+      output =
+        output +
+        '[' +
+        key +
+        '.json (' + Object.entries(unordered[key]).length + ' untranslated strings)](#' +
+        (key + '.json').toLowerCase().replace(/[^a-zA-Z0-9]+/g, '') +
+        ')\n\n'
+    })
+    output = output + '\n'
+    Object.entries(missingPerLang).forEach(([key, values]) => {
+      output = output + '## ' + key + '.json\n' + Object.entries(missingPerLang[key]).length + ' untranslated strings\n```\n'
+      values.forEach(sourceKey => {
+        output =
+          output +
+          '"' +
+          sourceKey +
+          '": "' +
+          source[sourceKey].replace(/\n/g, '\\n') +
+          '",\n'
+      })
+      output = output.substring(0, output.length - 2) + '\n```\n'
+    })
+    write('./.github/MISSING.md', output)
+  } else {
+    deleteAsync('./.github/MISSING.md')
+  }
   if (Object.keys(abandoned).length > 0) {
     output = ''
     output = output + '# Abandoned Translations.\n\n'


### PR DESCRIPTION
## Description.
Add MISSING.md page to list all missing keys for languages with less than 50 missing keys #1781 


## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
