### PR TITLE
fix(compendium): correct display of uncommon skill tag

### DIFF
--- a/module/scripts/compendium-filter.js
+++ b/module/scripts/compendium-filter.js
@@ -296,7 +296,7 @@ export function compendiumFilter () {
         for (const directoryItem of directoryItems) {
           const item = app.collection.index.get(directoryItem.dataset[keyName])
           if (item && item.type === 'skill') {
-            directoryItem.querySelector('a').innerHTML = item.name + ' (' + (item.system?.base ?? '?') + '%' + ((item.system?.properties?.rarity ?? false) ? ' ' + uncommon : '') + ')'
+            directoryItem.querySelector('a').innerHTML = item.name +' (' + (item.system?.base ?? '?') + '%)' + ((item.system?.properties?.rarity ?? false) ? ' ' + uncommon : '')
           }
         }
       }


### PR DESCRIPTION
## Description.

This commit corrects the display format of the uncommon skill tag in the compendium directory view. The uncommon skill tag (e.g., "[Infrecuente]") was incorrectly rendered inside the parentheses of the skill's value, for example: "Habilidad (50% [UC])".

This change modifies the `compendium-filter.js` script to adjust how the innerHTML of the directory item is constructed. It ensures the closing parenthesis appears before the tag, resulting in the correct display format, like "Habilidad (50%) [Infrecuente]".

## Motivation and Context.

Ensuring the uncommon skill tag is rendered accurately in the compendium directory avoids potential confusion for users and presents skill information more clearly.

## Screenshots.

N/A (Minor template/innerHTML adjustment within `compendium-filter.js`)

## Types of Changes.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Documentation change.