### PR TITLE
perf(coc-id): defer skill cache hydration and parallelize fromUuid loads

### DIFF
--- a/coc7/apps/coc-id.js
+++ b/coc7/apps/coc-id.js
@@ -591,19 +591,27 @@ export default class CoCID {
    * @returns {Array}
    */
   static async #onlyDocuments (candidates, progressBar) {
+    const tasks = []
     for (const offset in candidates) {
-      if (progressBar !== false) {
-        // await new Promise(resolve => setTimeout(resolve, 1000))
-        progressBar.bar.update({ pct: progressBar.current / progressBar.max })
-        progressBar.current++
-      }
       if (!(candidates[offset] instanceof foundry.abstract.DataModel)) {
-        candidates[offset] = await fromUuid(candidates[offset].uuid)
+        tasks.push(fromUuid(candidates[offset].uuid).then((doc) => {
+          candidates[offset] = doc
+          if (progressBar !== false) {
+            progressBar.current++
+            progressBar.bar.update({ pct: progressBar.current / progressBar.max })
+          }
+        }))
+      } else if (progressBar !== false) {
+        progressBar.current++
+        progressBar.bar.update({ pct: progressBar.current / progressBar.max })
       }
     }
-    if (progressBar !== false) {
-      // await new Promise(resolve => setTimeout(resolve, 1000))
-      progressBar.bar.remove()
+    try {
+      await Promise.all(tasks)
+    } finally {
+      if (progressBar !== false) {
+        progressBar.bar.remove()
+      }
     }
     return candidates
   }

--- a/coc7/hooks/ready.js
+++ b/coc7/hooks/ready.js
@@ -32,7 +32,6 @@ export default function () {
   }
 
   CoC7RegisterTours()
-  game.CoC7.skillNames.refreshList()
   game.socket.on('system.' + FOLDER_ID, async data => {
     CoC7SystemSocket.callSocket(data)
   })

--- a/coc7/setup/coc-id-skill-cache.js
+++ b/coc7/setup/coc-id-skill-cache.js
@@ -45,8 +45,10 @@ export default class CoCIDSkillCache {
     }
     return new Promise((resolve, reject) => {
       game.CoC7.cocid.fromCoCIDBest({ cocid, type: 'i' }).then((items) => {
-        if (typeof this.#cache === 'undefined') {
-          // If not already cached add it when doing a full cache
+        if (typeof this.#list === 'undefined') {
+          // Cache not yet populated (cold or in-flight). Wait for the full
+          // refresh — it will include this item — rather than writing into
+          // an undefined this.#list.
           this.getList().then((items) => {
             resolve()
           })


### PR DESCRIPTION
## Description.

Reloading a world consistently showed the "Loading Matching Items" progress bar for ~5 seconds at `ready`, blocking world load. Two causes:

1. `hooks/ready.js` eagerly called `game.CoC7.skillNames.refreshList()` on every world load, even though `CoCIDSkillCache.getList()` is already lazy (`if (typeof this.#cache === 'undefined')`).
2. `CoCID.#onlyDocuments()` hydrated indexed candidates by `await`-ing `fromUuid()` sequentially — ~200 round-trips serialized.

This PR:

- Removes the unconditional `refreshList()` call in `hooks/ready.js`. Cache now populates lazily on first access (character sheet open or item hook). The `worldEra` setting `onChange` refresh is intentionally left intact — that's a genuine invalidation event.
- Parallelizes `#onlyDocuments` via `Promise.all`, wrapped in `try/finally` so the progress bar always closes even if a `fromUuid` call rejects (rejection still propagates to the caller, matching the previous behavior).
- Fixes a latent race in `CoCIDSkillCache.addItem()` that the lazy cache change exposes. The cold-cache check was looking at `#cache` (set synchronously to a pending `Promise` during `refreshList`), which meant `addItem` during the refresh window would try to write to `this.#list` while it was still undefined. Now checks `#list` directly; a pending refresh just awaits the in-flight promise, and new items appear via the full walk.

## Motivation and Context.

The "Loading Matching Items" bar at every world load was frustrating enough to dig into. Once I saw the cache was already designed to be lazy, the eager `ready`-time call became the obvious thing to drop; parallelizing `#onlyDocuments` then collapsed the remaining hydration cost from ~5s to roughly one round-trip.

The `addItem` race fix is bundled because the lazy cache change is what makes it reachable in practice — keeping the two together is the honest framing of cause and effect.

## Screenshots.

N/A — no UI changes; the visible effect is the absence of the progress bar at `ready`.

## Support Tested On

- [ ] FoundryVTT v12.
- [ ] FoundryVTT v13.
- [x] FoundryVTT v14.

## Types of Changes.

- [ ] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)