### PR TITLE
Fix Investigator not updating backstory roll table list if era is switched

### DIFF
--- a/coc7/apps/investigator-wizard.js
+++ b/coc7/apps/investigator-wizard.js
@@ -1184,6 +1184,7 @@ export default class CoC7InvestigatorWizard extends foundry.applications.api.Han
           this.coc7Config.defaultEra = event.target.value
           await game.settings.set(FOLDER_ID, 'worldEra', this.coc7Config.defaultEra)
           this.coc7Config.cacheCoCID = await CoC7InvestigatorWizard.loadCacheItemByCoCID()
+          this.coc7Config.cacheBackstories = game.CoC7.cocid.fromCoCIDRegexBest({ cocidRegExp: /^rt\.\.backstory-/, type: 'rt' })
           // To prevent flashing show message for at least 500 ms
           const buffer = 500 - (Date.now() - started)
           // Don't bother if less than 10ms remaining

--- a/compendiums/en-items.yaml
+++ b/compendiums/en-items.yaml
@@ -63,7 +63,7 @@ system:
 flags:
   CoC7:
     cocidFlag:
-      id: i.setup.standard
+      id: i.setup.s-setup
       lang: en
       eras:
         standard: true

--- a/compendiums/en-items.yaml
+++ b/compendiums/en-items.yaml
@@ -206,7 +206,7 @@ img: systems/CoC7/assets/icons/skills/fighting_brawl.svg
 system:
   skill:
     main:
-      name: Brawl
+      name: i.skill.brawl
   range:
     normal:
       damage: 1D3


### PR DESCRIPTION
## Description.

## Support Tested On
- [X] FoundryVTT v12.
- [X] FoundryVTT v13.
- [X] FoundryVTT v14.

## Types of Changes.
- [X] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
