### PR TITLE
Remove CoC7.Spell from translations to prevent issues with CoC7.Spell.* keys

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,6 +11,19 @@ When not specified, all changes were made by @castanhocorreia, @HavlockV, and @s
 
 **_!! Not all features will work with FoundryVTT v12 please consider upgrading !!_**
 
+## Version 8.14
+
+When not specified, all changes were made by @castanhocorreia, @HavlockV, and @snap01.
+
+**_!! Not all features will work with FoundryVTT v12 please consider upgrading !!_**
+
+- Fix double penalty / bonus of ranged size.
+- Remove CoC7.Spell from translations to prevent issues with CoC7.Spell.* keys, thanks to @zeteticl #2126
+- Update spell cost "if" to support zero / non zero integer checks.
+- Update to French localization, thanks to @vonv #2128
+- Update to Simplified Chinese localization, thanks to @LiangHao-cloud #2129
+- Update to Taiwanese localization, thanks to @zeteticl #2125
+
 ## Version 8.13
 
 When not specified, all changes were made by @castanhocorreia, @HavlockV, and @snap01.

--- a/static/lang/cs.json
+++ b/static/lang/cs.json
@@ -1008,7 +1008,6 @@
   "CoC7.Specific": "Konkrétní",
   "CoC7.SpecificLocations": "Určitá lokace",
   "CoC7.SpeedCheck": "Kontrola rychlosti",
-  "CoC7.Spell": "Kouzlo",
   "CoC7.SpellAlreadyLearned": "Kouzlo s názvem ('{spell}') už umíte.",
   "CoC7.SpellCastingCost": "Cena seslání",
   "CoC7.SpellCastingTime": "Čas seslání",

--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -99,7 +99,6 @@
   "CoC7.Author": "Autor",
   "CoC7.Date": "Datum",
   "CoC7.Spells": "Zaubersprüche",
-  "CoC7.Spell": "Zauberspruch",
   "CoC7.Spells&Notes": "Zaubersprüche & Notizen",
   "CoC7.Weapons": "Waffen",
   "CoC7.Effects": "Effekte",

--- a/static/lang/es.json
+++ b/static/lang/es.json
@@ -99,7 +99,6 @@
   "CoC7.Author": "Autor",
   "CoC7.Date": "Fecha",
   "CoC7.Spells": "Hechizos",
-  "CoC7.Spell": "Hechizo",
   "CoC7.Spells&Notes": "Hechizos y notas",
   "CoC7.Weapons": "Armas",
   "CoC7.Effects": "Efectos",

--- a/static/lang/it.json
+++ b/static/lang/it.json
@@ -96,7 +96,6 @@
   "CoC7.Author": "Autore",
   "CoC7.Date": "Data",
   "CoC7.Spells": "Incantesimi",
-  "CoC7.Spell": "Incantesimo",
   "CoC7.Spells&Notes": "Incantesimi & Note",
   "CoC7.Weapons": "Armi",
   "CoC7.Effects": "Effetti",

--- a/static/lang/ko.json
+++ b/static/lang/ko.json
@@ -99,7 +99,6 @@
   "CoC7.Author": "저자",
   "CoC7.Date": "날짜",
   "CoC7.Spells": "주문",
-  "CoC7.Spell": "주문",
   "CoC7.Spells&Notes": "주문과 서적",
   "CoC7.Weapons": "장비",
   "CoC7.Effects": "효과",

--- a/static/lang/pl.json
+++ b/static/lang/pl.json
@@ -99,7 +99,6 @@
   "CoC7.Author": "Autor",
   "CoC7.Date": "Data",
   "CoC7.Spells": "Czary",
-  "CoC7.Spell": "Czar",
   "CoC7.Spells&Notes": "Czary i Notatki",
   "CoC7.Weapons": "Bronie",
   "CoC7.Effects": "Efekt",

--- a/static/lang/pt-BR.json
+++ b/static/lang/pt-BR.json
@@ -96,7 +96,6 @@
   "CoC7.Author": "Autor",
   "CoC7.Date": "Data",
   "CoC7.Spells": "Feitiços",
-  "CoC7.Spell": "Feitiço",
   "CoC7.Spells&Notes": "Feitiços e Anotações",
   "CoC7.Weapons": "Armas",
   "CoC7.Effects": "Efeitos",

--- a/static/lang/ru.json
+++ b/static/lang/ru.json
@@ -96,7 +96,6 @@
   "CoC7.Author": "Автор",
   "CoC7.Date": "Дата",
   "CoC7.Spells": "Заклинания",
-  "CoC7.Spell": "Заклинание",
   "CoC7.Spells&Notes": "Заклинания и заметки",
   "CoC7.Weapons": "Оружие",
   "CoC7.Effects": "Эффекты",

--- a/static/lang/uk.json
+++ b/static/lang/uk.json
@@ -95,7 +95,6 @@
   "CoC7.Author": "Автор",
   "CoC7.Date": "Дата",
   "CoC7.Spells": "Заклинання",
-  "CoC7.Spell": "Заклинання",
   "CoC7.Spells&Notes": "Заклинання та нотатки",
   "CoC7.Weapons": "Зброя",
   "CoC7.Effects": "Ефекти",


### PR DESCRIPTION
## Description.

## Support Tested On
- [ ] FoundryVTT v12.
- [ ] FoundryVTT v13.
- [ ] FoundryVTT v14.

## Types of Changes.
- [X] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [X] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
