### PR TITLE
add support for item piles

### DIFF
--- a/module/scripts/configure-documents.js
+++ b/module/scripts/configure-documents.js
@@ -11,9 +11,14 @@ import { CoC7Vehicle } from '../actors/vehicle/data.js'
 export function configureDocuments () {
   CONFIG.ActiveEffect.documentClass = CoC7ActiveEffect
   CONFIG.Actor.documentClass = CoCActor
+  
+  // Register all actor types including container
   CONFIG.Actor.documentClasses = {
-    vehicle: CoC7Vehicle
+    vehicle: CoC7Vehicle,
+    container: CoCActor
   }
+
+  // Register all item types
   CONFIG.Item.documentClass = CoC7Item
   CONFIG.Item.documentClasses = {
     book: CoC7Book,
@@ -21,4 +26,68 @@ export function configureDocuments () {
     chase: CoC7Chase,
     skill: CoC7Skill
   }
+
+  // Add hooks for item-piles integration
+  Hooks.on('preCreateActor', (actor, data, options, userId) => {
+    // Ensure type is set for item-piles
+    if (options?.pack === 'item-piles' || data.flags?.['item-piles']) {
+      data.type = 'container'
+      // Ensure system data exists
+      if (!data.system) {
+        data.system = {
+          attribs: {
+            hp: { value: 0, max: 0 },
+            mp: { value: 0, max: 0 },
+            san: { value: 0, max: 0 },
+            mov: { value: 0 },
+            db: { value: 0 },
+            build: { value: 0 }
+          },
+          characteristics: {
+            str: { value: 0 },
+            con: { value: 0 },
+            siz: { value: 0 },
+            dex: { value: 0 },
+            app: { value: 0 },
+            int: { value: 0 },
+            pow: { value: 0 },
+            edu: { value: 0 }
+          }
+        }
+      }
+    }
+  })
+
+  // Add hook to handle item-piles token creation
+  Hooks.on('preCreateToken', (token, data, options, userId) => {
+    if (token.actor?.type === 'container') {
+      // Set default token settings for item-piles
+      data.actorLink = true
+      data.disposition = 0
+      data.displayBars = 0
+      data.displayName = 0
+    }
+  })
+
+  // Add hook to handle item-piles actor updates
+  Hooks.on('preUpdateActor', (actor, data, options, userId) => {
+    if (actor.type === 'container' && !data.type) {
+      data.type = 'container'
+    }
+  })
+
+  // Add hook to handle item-piles document creation
+  Hooks.on('preCreateDocumentArray', (documents, data, options, userId) => {
+    if (documents[0]?.constructor.name === 'CoCActor') {
+      data.forEach(d => {
+        if (!d.type) {
+          if (options?.pack === 'item-piles' || d.flags?.['item-piles']) {
+            d.type = 'container'
+          } else {
+            d.type = 'character'
+          }
+        }
+      })
+    }
+  })
 }


### PR DESCRIPTION
## Description
Added support for the item-piles module in CoC7 system by implementing proper actor type handling and container functionality. 

## Motivation and Context
The item-piles module requires proper system integration to function correctly. Without this support, users were encountering validation errors when trying to create item piles, specifically:
```
CoCActor validation errors:
  type: may not be undefined
```
This change ensures seamless integration between CoC7 and item-piles, allowing users to:
- Create item piles on the canvas

## Types of Changes

- [x] New feature (non-breaking change which adds functionality)
  - Adds support for item-piles module
  - Implements container type handling
  - Adds default system data for item-piles containers

![image](https://github.com/user-attachments/assets/52cb0b81-dc33-4101-888b-f2971dcb97da)
![image](https://github.com/user-attachments/assets/be995d49-841d-498b-a78b-6a05a50fb999)
