### PR TITLE
Fix Swedish localization parse error by removing conflicting CoC7.Spell key

### DIFF
--- a/static/lang/sv.json
+++ b/static/lang/sv.json
@@ -102,7 +102,6 @@
   "CoC7.Author": "Författare",
   "CoC7.Date": "Datum",
   "CoC7.Spells": "Besvärjelser",
-  "CoC7.Spell": "Besvärjelse",
   "CoC7.Spells&Notes": "Besvärjelser & anteckningar",
   "CoC7.Weapons": "Vapen",
   "CoC7.Effects": "Effekter",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description.

Removes the "CoC7.Spell": "Besvärjelse" 
Because sv.json also contains CoC7.Spell.Cost.* and related nested keys, the standalone string key caused a type conflict
<img width="645" height="689" alt="image" src="https://github.com/user-attachments/assets/fb52a0a4-3db0-464c-8c9c-d360c64a0079" />

## Motivation and Context.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->

## Screenshots.

<!-- If appropriate. -->

## Support Tested On

<!--- The system currently supports FoundryVTT v12, v13, and v14. This is not required if only translation JSON and manual MD files are changed -->

- [ ] FoundryVTT v12.
- [ ] FoundryVTT v13.
- [ ] FoundryVTT v14.

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
