### PR TITLE
Fix v12 settings reboot and CCI: Player for player open sheet

### DIFF
--- a/coc7/apps/chaosium-canvas-interface-player.js
+++ b/coc7/apps/chaosium-canvas-interface-player.js
@@ -188,7 +188,8 @@ export default class ChaosiumCanvasInterfacePlayer extends ChaosiumCanvasInterfa
             name: game.i18n.localize('TYPES.RegionBehavior.ChaosiumCanvasInterfaceOpenDocument'),
             type: 'ChaosiumCanvasInterfaceOpenDocument',
             system: {
-              documentUuid: uuid
+              documentUuid: uuid,
+              permission: 'DOCUMENT'
             }
           })
         } else {

--- a/coc7/apps/settings-game-rules.js
+++ b/coc7/apps/settings-game-rules.js
@@ -389,9 +389,14 @@ export default class CoC7SettingsGameRules extends foundry.applications.api.Hand
     }
     game.settings.set(FOLDER_ID, 'pulpRules', pulpRules.true && !pulpRules.false)
     if (rebootRequired) {
-      foundry.applications.settings.SettingsConfig.reloadConfirm({
-        world: true
-      })
+      /* // FoundryVTT V12 */
+      if (game.release.generation === 12) {
+        foundry.utils.debouncedReload()
+      } else {
+        foundry.applications.settings.SettingsConfig.reloadConfirm({
+          world: true
+        })
+      }
     }
   }
 }


### PR DESCRIPTION
## Description.
Fix v12 settings reboot
Fix CCI: Player for player open sheet

## Support Tested On
- [X] FoundryVTT v12.
- [X] FoundryVTT v13.
- [X] FoundryVTT v14.

## Types of Changes.
- [X] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
