### PR TITLE
Fix average rolls

### DIFF
--- a/module/apps/average-roll.js
+++ b/module/apps/average-roll.js
@@ -35,10 +35,21 @@ export class AverageRoll extends Roll {
         // This section is replaced to calculate the average
         let total = term.total
         if (minimize && maximize && term.dice.length) {
-          total = Math.floor((term.dice[0].faces + 1) / 2 * term.total)
+          // Get min and max
+          const min = new AverageRoll(term.term)[(!foundry.utils.isNewerVersion(game.version, '12') ? 'evaluate' : 'evaluateSync')/* // FoundryVTT v11 */]({ minimize: true })
+          const max = new AverageRoll(term.term)[(!foundry.utils.isNewerVersion(game.version, '12') ? 'evaluate' : 'evaluateSync')/* // FoundryVTT v11 */]({ maximize: true })
+
+          // Get the average of min plus max
+          total = Math.floor((min.total + max.total) / 2)
+
+          // Round to nearest 5
+          total = Math.round(total / 5) * 5
         }
 
-        return new foundry.dice.terms.NumericTerm({ number: total, options: term.options })
+        return new foundry.dice.terms.NumericTerm({
+          number: total,
+          options: term.options
+        })
       }
       return term
     })


### PR DESCRIPTION
This PR is for fixing issue #1887
## Description.

This PR does two things:
- Fix the AverageRoll `_evaluateSync` method for when roll formulas contains symbols (`+`)
- Round down average values to nearest 5

> [!NOTE] 
**Rolls :** This PR calculates the true average value by rolling min and max formula behind the scene.
Although it does require two more rolls, AFAIK it is the only way to get an exact average roll value with Foundry.
**Rounding down**: per rulebook, most everything should be rounded down. Monster stats are, for the vast majority, rounded down to the nearest 5. There are some exceptions that don't follow any logical rule (can't do much about them).
For most monsters, this calculates the same stats, HP, MP and DB as the keeper rulebook.

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
