### PR TITLE
Expose skill check result to macros

### DIFF
--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -2867,6 +2867,7 @@ export class CoCActor extends Actor {
     else check.pushing = !!options.pushing
     await check.roll()
     check.toMessage(check.pushing)
+    return check
   }
 
   async weaponCheck (weaponData, fastForward = false) {

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -236,7 +236,7 @@ export class CoC7Utilities {
     }
   }
 
-  static skillCheckMacro (skill, event, options = {}) {
+  static async skillCheckMacro (skill, event, options = {}) {
     event.preventDefault()
     const speaker = ChatMessage.getSpeaker()
     let actor
@@ -248,7 +248,9 @@ export class CoC7Utilities {
       return
     }
 
-    actor.skillCheck(skill, event.shiftKey, options)
+    const check = await actor.skillCheck(skill, event.shiftKey, options)
+    
+    return check?.dice?.roll?.options?.coc7Result?.successLevel;
   }
 
   static weaponCheckMacro (weapon, event) {


### PR DESCRIPTION
## Description
This PR modifies the `skillCheckMacro` function to return the success level of a skill check, allowing macros to programmatically determine the outcome of skill checks. This enables more complex automation and integration with other systems like Monk's Active Tiles.
https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/issues/1752


## Motivation and Context
Currently, when using skill checks in macros, the result is only pushed to chat and cannot be programmatically accessed. This makes it difficult to create automated workflows that depend on skill check outcomes. For example, when using Monk's Active Tiles as a trigger, there's no way to automatically respond to different skill check results.

## Types of Changes
- [x] New feature (non-breaking change which adds functionality)

## Implementation Details
- Modified `skillCheckMacro` to return the success level from the check result
- The success level can be accessed via `check?.dice?.roll?.options?.coc7Result?.successLevel`


## Usage Example
![image](https://github.com/user-attachments/assets/0667279f-fdd8-4a4a-b88e-f0c7ad42aba3)

```javascript
// Example macro usage
const result = await game.CoC7.macros.skillCheck(
  {name:'Electrical Repair', uuid:'Actor.XtrMSMlCAsEecM0G.Item.NBkq8oCGM1FjmsyF'}, 
  event
);

// Check the result
if (result === 'extreme') {
  // Handle extreme success
} else if (result === 'hard') {
  // Handle hard success
} else if (result === 'regular') {
  // Handle regular success
} else {
  // Handle failure
}
```
```
