### PR TITLE
Fix: Hotbar Drop Hook Async Handling

### DIFF
--- a/module/hooks/hotbar-drop.js
+++ b/module/hooks/hotbar-drop.js
@@ -1,5 +1,13 @@
 import { CoC7Utilities } from '../utilities.js'
 
 export default function (bar, data, slot) {
-  CoC7Utilities.createMacro(bar, data, slot)
+  // Check if this is a CoC7 item first
+  if (data.type === 'Item') {
+    // Handle the async operation but don't wait for it
+    CoC7Utilities.createMacro(bar, data, slot)
+    // Return false immediately to prevent default behavior
+    return false
+  }
+  // Let default behavior handle other cases
+  return true
 }


### PR DESCRIPTION
## Description
Fixed an issue with the hotbar drop hook where macros were being overwritten due to improper async handling. The hook now properly checks for CoC7 items first and prevents default behavior synchronously before handling the async macro creation.

## Motivation and Context
The previous implementation had a race condition where the async macro creation would complete after the default Foundry behavior had already processed the drop. This caused CoC7 macros to be overwritten with default Foundry macros. The fix ensures that CoC7 items are handled correctly by:
1. Checking item type synchronously
2. Preventing default behavior immediately for CoC7 items
3. Handling the async macro creation independently

## Screenshots
REF:
![image](https://github.com/user-attachments/assets/478707b3-5920-4435-bdbb-f92c531ebd49)

Before:
![image](https://github.com/user-attachments/assets/4c3187d7-35e2-4707-8820-c59cd95f6b12)

After:
![image](https://github.com/user-attachments/assets/64e8a955-f3fc-4c84-b629-c54d933cbf0c)


## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
