### PR TITLE
fix: replace <h4> with <div> for correct text rendering

### DIFF
--- a/templates/chat/roll-result.html
+++ b/templates/chat/roll-result.html
@@ -160,9 +160,9 @@
           </section>
 
           {{#if successRequired}}
-            <h4 class="result-details">{{resultType}}, {{successRequired}}</h4>
+            <div class="result-details">{{resultType}}, {{successRequired}}</div>
           {{else}}
-            <h4 class="result-details">{{resultType}}</h4>
+            <div class="result-details">{{resultType}}</div>
           {{/if}}
 
           <div class="card-buttons owner-only" data-actor-id="{{actor.id}}" style="padding-top: 5px;margin: 0;">


### PR DESCRIPTION
## Description.

Replace `<h4>` with `<div>` in dice-total to avoid heading styles affecting spacing/wrapping. No behavior change; class names preserved.

## Motivation and Context.

The text looks very large, made it as it was in v12.

## Screenshots.

**Before**
<img width="275" height="387" alt="image" src="https://github.com/user-attachments/assets/59622a82-546c-45f0-aabb-ee3b8af1ecf1" />

**After**
<img width="280" height="264" alt="image" src="https://github.com/user-attachments/assets/167e7637-adf8-431a-bc6c-7157fbdafa03" />

## Types of Changes.

Replace `<h4>` with `<div>` in dice-total to avoid heading styles affecting spacing/wrapping. No behavior change; class names preserved.
The text looks very large, made it as it was in v12.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
