### PR TITLE
Scroll bar for NPC sheet, fixes for weapon, UI update for active effects

### DIFF
--- a/coc7/apps/active-effect.js
+++ b/coc7/apps/active-effect.js
@@ -1,4 +1,4 @@
-/* global game */
+/* global Actor CONFIG CONST foundry fromUuid game TextEditor */
 import { STATUS_EFFECTS } from '../constants.js'
 import deprecated from '../deprecated.js'
 
@@ -9,11 +9,11 @@ export default class CoC7ActiveEffect {
    * @param {Document} owner
    * @returns {Document}
    */
-  static #onManageActiveEffect (event, owner) {
+  static async #onManageActiveEffect (event, owner) {
     event.preventDefault()
     const button = event.currentTarget
     const li = button.closest('li')
-    const effect = li.dataset.effectId ? owner.effects.get(li.dataset.effectId) : null
+    const effect = li.dataset.effectUuid ? await fromUuid(li.dataset.effectUuid) : null
     switch (button.dataset.action) {
       case 'create':
         return owner.createEmbeddedDocuments('ActiveEffect', [
@@ -68,13 +68,118 @@ export default class CoC7ActiveEffect {
   }
 
   /**
+   * Get simplified data
+   * @param {Document} effect
+   * @param {object} object
+   * @param {boolean} object.embeddedItem
+   * @returns {Promise<object>}
+   */
+  static async effectData (effect, { embeddedItem = false }) {
+    const readable = []
+    /* // FoundryVTT V13 */
+    const changes = (game.release.generation < 14 ? effect.changes : effect.system.changes)
+    for (const change of changes) {
+      /* // FoundryVTT V13 */
+      const changeType = (game.release.generation < 14 ? (change.mode === CONST.ACTIVE_EFFECT_MODES.ADD ? 'add' : (change.mode === CONST.ACTIVE_EFFECT_MODES.OVERRIDE? 'override' : 'other')) : change.type)
+      if (['add', 'override'].includes(changeType)) {
+        let name = false
+        let what = false
+        let unit = ''
+        const match = change.key.match(/^system\.skills\.(i(\.|>>)skill(\.|>>))?(.+)\.system\.(bonusDice|value)$/)
+        if (match) {
+          let key = match[4]
+          if (typeof match[1] !== 'undefined') {
+            key = 'i>>skill>>' + key
+          }
+          what = match[5]
+          unit = '%'
+          /* // FoundryVTT V13 */
+          if (game.release.generation < 14 && effect.parent instanceof Actor) {
+            name = effect.parent.system.skills[key].name
+          } else if (typeof effect.actor?.system.skills[key] !== 'undefined') {
+            name = effect.actor.system.skills[key].name
+          } else {
+            name = key.replace(/>>/g, '.')
+          }
+        } else {
+          const match = change.key.match(/^system\.(characteristics|attribs)\.([^.]+)\.(bonusDice|max|value)$/)
+          if (match && (match[3] !== 'max' || match[1] === 'attribs')) {
+            what = match[3]
+            switch (match[1]) {
+              case 'attribs':
+                name = game.i18n.localize(CONFIG.Actor.dataModels.character.defineSchema().attribs.getField(match[2])?.hint ?? false)
+                if (['lck', 'san'].includes(match[2])) {
+                  unit = '%'
+                }
+                break
+              case 'characteristics':
+                name = game.i18n.localize(CONFIG.Actor.dataModels.character.defineSchema().characteristics.getField(match[2])?.hint ?? false)
+                unit = '%'
+                break
+            }
+          } else {
+            const match = change.key.match(/^system.config.(luckRecovery|naturalHealing)$/)
+            if (match) {
+              what = 'value'
+              switch (match[1]) {
+                case 'luckRecovery':
+                  name = game.i18n.localize('CoC7.RecoverLuckPoints')
+                  break
+                case 'naturalHealing':
+                  name = game.i18n.localize('CoC7.ActorConfig.NaturalHealing')
+                  break
+              }
+            }
+          }
+        }
+        switch (what) {
+          case 'value':
+            what = (changeType === 'add' ? (change.value < 0 ? '' : '+') : '=') + change.value + unit
+            break
+          case 'max':
+            what = (changeType === 'add' ? (change.value < 0 ? '' : '+') : '=') + change.value + ' ' + game.i18n.localize('CoC7.Maximum')
+            break
+          case 'bonusDice':
+            if (change.value < 0) {
+              what = (changeType === 'add' ? '+' : '=') + Math.abs(change.value) + ' ' + game.i18n.localize('CoC7.DiceModifierPenalty') + ' ' + game.i18n.localize('CoC7.Dice')
+            } else if (change.value > 0) {
+              what = (changeType === 'add' ? '+' : '=') + Math.abs(change.value) + ' ' + game.i18n.localize('CoC7.DiceModifierBonus') + ' ' + game.i18n.localize('CoC7.Dice')
+            } else {
+              what = (changeType === 'add' ? '+' : '=') + Math.abs(change.value) + ' ' + game.i18n.localize('CoC7.DiceModifierBonus') + ' ' + game.i18n.localize('CoC7.Dice')
+            }
+            break
+        }
+        if (name !== false && what !== false) {
+          readable.push(name + ' ' + what)
+        } else {
+          readable.push(change.key + ' ' + (changeType === 'add' ? (change.value < 0 ? '' : '+') : '=') + change.value)
+        }
+      } else {
+        readable.push(change.key + ' ' + changeType + ' ' + change.value)
+      }
+    }
+    return {
+      uuid: effect.uuid,
+      img: effect.img,
+      name: effect.name,
+      /* // FoundryVTT V12 */
+      source: effect.transfer && embeddedItem ? await (foundry.applications.ux?.TextEditor.implementation ?? TextEditor).enrichHTML(effect.parent.link, { async: true }) : effect.sourceName,
+      duration: effect.duration.label,
+      isSuppressed: effect.isSuppressed,
+      isTemporary: effect.isTemporary,
+      disabled: effect.disabled,
+      readable: (readable.length > 0 ? '<ul class="active-effect-adjustments"><li>' + readable.join('</li><li>') + '</li></ul>' : '')
+    }
+  }
+
+  /**
    * Sort Actor effects into categories
-   * @param {object} effects
+   * @param {Document} document
    * @param {options} options
    * @param {boolean} options.status
-   * @returns {object}
+   * @returns {Promise<object>}
    */
-  static prepareActiveEffectCategories (effects, { status = true } = {}) {
+  static async prepareActiveEffectCategories (document, { status = true } = {}) {
     // Define effect header categories
     const categories = {
       temporary: {
@@ -108,17 +213,34 @@ export default class CoC7ActiveEffect {
       }
     }
     // Iterate over active effects, classifying them into categories
-    for (const e of effects) {
-      if (e.isSuppressed) {
-        categories.suppressed.effects.push(e)
+    for (const e of document.effects ?? []) {
+      const effect = await CoC7ActiveEffect.effectData(e, { embeddedItem: false })
+      if (effect.isSuppressed) {
+        categories.suppressed.effects.push(effect)
       } else if (CoC7ActiveEffect.getStatusKey(e) && status) {
-        categories.status.effects.push(e)
-      } else if (e.disabled) {
-        categories.inactive.effects.push(e)
-      } else if (e.isTemporary) {
-        categories.temporary.effects.push(e)
+        categories.status.effects.push(effect)
+      } else if (effect.disabled) {
+        categories.inactive.effects.push(effect)
+      } else if (effect.isTemporary) {
+        categories.temporary.effects.push(effect)
       } else {
-        categories.passive.effects.push(e)
+        categories.passive.effects.push(effect)
+      }
+    }
+    for (const i of document.items ?? []) {
+      for (const e of i.effects) {
+        const effect = await CoC7ActiveEffect.effectData(e, { embeddedItem: true })
+        if (effect.isSuppressed) {
+          categories.suppressed.effects.push(effect)
+        } else if (CoC7ActiveEffect.getStatusKey(e) && status) {
+          categories.status.effects.push(effect)
+        } else if (effect.disabled) {
+          categories.inactive.effects.push(effect)
+        } else if (effect.isTemporary) {
+          categories.temporary.effects.push(effect)
+        } else {
+          categories.passive.effects.push(effect)
+        }
       }
     }
 
@@ -128,10 +250,10 @@ export default class CoC7ActiveEffect {
 
   /**
    * Sort Actor effects into categories
-   * @param {object} effects
-   * @returns {object}
+   * @param {Document} document
+   * @returns {Promise<object>}
    */
-  static prepareNPCActiveEffectCategories (effects) {
+  static async prepareNPCActiveEffectCategories (document) {
     // Define effect header categories
     const categories = {
       active: {
@@ -146,11 +268,22 @@ export default class CoC7ActiveEffect {
       }
     }
     // Iterate over active effects, classifying them into categories
-    for (const e of effects) {
-      if (e.isSuppressed || e.disabled) {
-        categories.inactive.effects.push(e)
+    for (const e of document.effects ?? []) {
+      const effect = await CoC7ActiveEffect.effectData(e, { embeddedItem: false })
+      if (effect.isSuppressed || effect.disabled) {
+        categories.inactive.effects.push(effect)
       } else {
-        categories.active.effects.push(e)
+        categories.active.effects.push(effect)
+      }
+    }
+    for (const i of document.items ?? []) {
+      for (const e of i.effects) {
+        const effect = await CoC7ActiveEffect.effectData(e, { embeddedItem: true })
+        if (effect.isSuppressed || effect.disabled) {
+          categories.inactive.effects.push(effect)
+        } else {
+          categories.active.effects.push(effect)
+        }
       }
     }
     return categories

--- a/coc7/apps/actor-picker-dialog.js
+++ b/coc7/apps/actor-picker-dialog.js
@@ -123,15 +123,21 @@ export default class CoC7ActorPickerDialog extends foundry.applications.api.Hand
    * @param {boolean} options.allowNoActor
    * @param {string|null} options.notAutomaticUuid
    * @param {string|null} options.selected
+   * @param {boolean} options.preferTargeted
    * @returns {string}
    */
-  static async create ({ allowNoActor = false, notAutomaticUuid = null, selected = null } = {}) {
+  static async create ({ allowNoActor = false, notAutomaticUuid = null, selected = null, preferTargeted = false } = {}) {
     let found = []
-    if (game.user.isGM && canvas.ready && canvas.tokens.controlled.length > 0) {
-      found = canvas.tokens.controlled.map(t => t.document)
+    if (preferTargeted && game.user.targets.size > 0) {
+      found = [...game.user.targets.map(doc => doc.document)]
     }
-    if (found.length === 1 && (found[0].uuid === notAutomaticUuid || found[0].actor?.uuid === notAutomaticUuid)) {
-      found = []
+    if (found.length === 0) {
+      if (game.user.isGM && canvas.ready && canvas.tokens.controlled.length > 0) {
+        found = canvas.tokens.controlled.map(t => t.document)
+      }
+      if (found.length === 1 && (found[0].uuid === notAutomaticUuid || found[0].actor?.uuid === notAutomaticUuid)) {
+        found = []
+      }
     }
     if (found.length === 0) {
       if (canvas.ready) {

--- a/coc7/apps/chat-damage.js
+++ b/coc7/apps/chat-damage.js
@@ -608,7 +608,7 @@ export default class CoC7ChatDamage {
           if (check) {
             const damage = await check.#inflictDamageText()
             if (typeof damage !== 'string') {
-              const actorUuid = await CoC7ActorPickerDialog.create()
+              const actorUuid = await CoC7ActorPickerDialog.create({ preferTargeted: true })
               const actor = await CoC7Utilities.getActorFromUuid(actorUuid)
               if (actor) {
                 const damageTaken = await actor.dealDamage(damage)

--- a/coc7/apps/investigator-wizard.js
+++ b/coc7/apps/investigator-wizard.js
@@ -1568,8 +1568,8 @@ export default class CoC7InvestigatorWizard extends foundry.applications.api.Han
             if (table.length === 1) {
               const tableResults = await table[0].roll()
               for (const tableResult of tableResults.results) {
-                if (tableResult.type === CONST.TABLE_RESULT_TYPES.TEXT) {
-                  /* // FoundryVTT V12 */
+                /* // FoundryVTT V12 */
+                if (tableResult.type === CONST.TABLE_RESULT_TYPES.TEXT || (tableResult.type === CONST.TABLE_RESULT_TYPES.DOCUMENT && typeof tableResult.type.documentUuid === 'undefined')) {
                   this.coc7Config.bioSections[index].value = (this.coc7Config.bioSections[index].value + '\n' + (tableResult.description ?? tableResult.text).trim()).trim()
                 }
               }

--- a/coc7/apps/updater.js
+++ b/coc7/apps/updater.js
@@ -686,7 +686,7 @@ export default class CoC7Updater {
             costList.push({
               config: { prompt: document.system.costs.others },
               if: '',
-              type: 'otherCost'
+              type: 'additionalInformation'
             })
           }
           if (costList.length > 0) {

--- a/coc7/models/actor/global-sheet.js
+++ b/coc7/models/actor/global-sheet.js
@@ -67,7 +67,7 @@ export default class CoC7ModelsActorGlobalSheet extends foundry.applications.api
       context.hasInventory = this.hasInventory(context)
     }
 
-    context.effects = context.document.type === 'character' ? CoC7ActiveEffect.prepareActiveEffectCategories(context.document.effects) : CoC7ActiveEffect.prepareNPCActiveEffectCategories(context.document.effects)
+    context.effects = context.document.type === 'character' ? await CoC7ActiveEffect.prepareActiveEffectCategories(context.document) : await CoC7ActiveEffect.prepareNPCActiveEffectCategories(context.document)
 
     context.allowUnlock = this.allowUnlock
 

--- a/coc7/models/actor/global-sheet.js
+++ b/coc7/models/actor/global-sheet.js
@@ -217,11 +217,13 @@ export default class CoC7ModelsActorGlobalSheet extends foundry.applications.api
         const fn = () => {
           if (button.classList.contains('slid-out-notes')) {
             outer.classList.remove('sliding-out-notes')
+          } else {
+            outer.classList.remove('visible-notes')
           }
           element.removeEventListener('transitionend', fn)
         }
         outer.addEventListener('transitionend', fn)
-        outer.classList.add('sliding-out-notes')
+        outer.classList.add('sliding-out-notes', 'visible-notes')
         if (button.classList.contains('slid-out-notes')) {
           button.classList.remove('slid-out-notes')
           outer.classList.add('slide-out-notes')

--- a/coc7/models/actor/npc-sheet-v2.js
+++ b/coc7/models/actor/npc-sheet-v2.js
@@ -18,7 +18,7 @@ export default class CoC7ModelsActorNPCSheetV2 extends CoC7ModelsActorGlobalShee
   static PARTS = {
     body: {
       template: 'systems/' + FOLDER_ID + '/templates/actors/npc-v2/body.hbs',
-      scrollable: ['section.tab-group-tab']
+      scrollable: ['', 'section.tab-group-tab']
     }
   }
 

--- a/coc7/models/item/armor-sheet.js
+++ b/coc7/models/item/armor-sheet.js
@@ -86,7 +86,7 @@ export default class CoC7ModelsItemArmorSheet extends CoC7ModelsItemGlobalSheet 
         )
         break
       case 'activeEffects':
-        context.effects = CoC7ActiveEffect.prepareActiveEffectCategories(context.document.effects, { status: false })
+        context.effects = await CoC7ActiveEffect.prepareActiveEffectCategories(context.document, { status: false })
         break
       case 'keeper':
         /* // FoundryVTT V12 */

--- a/coc7/models/item/item-sheet-v2.js
+++ b/coc7/models/item/item-sheet-v2.js
@@ -99,7 +99,7 @@ export default class CoC7ModelsItemItemSheetV2 extends CoC7ModelsItemGlobalSheet
         )
         break
       case 'activeEffects':
-        context.effects = CoC7ActiveEffect.prepareActiveEffectCategories(context.document.effects, { status: false })
+        context.effects = await CoC7ActiveEffect.prepareActiveEffectCategories(context.document, { status: false })
         break
       case 'prices':
         context._eras = []

--- a/coc7/models/item/status-sheet.js
+++ b/coc7/models/item/status-sheet.js
@@ -119,7 +119,7 @@ export default class CoC7ModelsItemStatusSheet extends CoC7ModelsItemGlobalSheet
         )
         break
       case 'activeEffects':
-        context.effects = CoC7ActiveEffect.prepareActiveEffectCategories(context.document.effects, { status: false })
+        context.effects = await CoC7ActiveEffect.prepareActiveEffectCategories(context.document, { status: false })
         break
       case 'keeper':
         /* // FoundryVTT V12 */

--- a/coc7/models/item/weapon-system.js
+++ b/coc7/models/item/weapon-system.js
@@ -406,7 +406,7 @@ export default class CoC7ModelsItemWeaponSystem extends CoC7ModelsItemGlobalSyst
    * @returns {boolean}
    */
   get multipleShots () {
-    const value = this.usesPerRound.max.toString()
+    const value = (this.usesPerRound.max ?? '').toString()
     const roll = new Roll(value)
     if (value !== '' && roll.isDeterministic) {
       return roll.evaluateSync().total > 1
@@ -419,7 +419,7 @@ export default class CoC7ModelsItemWeaponSystem extends CoC7ModelsItemGlobalSyst
    * @returns {boolean}
    */
   get singleShot () {
-    const value = this.usesPerRound.normal.toString()
+    const value = (this.usesPerRound.normal ?? '').toString()
     const roll = new Roll(value)
     if (value !== '' && roll.isDeterministic) {
       return roll.evaluateSync().total > 0

--- a/coc7/polyfill.js
+++ b/coc7/polyfill.js
@@ -10,6 +10,9 @@ if (typeof foundry.appv1 === 'undefined') {
     }
   }
 }
+if (CONFIG.ActiveEffect?.legacyTransferral === true) {
+  CONFIG.ActiveEffect.legacyTransferral = false
+}
 // Translations TOKEN.MOVEMENT.ACTIONS.* in static/lang/*.json
 if (typeof CONFIG.Token.movement === 'undefined') {
   CONFIG.Token.movement = {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -353,7 +353,7 @@
   "CoC7.ItemWeight": "Weight",
   "CoC7.ItemDetails": "Details",
   "CoC7.Description": "Description",
-  "CoC7.Reload": "Left/Right click : add/remove 1 bullet\nShift + Left/Right click : Reload/Empty",
+  "CoC7.Reload": "Left/Right click : add/remove 1 bullet<br>Shift + Left/Right click : Reload/Empty",
   "CoC7.WeaponRange": "Range",
   "CoC7.WeaponDamage": "Damage",
   "CoC7.Weapon.BlastRadius": "Blast radius",

--- a/static/templates/actors/npc-v2/body.hbs
+++ b/static/templates/actors/npc-v2/body.hbs
@@ -1,4 +1,4 @@
-<div class="npc flexcol">
+<div class="npc flexcol scrollable">
   <div class="character-details flexrow">
     <div class="character-detail">
       <div class="title">{{localize 'CoC7.Name'}}</div>
@@ -35,7 +35,7 @@
             <div class="item-controlled-width" data-tooltip="CoC7.NpcCharacteristicsValues"><i class="fa-solid fa-user-edit"></i></div>
           {{/if}}
         {{/unless}}
-        <div class="item-controlled-width slide-out-notes clickable{{#if document.system.flags.panelNotes}} slid-out-notes{{/if}}" style="text-align: center"><i class="fa-solid fa-note-sticky"></i></div>
+        <div class="item-controlled-width slide-out-notes clickable{{#if document.system.flags.panelNotes}} slid-out-notes{{/if}}" style="text-align: center" data-tooltip="CoC7.Notes"><i class="fa-solid fa-note-sticky"></i></div>
       </div>
     </div>
   </div>
@@ -271,11 +271,13 @@
       </div>
     </div>
   {{/if}}
-  <div class="tab-group tab-group-notes flexcol{{#unless document.system.flags.panelNotes}} sliding-out-notes slide-out-notes{{/unless}}" data-panel="Notes" data-slide-under="on">
+  <div class="tab-group tab-group-notes flexcol{{#if document.system.flags.panelNotes}} visible-notes{{else}} sliding-out-notes slide-out-notes{{/if}}" data-panel="Notes" data-slide-under="on">
     <div class="tab-group-header">
+      <i class="fa-sharp fa-thin fa-left-from-line" style="height:0; overflow: hidden;"></i>
       <div class="tab-group-title">{{localize 'CoC7.Notes'}}</div>
+      <i class="fa-sharp fa-thin fa-left-from-line"></i>
     </div>
-    <section class="tab-group-tab scrollable">
+    <section class="coc7-formatted-text tab-group-tab scrollable">
       <prose-mirror name="system.biography.personalDescription.value" value="{{document.system.biography.personalDescription.value}}" data-document-uuid="{{document.uuid}}" toggled>{{{enrichedBiographyPersonalDescription}}}</prose-mirror>
     </section>
   </div>

--- a/static/templates/actors/npc-v2/body.hbs
+++ b/static/templates/actors/npc-v2/body.hbs
@@ -273,9 +273,9 @@
   {{/if}}
   <div class="tab-group tab-group-notes flexcol{{#if document.system.flags.panelNotes}} visible-notes{{else}} sliding-out-notes slide-out-notes{{/if}}" data-panel="Notes" data-slide-under="on">
     <div class="tab-group-header">
-      <i class="fa-sharp fa-thin fa-left-from-line" style="height:0; overflow: hidden;"></i>
+      <i class="fa-regular fa-left-from-line" style="height:0; overflow: hidden;"></i>
       <div class="tab-group-title">{{localize 'CoC7.Notes'}}</div>
-      <i class="fa-sharp fa-thin fa-left-from-line"></i>
+      <i class="fa-regular fa-left-from-line"></i>
     </div>
     <section class="coc7-formatted-text tab-group-tab scrollable">
       <prose-mirror name="system.biography.personalDescription.value" value="{{document.system.biography.personalDescription.value}}" data-document-uuid="{{document.uuid}}" toggled>{{{enrichedBiographyPersonalDescription}}}</prose-mirror>

--- a/static/templates/actors/npc-v2/tab/combat.hbs
+++ b/static/templates/actors/npc-v2/tab/combat.hbs
@@ -31,7 +31,11 @@
                 <span class="tag">{{weapon.system.ammo}}</span>
               </div>
               <div class="control">
-                <a class="reload-weapon" data-tooltip="CoC7.Reload"><i class="game-icon game-icon-chaingun"></i></a>
+                {{#if (eq null weapon.system.bullets)}}
+                  <a class="item-control" data-action="item-edit" data-tooltip="CoC7.EditWeapon" style=""><i class="fa-solid fa-edit"></i></a>
+                {{else}}
+                  <a class="reload-weapon" data-tooltip="CoC7.Reload"><i class="game-icon game-icon-chaingun"></i></a>
+                {{/if}}
               </div>
             </div>
           {{else}}

--- a/static/templates/common/active-effects.hbs
+++ b/static/templates/common/active-effects.hbs
@@ -23,13 +23,13 @@
         </li>
       {{/if}}
       {{#each category.effects as |effect|}}
-        <li class="item effect" data-effect-id="{{effect.id}}">
-          <div class="effect-identifier">
+        <li class="item effect" data-effect-uuid="{{effect.uuid}}">
+          <div class="effect-identifier" data-tooltip="{{effect.readable}}">
             <div class="item-image" style="background-image: url('{{effect.img}}')"></div>
             <h4 class="item-name effect-name">{{effect.name}}</h4>
           </div>
-          <div class="effect-source">{{effect.sourceName}}</div>
-          <div class="effect-duration">{{effect.duration.label}}</div>
+          <div class="effect-source">{{{effect.source}}}</div>
+          <div class="effect-duration">{{effect.duration}}</div>
           <div class="item-controls effect-controls">
             {{#if @root.editable}}
               <a class="item-control effect-control" data-action="toggle" data-tooltip="{{#if effect.disabled}}CoC7.Enable{{else}}CoC7.Disable{{/if}}">

--- a/styles/coc7-globals.less
+++ b/styles/coc7-globals.less
@@ -446,6 +446,7 @@ body.theme-dark .application.coc7,
   .item-controls {
     .flex-row(@col-gap: @5px);
     justify-content: flex-end;
+    flex: 0 0 auto;
 
     .item-control-disabled,
     .item-control {
@@ -676,6 +677,10 @@ body.theme-dark .application.coc7,
       border-radius: @8px;
     }
   }
+}
+
+ul.active-effect-adjustments {
+  margin: 0;
 }
 
 /* ---------------------------------------- */

--- a/styles/coc7-npc.less
+++ b/styles/coc7-npc.less
@@ -3,7 +3,9 @@
   font-size: @16px;
 
   section.window-content {
-    overflow: visible;
+    &:has(.tab-group-notes.visible-notes) {
+      overflow: visible;
+    }
     background-position: top right;
     font-family: var(--investigator-sheet-secondary-font);
 

--- a/styles/coc7-npc.less
+++ b/styles/coc7-npc.less
@@ -6,6 +6,7 @@
     &:has(.tab-group-notes.visible-notes) {
       overflow: visible;
     }
+    max-height: calc(90vh - 2rem);
     background-position: top right;
     font-family: var(--investigator-sheet-secondary-font);
 


### PR DESCRIPTION
## Description.
- Add scroll bar to NPC sheet
- Damage card Inflict Damage button will now pick targets over selection
- If weapon Item has no maximum ammunition on NPC sheet show edit button instead of reload
- Fix reload tooltip to use &lt;br&gt; instead of \n
- Fix console error if uses per round has no normal / max
- Update Active Effect tab to separate on Actor and on Item Active Effects, create tooltip to decode common changes.

## Support Tested On
- [X] FoundryVTT v12.
- [X] FoundryVTT v13.
- [X] FoundryVTT v14.

## Types of Changes.
- [X] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
