### PR TITLE
Fix onlyDocuments optimisation for non Items

### DIFF
--- a/coc7/apps/coc-id.js
+++ b/coc7/apps/coc-id.js
@@ -600,11 +600,13 @@ export default class CoCID {
           progressBar.current++
         }
       } else {
-        const match = candidates[offset].uuid.match(/^Compendium\.(.+)\.Item\.(.+)$/)
-        if (typeof packs[match[1]] === 'undefined') {
-          packs[match[1]] = {}
+        const parts = foundry.utils.parseUuid(candidates[offset].uuid)
+        if (typeof parts.collection?.collection === 'string' && typeof parts.id === 'string') {
+          if (typeof packs[parts.collection.collection] === 'undefined') {
+            packs[parts.collection.collection] = {}
+          }
+          packs[parts.collection.collection][parts.id] = offset
         }
-        packs[match[1]][match[2]] = offset
       }
     }
     const all = []


### PR DESCRIPTION
## Description.
Switch to foundry.utils.parseUuid instead of regular expression as it works the same on all supported versions.

## Support Tested On
- [X] FoundryVTT v12.
- [X] FoundryVTT v13.
- [X] FoundryVTT v14.

## Types of Changes.
- [X] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
