### PR TITLE
feat(tour): add Spanish translation for variant rules tour

### DIFF
--- a/coc7/setup/register-tours.js
+++ b/coc7/setup/register-tours.js
@@ -1,6 +1,7 @@
 /* global game */
 import { FOLDER_ID } from '../constants.js'
 import CoC7EnableVariantRulesEn from '../tours/enable-variant-rules-en.js'
+import CoC7EnableVariantRulesEs from '../tours/enable-variant-rules-es.js'
 import CoC7EnableVariantRulesFr from '../tours/enable-variant-rules-fr.js'
 
 export default function () {
@@ -8,6 +9,9 @@ export default function () {
   const tours = {
     en: {
       'enable-variant-rules': CoC7EnableVariantRulesEn
+    },
+    es: {
+      'enable-variant-rules': CoC7EnableVariantRulesEs
     },
     fr: {
       'enable-variant-rules': CoC7EnableVariantRulesFr

--- a/coc7/tours/enable-variant-rules-es.js
+++ b/coc7/tours/enable-variant-rules-es.js
@@ -1,0 +1,26 @@
+import CoC7EnableVariantRulesEn from './enable-variant-rules-en.js'
+
+export default class CoC7EnableVariantRulesEs extends CoC7EnableVariantRulesEn {
+  /**
+   * Tour configuration
+   * @param {object} config
+   */
+  constructor (config) {
+    super({
+      title: 'Activar ambientaciones y reglas opcionales.',
+      description: 'Aprende cómo activar las reglas de Pulp Cthulhu u otras ambientaciones y reglas opcionales',
+      localization: {
+        'COC7.Tour.GotoSettingsTitle': 'Ajustes del juego',
+        'COC7.Tour.GotoSettingsContent': 'Ve a la pestaña de Ajustes del juego',
+        'COC7.Tour.GotoConfigureTitle': 'Configurar ajustes',
+        'COC7.Tour.GotoConfigureContent': 'Haz clic en el botón Configurar ajustes',
+        'COC7.Tour.GotoSystemSettingsTitle': 'Ajustes del sistema',
+        'COC7.Tour.GotoSystemSettingsContent': 'Ve a la pestaña de Ajustes del sistema',
+        'COC7.Tour.GotoGameRulesTitle': 'Configurar ambientaciones y reglas opcionales',
+        'COC7.Tour.GotoGameRulesContent': 'Haz clic en el botón Configurar ambientaciones y reglas opcionales',
+        'COC7.Tour.SaveGameRulesTitle': 'Guardar cambios en las reglas',
+        'COC7.Tour.SaveGameRulesContent': 'Una vez que hayas realizado tus cambios, haz clic en el botón Guardar cambios'
+      }
+    })
+  }
+}


### PR DESCRIPTION
## Description.

Adds the Spanish translation for the variant rules tour (`EnableVariantRulesEs`). This was originally part of #1863, but I'm submitting it separately here as requested by the reviewer so it can be merged independently.

## Motivation and Context.

To give Spanish-speaking users a fully localized experience when running the variant rules tour. 

## Screenshots.

N/A

## Support Tested On

- [ ] FoundryVTT v12.
- [ ] FoundryVTT v13.
- [ ] FoundryVTT v14.

## Types of Changes.

- [x] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)