### PR TITLE
fix(actor-sheet): correct skill grouping by sorting on specialization…

### DIFF
--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -229,17 +229,17 @@ export class CoC7ActorSheet extends foundry.appv1.sheets.ActorSheet {
         // ce bloc devrait etre déplacé dans le bloc _updateFormData
         if (item.type === 'skill') {
           if (item.system.properties.special) {
-            if (item.system.properties.fighting) {
+            if (item.system.properties.fighting && !item.system.specialization) {
               item.system.specialization = game.i18n.localize(
                 'CoC7.FightingSpecializationName'
               )
             }
-            if (item.system.properties.firearm) {
+            if (item.system.properties.firearm && !item.system.specialization) {
               item.system.specialization = game.i18n.localize(
                 'CoC7.FirearmSpecializationName'
               )
             }
-            if (item.system.properties.ranged) {
+            if (item.system.properties.ranged && !item.system.specialization) {
               item.system.specialization = game.i18n.localize(
                 'CoC7.RangedSpecializationName'
               )

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -336,13 +336,17 @@ export class CoC7ActorSheet extends foundry.appv1.sheets.ActorSheet {
       }
 
       for (const itemType in sheetData.itemsByType) {
-        sheetData.itemsByType[itemType].sort(CoC7Utilities.sortByNameKey)
-      }
+        if (itemType === 'skill') {
+          sheetData.itemsByType[itemType].sort(CoC7Utilities.sortBySpecializationThenName)
+        } else {
+          sheetData.itemsByType[itemType].sort(CoC7Utilities.sortByNameKey)
+        }
+       }
 
       // redondant avec matrice itembytype
       sheetData.skills = sheetData.items
         .filter(item => item.type === 'skill')
-        .sort(CoC7Utilities.sortByNameKey)
+        .sort(CoC7Utilities.sortBySpecializationThenName)
 
       sheetData.meleeSkills = sheetData.skills.filter(
         skill =>

--- a/module/actors/sheets/character.js
+++ b/module/actors/sheets/character.js
@@ -152,15 +152,6 @@ export class CoC7CharacterSheet extends CoC7ActorSheet {
     sheetData.isSummarized = this.summarized
     sheetData.skillList = []
     let previousSpec = ''
-    const sortedSkills = [...sheetData.skills].sort((a, b) => {
-      const sortKeyA = a.system.specialization || a.name
-      const sortKeyB = b.system.specialization || b.name
-      const primaryCompare = sortKeyA.localeCompare(sortKeyB, game.i18n.lang)
-      if (primaryCompare !== 0) {
-        return primaryCompare
-      }
-      return a.name.localeCompare(b.name, game.i18n.lang)
-    })
     for (const skill of sortedSkills) {
       if (sheetData.skillShowUncommon || !skill.system.properties.rarity) {
         if (skill.system.properties.special) {

--- a/module/actors/sheets/character.js
+++ b/module/actors/sheets/character.js
@@ -152,7 +152,16 @@ export class CoC7CharacterSheet extends CoC7ActorSheet {
     sheetData.isSummarized = this.summarized
     sheetData.skillList = []
     let previousSpec = ''
-    for (const skill of sheetData.skills) {
+    const sortedSkills = [...sheetData.skills].sort((a, b) => {
+      const sortKeyA = a.system.specialization || a.name
+      const sortKeyB = b.system.specialization || b.name
+      const primaryCompare = sortKeyA.localeCompare(sortKeyB, game.i18n.lang)
+      if (primaryCompare !== 0) {
+        return primaryCompare
+      }
+      return a.name.localeCompare(b.name, game.i18n.lang)
+    })
+    for (const skill of sortedSkills) {
       if (sheetData.skillShowUncommon || !skill.system.properties.rarity) {
         if (skill.system.properties.special) {
           if (previousSpec !== skill.system.specialization) {

--- a/module/actors/sheets/character.js
+++ b/module/actors/sheets/character.js
@@ -152,7 +152,7 @@ export class CoC7CharacterSheet extends CoC7ActorSheet {
     sheetData.isSummarized = this.summarized
     sheetData.skillList = []
     let previousSpec = ''
-    for (const skill of sortedSkills) {
+    for (const skill of sheetData.skills) {
       if (sheetData.skillShowUncommon || !skill.system.properties.rarity) {
         if (skill.system.properties.special) {
           if (previousSpec !== skill.system.specialization) {

--- a/module/utilities.js
+++ b/module/utilities.js
@@ -963,6 +963,24 @@ export class CoC7Utilities {
           .toLocaleLowerCase()
       )
   }
+ 
+  static sortBySpecializationThenName (a, b) {
+    const normalize = (str) => (str || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLocaleLowerCase()
+
+    // Use specialization as the primary sort key, or the skill name if no specialization exists.
+    const sortKeyA = normalize(a.system.specialization || a.name)
+    const sortKeyB = normalize(b.system.specialization || b.name)
+
+    // Compare the primary sort keys.
+    const primaryCompare = sortKeyA.localeCompare(sortKeyB)
+    if (primaryCompare !== 0) {
+      return primaryCompare
+    }
+
+    const nameA = normalize(a.name)
+    const nameB = normalize(b.name)
+    return nameA.localeCompare(nameB)
+  }
 
   static getAnIdForGm () {
     const keepers = game.users.filter(u => u.active && u.isGM && u.id !== game.user.id)


### PR DESCRIPTION
## Description.

This commit corrects the skill grouping logic on the character sheet. Previously, skills were sorted purely alphabetically by their full name. This resulted in an undesirable visual grouping where specialized skills (e.g., "Artillería (Cañón)") could appear under unrelated skills (e.g., "Arqueología"), making it look like a sub-skill, which is confusing and incorrect.

The sorting logic in `CoC7CharacterSheet.prototype.getData` has been updated. It now sorts skills primarily by their specialization name. If skills share the same specialization (or have no specialization), they are then sorted alphabetically by their full name.

## Motivation and Context.

This change ensures that all related skills (e.g., all Firearms, all Art/Craft) are grouped together correctly under their respective headers on the character sheet, providing a more logical and intuitive layout for the user and improving readability.

## Screenshots.

![image](https://github.com/user-attachments/assets/36e14d4b-4b79-41a6-85ab-9533d728b2ee)

## Types of Changes.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Documentation change.