### PR TITLE
Temporary disable spells automation

### DIFF
--- a/module/hooks/render-chat-message.js
+++ b/module/hooks/render-chat-message.js
@@ -1,3 +1,4 @@
+/* global $ */
 import { CoC7Chat } from '../chat.js'
 import { CoC7GroupMessage } from '../apps/coc7-group-message.js'
 
@@ -7,4 +8,7 @@ export default function (app, html, data) {
   if (typeof app.flags?.CoC7?.['group-message'] !== 'undefined') {
     CoC7GroupMessage.renderChatMessage(app, html, data)
   }
+  html.find('div.coc7-chat-toggler').click(function () {
+    $(this).next('div.coc7-chat-toggled').slideToggle(200)
+  })
 }

--- a/module/items/spell/data.js
+++ b/module/items/spell/data.js
@@ -18,7 +18,7 @@ export class CoC7Spell extends CoC7Item {
     }
     const costs = foundry.utils.duplicate(this.system.costs)
     const losses = []
-    // TODO: Temporary disabled while automation is improved
+    // TODO: Temporary disable while automation is improved
     // let convertSurplusIntoHitPoints
     // costs.magicPoints = CoC7Utilities.isFormula(costs.magicPoints)
     //   ? (await new Roll(costs.magicPoints).roll({ async: true })).total
@@ -99,7 +99,7 @@ export class CoC7Spell extends CoC7Item {
     return await ChatMessage.create(chatData)
   }
 
-  // TODO: Temporary disabled while automation is improved
+  // TODO: Temporary disable while automation is improved
   // async resolveLosses (characteristic, value, priv) {
   //   let characteristicName
   //   let loss

--- a/styles/chat/all.less
+++ b/styles/chat/all.less
@@ -76,3 +76,22 @@
     }
   }
 }
+
+div.coc7-chat-toggler {
+  &.gm-visible-only {
+    background: #f5eaf5;
+  }
+  flex: 0 0 100%;
+  position: relative;
+  margin: 0;
+  line-height: 24px;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--color-border-light-2);
+  border-radius: 3px;
+  box-shadow: 0 0 2px #FFF inset;
+  word-break: break-all;
+}
+div.coc7-chat-toggled {
+  display: none;
+}

--- a/templates/items/spell/chat.html
+++ b/templates/items/spell/chat.html
@@ -5,6 +5,10 @@
     {{/each}}
   </ul>
   <hr>
-  {{{description}}}
-
+  <div class="coc7-chat-toggler gm-visible-only">
+    {{localize "CoC7.Description"}}
+  </div>
+  <div class="coc7-chat-toggled">
+    {{{description}}}
+  </div>
 </html>


### PR DESCRIPTION
## Description.
Spells can be cast over multiple days or require multiple casters and cultists, disable automation.

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to change).
