### PR TITLE
Reduce number of database queries when loading compendium items

### DIFF
--- a/coc7/apps/coc-id.js
+++ b/coc7/apps/coc-id.js
@@ -591,16 +591,38 @@ export default class CoCID {
    * @returns {Array}
    */
   static async #onlyDocuments (candidates, progressBar) {
+    const packs = {}
     for (const offset in candidates) {
-      if (progressBar !== false) {
-        // await new Promise(resolve => setTimeout(resolve, 1000))
-        progressBar.bar.update({ pct: progressBar.current / progressBar.max })
-        progressBar.current++
-      }
-      if (!(candidates[offset] instanceof foundry.abstract.DataModel)) {
-        candidates[offset] = await fromUuid(candidates[offset].uuid)
+      if (candidates[offset] instanceof foundry.abstract.DataModel) {
+        if (progressBar !== false) {
+          // await new Promise(resolve => setTimeout(resolve, 1000))
+          progressBar.bar.update({ pct: progressBar.current / progressBar.max })
+          progressBar.current++
+        }
+      } else {
+        const match = candidates[offset].uuid.match(/^Compendium\.(.+)\.Item\.(.+)$/)
+        if (typeof packs[match[1]] === 'undefined') {
+          packs[match[1]] = {}
+        }
+        packs[match[1]][match[2]] = offset
       }
     }
+    const all = []
+    for (const packId in packs) {
+      const pack = game.packs.get(packId)
+      all.push(pack.getDocuments({ _id__in: Object.keys(packs[packId]) }).then(documents => {
+        for (const document of documents) {
+          if (progressBar !== false) {
+            // await new Promise(resolve => setTimeout(resolve, 1000))
+            progressBar.bar.update({ pct: progressBar.current / progressBar.max })
+            progressBar.current++
+          }
+          const offset = packs[packId][document._id]
+          candidates[offset] = document
+        }
+      }))
+    }
+    await Promise.all(all)
     if (progressBar !== false) {
       // await new Promise(resolve => setTimeout(resolve, 1000))
       progressBar.bar.remove()

--- a/coc7/setup/coc-id-skill-cache.js
+++ b/coc7/setup/coc-id-skill-cache.js
@@ -45,7 +45,7 @@ export default class CoCIDSkillCache {
     }
     return new Promise((resolve, reject) => {
       game.CoC7.cocid.fromCoCIDBest({ cocid, type: 'i' }).then((items) => {
-        if (typeof this.#cache === 'undefined') {
+        if (typeof this.#list === 'undefined') {
           // If not already cached add it when doing a full cache
           this.getList().then((items) => {
             resolve()


### PR DESCRIPTION
## Description.
Implements #2086 Refactor of loading documents instead of individual fromUuid calls use batch getDocuments and reimplement race condition fix from pull request
This does not remove the call in the ready hook for refreshList() as this is currently required by the Chase Item type

## Support Tested On
- [X] FoundryVTT v12.
- [X] FoundryVTT v13.
- [X] FoundryVTT v14.

## Types of Changes.
- [X] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
